### PR TITLE
Call fwd.Stream on vidfowardSecondaryStarting entry

### DIFF
--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -259,10 +259,20 @@ func newVidforwardSecondaryStarting(ctx *broadcastContext) *vidforwardSecondaryS
 }
 func (s *vidforwardSecondaryStarting) enter() {
 	s.LastEntered = time.Now()
+	// We pass this to createBroadcastAndRequestHardware so that it's run after
+	// broadcast creation, therefore vidforward gets up to date RTMP endpoint
+	// information.
+	onBroadcastCreation := func() error {
+		err := s.fwd.Stream(s.cfg)
+		if err != nil {
+			return fmt.Errorf("could not set vidforward mode to stream: %w", err)
+		}
+		return nil
+	}
 	createBroadcastAndRequestHardware(
 		s.broadcastContext,
 		s.cfg,
-		nil, // Don't require anything on creation.
+		onBroadcastCreation,
 	)
 }
 func (s *vidforwardSecondaryStarting) exit() {}


### PR DESCRIPTION
Once we successfully create broadcast when we enter the vidforwardSecondaryStarting state, we will call Stream on the forwarding service so that the RTMP endpoints are updated (the implementation of Stream should provide the forwarding service with the create RTMP endpoints).