### PR TITLE
cmd/datablue/handlers.go: log device error responses regardless of debug

### DIFF
--- a/cmd/datablue/handlers.go
+++ b/cmd/datablue/handlers.go
@@ -538,5 +538,5 @@ func writeDeviceError(w http.ResponseWriter, dev *iotds.Device, err error) {
 	}
 	w.Header().Add("Content-Type", "application/json")
 	fmt.Fprint(w, `{"er":"`+err.Error()+`"`+rc+`}`)
-	log.Println("Wrote error: " + err.Error())
+	log.Println("Wrote device error: " + err.Error())
 }

--- a/cmd/datablue/handlers.go
+++ b/cmd/datablue/handlers.go
@@ -538,7 +538,5 @@ func writeDeviceError(w http.ResponseWriter, dev *iotds.Device, err error) {
 	}
 	w.Header().Add("Content-Type", "application/json")
 	fmt.Fprint(w, `{"er":"`+err.Error()+`"`+rc+`}`)
-	if debug {
-		log.Println("Wrote error: " + err.Error())
-	}
+	log.Println("Wrote error: " + err.Error())
 }


### PR DESCRIPTION
This was done because it was rather hard to debug errors being returned to ESP clients without redeploying datablue in debug mode (undesirable).