### PR TITLE
Stop secondary broadcasts when live state exited

### DIFF
--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -239,7 +239,12 @@ func newVidforwardSecondaryLive(ctx *broadcastContext) *vidforwardSecondaryLive 
 }
 
 func (s *vidforwardSecondaryLive) enter() {}
-func (s *vidforwardSecondaryLive) exit()  {}
+func (s *vidforwardSecondaryLive) exit() {
+	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
+	if err != nil {
+		log.Printf("broadcast: %s, ID: %s, could not stop broadcast", s.cfg.Name, s.cfg.ID)
+	}
+}
 
 type vidforwardSecondaryLiveUnhealthy struct{}
 


### PR DESCRIPTION
This step was inadvertently left out; the whole point of secondary broadcasts is that they stop.