### PR TITLE
Use permanent state constructors

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -315,9 +315,9 @@ func (sm *broadcastStateMachine) handleStartedEvent(event startedEvent) error {
 	sm.log("handling started event")
 	switch sm.currentState.(type) {
 	case *vidforwardPermanentStarting:
-		sm.transition(&vidforwardPermanentLive{})
+		sm.transition(newVidforwardPermanentLive())
 	case *vidforwardSecondaryStarting:
-		sm.transition(&vidforwardSecondaryLive{})
+		sm.transition(newVidforwardSecondaryLive(sm.ctx))
 	case *directStarting:
 		sm.transition(&directLive{})
 	default:


### PR DESCRIPTION
We were mistakenly using brace initialisation of the states instead of their constructors.