### PR TITLE
Initial revision

### DIFF
--- a/model/actuator.go
+++ b/model/actuator.go
@@ -1,0 +1,228 @@
+/*
+AUTHORS
+  Saxon Nelson-Milton <saxon@ausocean.org>
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2020-2023 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// Actuator errors.
+var (
+	ErrWrongNumParts = errors.New("wrong number of values for actuator")
+	ErrSKeyParse     = errors.New("cannot parse site key for actuator")
+)
+
+const (
+	typeActuator   = "Actuator" // Actuator datastore type.
+	typeActuatorV2 = "ActuatorV2"
+	numParts       = 4 // Number of parts for actuator in TSV.
+)
+
+// Actuator represents an actuator datastore type to link a device output with
+// a variable such that that variable value changes the physical device output value.
+// NB: This type is deprecated. See ActuatorV2.
+type Actuator struct {
+	SKey int64  `datastore:"Skey"` // Site key.
+	AID  string `datastore:"Aid"`  // Actuator ID.
+	Var  string // The variable whose value is applied to the pin.
+	Pin  string // The device pin actuated represented as <DeviceID>.<Pin>.
+}
+
+// Encode serializes an Actuator into tab-separated values.
+func (a *Actuator) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%s\t%s", a.SKey, a.AID, a.Var, a.Pin))
+}
+
+// Decode deserializes an Actuator from tab-separated values.
+func (a *Actuator) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != numParts {
+		return ErrWrongNumParts
+	}
+	var err error
+	a.SKey, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return ErrSKeyParse
+	}
+	a.AID = p[1]
+	a.Var = p[2]
+	a.Pin = p[3]
+	return nil
+}
+
+// Copy is not currently implemented.
+func (a *Actuator) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (a *Actuator) GetCache() datastore.Cache {
+	return nil
+}
+
+// GetActuatorByPin gets an actuator for device did and with pin.
+// NB: Filter fields must be datastore field names!
+func GetActuatorByPin(ctx context.Context, store datastore.Store, skey int64, did string, pin string) ([]Actuator, error) {
+	q := store.NewQuery(typeActuator, false, "Skey", "Aid", "Pin")
+	q.Filter("Skey =", skey)
+	q.Filter("Aid =", nil)
+	q.Filter("Pin =", did+"."+pin)
+
+	// TODO: do we check for multiple Actuators ? and if so what do we do when there is?
+	var acts []Actuator
+	_, err := store.GetAll(ctx, q, &acts)
+	return acts, err
+}
+
+// GetActuatorsBySite returns the actuators associated with a site optionally
+// filtered by device. Provide "" for no filtering.
+func GetActuatorsBySite(ctx context.Context, store datastore.Store, sKey int64, devID string) ([]Actuator, error) {
+	q := store.NewQuery(typeActuator, false, "Skey", "Aid", "Pin")
+	q.Filter("Skey =", sKey)
+	q.Order("Aid")
+	var all, toOut []Actuator
+	_, err := store.GetAll(ctx, q, &all)
+	if err != nil {
+		return nil, err
+	}
+	if devID == "" {
+		return all, nil
+	}
+
+	for _, a := range all {
+		if strings.Split(a.Pin, ".")[0] == devID {
+			toOut = append(toOut, a)
+		}
+	}
+	return toOut, nil
+}
+
+// PutActuator puts an actuator in the datastore.
+func PutActuator(ctx context.Context, store datastore.Store, act *Actuator) error {
+	pin := ""
+	_, filestore := store.(*datastore.FileStore)
+	if filestore {
+		pin = "." + act.Pin // Include pin as part of key name for filestore.
+	}
+	k := store.NameKey(typeActuator, strconv.FormatInt(act.SKey, 10)+"."+act.AID+pin)
+	_, err := store.Put(ctx, k, act)
+	return err
+}
+
+// DeleteActuator deletes and actuator from the datastore given its actuator ID.
+func DeleteActuator(ctx context.Context, store datastore.Store, aid string) error {
+	q := store.NewQuery(typeActuator, true, "Aid")
+	q.Filter("Aid =", aid)
+	keys, err := store.GetAll(ctx, q, nil)
+	if err != nil {
+		return fmt.Errorf("get all error: %v", err)
+	}
+	return store.DeleteMulti(ctx, keys)
+}
+
+// ActuatorV2 defines a version 2 actuator. An actuator sends the
+// value of a variable to a device's output pin. The key is the MAC
+// address concatenated with the pin. Version 2 actuators do not have
+// a site key, but are linked to a site indirectly via their
+// device. The variable name is relative to the device, not a full
+// variable name.
+type ActuatorV2 struct {
+	Name string // Name of actuator (mutable).
+	Mac  int64  // MAC address of associated device (immutable).
+	Pin  string // Pin of associated device (immutable).
+	Var  string // Relative name of device variable (mutable).
+}
+
+// Encode encodes an actuator as JSON.
+func (a *ActuatorV2) Encode() []byte {
+	bytes, _ := json.Marshal(a)
+	return bytes
+}
+
+// Decode decodes an actuator from JSON.
+func (a *ActuatorV2) Decode(b []byte) error {
+	return json.Unmarshal(b, a)
+}
+
+// Copy copies an actuator to dst, or returns a copy of the acuator when dst is nil.
+func (a *ActuatorV2) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var a2 *ActuatorV2
+	if dst == nil {
+		a2 = new(ActuatorV2)
+	} else {
+		var ok bool
+		a2, ok = dst.(*ActuatorV2)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*a2 = *a
+	return a2, nil
+}
+
+var actuatorCache datastore.Cache = datastore.NewEntityCache()
+
+// GetCache returns the actuator cache.
+func (s *ActuatorV2) GetCache() datastore.Cache {
+	return actuatorCache
+}
+
+// PutActuatorV2 creates/updates an actuator.
+func PutActuatorV2(ctx context.Context, store datastore.Store, act *ActuatorV2) error {
+	k := store.NameKey(typeActuatorV2, strconv.FormatInt(act.Mac, 10)+"."+act.Pin)
+	_, err := store.Put(ctx, k, act)
+	return err
+}
+
+// GetActuatorV2 gets an actuator.
+func GetActuatorV2(ctx context.Context, store datastore.Store, mac int64, pin string) (*ActuatorV2, error) {
+	k := store.NameKey(typeActuatorV2, strconv.FormatInt(mac, 10)+"."+pin)
+	act := new(ActuatorV2)
+	err := store.Get(ctx, k, act)
+	if err != nil {
+		return nil, err
+	}
+	return act, nil
+}
+
+// GetActuatorsV2 gets all actuators for a device.
+func GetActuatorsV2(ctx context.Context, store datastore.Store, mac int64) ([]ActuatorV2, error) {
+	q := store.NewQuery(typeActuatorV2, false, "Mac", "Pin")
+	q.Filter("Mac =", mac)
+	var acts []ActuatorV2
+	_, err := store.GetAll(ctx, q, &acts)
+	return acts, err
+}
+
+// DeleteActuatorV2 deletes an actuator.
+func DeleteActuatorV2(ctx context.Context, store datastore.Store, mac int64, pin string) error {
+	k := store.NameKey(typeActuatorV2, strconv.FormatInt(mac, 10)+"."+pin)
+	return store.DeleteMulti(ctx, []*datastore.Key{k})
+}

--- a/model/binary.go
+++ b/model/binary.go
@@ -1,0 +1,84 @@
+/*
+AUTHORS
+  Saxon Nelson-Milton <saxon@ausocean.org>
+
+LICENSE
+  Copyright (C) 2022 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+const typeBinaryData = "BinaryData"
+
+// BinaryData a cloud type for storing binary data.
+type BinaryData struct {
+	Mac       int64
+	Timestamp int64
+	Fmt       string
+	Data      []byte
+	Pin       string
+	Date      time.Time
+}
+
+// GetBinaryData retreives BinaryData entities for a given media ID, optionally
+// filtered by timestamp(s). If ts is given with len(ts) == 1, then a single entity
+// with the matching timestamp will be returned. If the ts is given with len(ts) == 2
+// then multiple entities corresponding to the range of ts[0] to ts[1] will be
+// given.
+func GetBinaryData(ctx context.Context, store datastore.Store, mid int64, ts []int64) ([]BinaryData, error) {
+	q, err := newBinaryDataQuery(store, mid, ts, false)
+	if err != nil {
+		return nil, fmt.Errorf("could not create new binary data query: %w", err)
+	}
+	var bds []BinaryData
+	_, err = store.GetAll(ctx, q, &bds)
+	return bds, err
+}
+
+func newBinaryDataQuery(store datastore.Store, mid int64, ts []int64, keysOnly bool) (datastore.Query, error) {
+	q := store.NewQuery(typeBinaryData, false, "MID", "Timestamp")
+	mac, _ := FromMID(mid)
+	q.Filter("mac =", MacEncode(mac))
+
+	if ts == nil {
+		return q, nil
+	}
+
+	if len(ts) < 1 || len(ts) > 2 {
+		return nil, fmt.Errorf("unexpected ts length: %d", len(ts))
+	}
+
+	if len(ts) == 1 {
+		q.Filter("timestamp =", ts[0])
+		return q, nil
+	}
+
+	q.Filter("timestamp >=", ts[0])
+	if ts[1] < datastore.EpochEnd {
+		q.Filter("timestamp <", ts[1])
+	}
+	q.Order("timestamp")
+
+	return q, nil
+}

--- a/model/credential.go
+++ b/model/credential.go
@@ -1,0 +1,214 @@
+/*
+DESCRIPTION
+  Datastore credential type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, eitherc version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// typeCredential is the name of our datastore type.
+const typeCredential = "Credential"
+
+// Credential represents a user credential to access media. One
+// credential exists for each media item for which a user, group or
+// domain is permitted access. The same user/group/domain may have
+// different credentials for different media, for example, have write
+// access for one media item but only have read access for another.
+type Credential struct {
+	MID     int64     // Media ID.
+	Name    string    // User name, email address, group or domain.
+	Perm    int64     // Permissions.
+	Created time.Time // Date/time created.
+}
+
+const (
+	ReadPermission  = 0x0001 // Required to find or play media.
+	WritePermission = 0x0002 // Required to update media.
+	AdminPermission = 0x0004 // Required to create or delete media.
+	SuperPermission = 0x0100 // Required to modify other's credentials.
+)
+
+// IsReadable returns true for a credential with read permissions.
+func (c *Credential) IsReadable() bool {
+	return c.Perm&ReadPermission != 0
+}
+
+// IsWritable returns true for a credential with write permissions.
+func (c *Credential) IsWritable() bool {
+	return c.Perm&WritePermission != 0
+}
+
+// IsAdmin returns true for a credential with admin permissions.
+func (c *Credential) IsAdmin() bool {
+	return c.Perm&AdminPermission != 0
+}
+
+// IsSuper returns true for a credential with super permissions.
+func (c *Credential) IsSuper() bool {
+	return c.Perm&SuperPermission != 0
+}
+
+// Encode serializes a Credential into tab-separated values.
+func (c *Credential) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%d\t%d", c.MID, c.Name, c.Perm, c.Created.Unix()))
+}
+
+// Decode deserializes a Credential from tab-separated values.
+func (c *Credential) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 4 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	c.MID, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	c.Name = p[1]
+	c.Perm, err = strconv.ParseInt(p[2], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	ts, err := strconv.ParseInt(p[3], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	c.Created = time.Unix(ts, 0)
+	return nil
+}
+
+// Copy is not currently implemented.
+func (c *Credential) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (c *Credential) GetCache() datastore.Cache {
+	return nil
+}
+
+// PutCredential creates or updates a Credential using MID.Name as the key.
+func PutCredential(ctx context.Context, store datastore.Store, c *Credential) error {
+	key := store.NameKey(typeCredential, strconv.FormatInt(c.MID, 10)+"."+c.Name)
+	_, err := store.Put(ctx, key, c)
+	return err
+}
+
+// GetCredential returns a Credential for given a MID and name.
+func GetCredential(ctx context.Context, store datastore.Store, mid int64, name string) (*Credential, error) {
+	key := store.NameKey(typeCredential, strconv.FormatInt(mid, 10)+"."+name)
+	var c Credential
+	err := store.Get(ctx, key, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+// GetCredentialsByMID returns all credentials for a given MID.
+func GetCredentialsByMID(ctx context.Context, store datastore.Store, mid int64) ([]Credential, error) {
+	q := store.NewQuery(typeCredential, false, "MID", "Name")
+	q.Filter("MID =", mid)
+	q.Order("Name")
+
+	var creds []Credential
+	_, err := store.GetAll(ctx, q, &creds)
+	if err != nil {
+		return nil, err
+	}
+	return creds, err
+}
+
+// GetCredentialsByName returns all credentials for a given name.
+func GetCredentialsByName(ctx context.Context, store datastore.Store, name string) ([]Credential, error) {
+	q := store.NewQuery(typeCredential, false, "MID", "Name")
+	q.Filter("Name =", name)
+	q.Order("MID")
+
+	var creds []Credential
+	_, err := store.GetAll(ctx, q, &creds)
+	if err != nil {
+		return nil, err
+	}
+	return creds, err
+}
+
+// DeleteCredential deletes a single credential.
+func DeleteCredential(ctx context.Context, store datastore.Store, mid int64, name string) error {
+	key := store.NameKey(typeCredential, strconv.FormatInt(mid, 10)+"."+name)
+	return store.DeleteMulti(ctx, []*datastore.Key{key})
+}
+
+// DeleteCredentials deletes all credential for a given name.
+func DeleteCredentials(ctx context.Context, store datastore.Store, name string) error {
+	q := store.NewQuery(typeCredential, true, "MID", "Name")
+	q.Filter("Name =", name)
+
+	keys, err := store.GetAll(ctx, q, nil)
+	if err != nil {
+		return err
+	}
+
+	return store.DeleteMulti(ctx, keys)
+}
+
+// HasPermission returns true if the user's email address or domain
+// has the requested permission for the given MID. Note that the
+// permission for a user (i.e., one associated with an email address)
+// takes priority over the permission for a domain. This means that a
+// particular user may have write or admin permission whereas other
+// users in the domain are limited to read permissions. The
+// single-character name "@" represents any domain, effectively
+// granting public access.
+func HasPermission(ctx context.Context, store datastore.Store, mid int64, email string, perm int64) bool {
+	return hasPermission(ctx, store, mid, email, perm) || hasPermission(ctx, store, 0, email, perm)
+}
+
+func hasPermission(ctx context.Context, store datastore.Store, mid int64, email string, perm int64) bool {
+	c, err := GetCredential(ctx, store, mid, email)
+	if err == nil && c.Perm&perm != 0 {
+		return true
+	}
+	i := strings.Index(email, "@")
+	if i == -1 || len(email[i:]) == 1 {
+		return false // Not an email address.
+	}
+	c, err = GetCredential(ctx, store, mid, email[i:])
+	if err == nil && c.Perm&perm != 0 {
+		return true
+	}
+	c, err = GetCredential(ctx, store, mid, "@")
+	if err == nil && c.Perm&perm != 0 {
+		return true
+	}
+	return false
+}

--- a/model/cron.go
+++ b/model/cron.go
@@ -1,0 +1,172 @@
+/*
+DESCRIPTION
+  Cron datastore type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2021 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+const (
+	typeCron  = "Cron" // Cron datastore type.
+	minsInDay = 1440   // Minutes in the day.
+)
+
+var ErrInvalidTime = errors.New("invalid time")
+
+// Cron represents a cloud cron which perform actions at
+// specified times (to the nearest minute).
+type Cron struct {
+	Skey    int64     // Site key.
+	ID      string    // Cron ID.
+	Time    time.Time // Cron time.
+	TOD     string    // Symbolic time of day, e.g., "Sunset", or repeating time "*30".
+	Repeat  bool      // True if repeating time.
+	Minutes int64     // Minutes since start of UTC day or repeat minutes.
+	Action  string    // Action to be performed
+	Var     string    // Action variable (if any).
+	Data    string    `datastore:",noindex"` // Action data (if any).
+	Enabled bool      // True if enabled, false otherwise.
+}
+
+// Encode serializes a Cron into tab-separated values.
+func (c *Cron) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%d\t%s\t%t\t%d\t%s\t%s\t%s\t%t",
+		c.Skey, c.ID, c.Time.Unix(), c.TOD, c.Repeat, c.Minutes, c.Action, c.Var, c.Data, c.Enabled))
+}
+
+// Decode deserializes a Cron from tab-separated values.
+func (c *Cron) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 10 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	c.Skey, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	c.ID = p[1]
+	ts, err := strconv.ParseInt(p[2], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	c.Time = time.Unix(ts, 0)
+	c.TOD = p[3]
+	c.Repeat, err = strconv.ParseBool(p[4])
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	m, err := strconv.ParseInt(p[5], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	c.Minutes = m
+	c.Action = p[6]
+	c.Var = p[7]
+	c.Data = p[8]
+	c.Enabled, err = strconv.ParseBool(p[9])
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	return nil
+}
+
+// Copy is not currently implemented.
+func (c *Cron) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (c *Cron) GetCache() datastore.Cache {
+	return nil
+}
+
+// PutCron creates or updates a cron.
+func PutCron(ctx context.Context, store datastore.Store, c *Cron) error {
+	key := store.NameKey(typeCron, strconv.FormatInt(c.Skey, 10)+"."+c.ID)
+	_, err := store.Put(ctx, key, c)
+	return err
+}
+
+// GetCron gets a cron.
+func GetCron(ctx context.Context, store datastore.Store, skey int64, id string) (*Cron, error) {
+	key := store.NameKey(typeCron, strconv.FormatInt(skey, 10)+"."+id)
+	c := new(Cron)
+	err := store.Get(ctx, key, c)
+	if err != nil {
+		return nil, err
+	}
+	return c, err
+}
+
+// GetCronsBySite returns all the crons for a given site.
+func GetCronsBySite(ctx context.Context, store datastore.Store, skey int64) ([]Cron, error) {
+	q := store.NewQuery(typeCron, false, "Skey", "ID")
+	q.Filter("Skey =", skey)
+	q.Order("ID")
+	var crons []Cron
+	_, err := store.GetAll(ctx, q, &crons)
+	return crons, err
+}
+
+// DeleteCron deletes a cron.
+func DeleteCron(ctx context.Context, store datastore.Store, skey int64, id string) error {
+	key := store.NameKey(typeCron, strconv.FormatInt(skey, 10)+"."+id)
+	return store.DeleteMulti(ctx, []*datastore.Key{key})
+}
+
+// Helper functions.
+
+// ParseTime parses a string representing a 24-hour time, i.e., hh:mm
+// or hhmm, or a symbolic time of day, e.g., Sunrise or Sunset, and
+// sets the cron time properties accordingly.
+func (c *Cron) ParseTime(s string, tz float64) error {
+	c.TOD = s
+	split := strings.Split(s, ":")
+	if len(split) == 2 {
+		h := strings.TrimPrefix(split[0], "0")
+		m := strings.TrimPrefix(split[1], "0")
+		c.TOD = fmt.Sprintf("%s %s * * *", m, h)
+	}
+	return nil
+}
+
+// FormatTime formats the cron time either as hh:mm or the time of day.
+func (c *Cron) FormatTime(tz float64) string {
+	if c.TOD != "" {
+		return c.TOD
+	}
+	mins := (c.Minutes + int64(tz*60)) % minsInDay
+	h := mins / 60
+	m := mins % 60
+	return fmt.Sprintf("%02d:%02d", h, m)
+}

--- a/model/cron_test.go
+++ b/model/cron_test.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestParseTime(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{in: "03:34", want: "34 3 * * *"},
+		{in: "03:02", want: "2 3 * * *"},
+		{in: "12:04", want: "4 12 * * *"},
+		{in: "30 5 4 3 1", want: "30 5 4 3 1"},
+	}
+
+	for i, test := range tests {
+		var c Cron
+		err := c.ParseTime(test.in, 0.0)
+		if err != nil {
+			t.Fatalf("did not expect error from ParseTime for test no. %d, err: %v", i, err)
+		}
+
+		if test.want != c.TOD {
+			t.Errorf("unexpected result for test no. %d want: %s got: %s", i, test.want, c.TOD)
+		}
+	}
+}

--- a/model/device.go
+++ b/model/device.go
@@ -1,0 +1,410 @@
+/*
+DESCRIPTION
+  Datastore device type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019-2023 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// typeDevice is the name of the datastore device type.
+const typeDevice = "Device"
+
+var (
+	ErrDeviceNotEnabled   = errors.New("device not enabled")
+	ErrDeviceNotFound     = errors.New("device not found")
+	ErrMissingDeviceKey   = errors.New("missing device key")
+	ErrMalformedDeviceKey = errors.New("malformed device key")
+	ErrInvalidDeviceKey   = errors.New("invalid device key")
+	ErrInvalidMACAddress  = errors.New("invalid MAC address")
+)
+
+// Device represents a cloud device. The encoded MAC address
+// serves as the datastore ID key. See MacEncode.
+type Device struct {
+	Skey          int64             // Site key.
+	Dkey          int64             // Device key.
+	Mac           int64             // Encoded MAC address (immutable).
+	Name          string            // Device name.
+	Inputs        string            // Input pins.
+	Outputs       string            // Output pins.
+	Wifi          string            // Wifi credentials, if any.
+	MonitorPeriod int64             // Monitor period (s).
+	ActPeriod     int64             // Actuation period (s)
+	Type          string            // Client type.
+	Version       string            // Client version.
+	Protocol      string            // Client protocol.
+	Status        int64             // Status code.
+	Latitude      float64           // Device latitude.
+	Longitude     float64           // Device longtitude.
+	Enabled       bool              // True if enabled, false otherwise.
+	Updated       time.Time         // Date/time last updated.
+	other         map[string]string // Other, non-persistent data.
+}
+
+// Encode serializes a Device into tab-separated values.
+func (dev *Device) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%d\t%d\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%f\t%f\t%t\t%d",
+		dev.Skey, dev.Dkey, dev.Mac, dev.Name, dev.Inputs, dev.Outputs, dev.Wifi, dev.MonitorPeriod, dev.ActPeriod, dev.Status, dev.Type, dev.Version, dev.Protocol, dev.Latitude, dev.Longitude, dev.Enabled, dev.Updated.Unix()))
+}
+
+// Decode deserializes a Device from tab-separated values.
+func (dev *Device) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 17 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	dev.Skey, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Dkey, err = strconv.ParseInt(p[1], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Mac, err = strconv.ParseInt(p[2], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Name = p[3]
+	dev.Inputs = p[4]
+	dev.Outputs = p[5]
+	dev.Wifi = p[6]
+	dev.MonitorPeriod, err = strconv.ParseInt(p[7], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.ActPeriod, err = strconv.ParseInt(p[8], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Status, err = strconv.ParseInt(p[9], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Type = p[10]
+	dev.Version = p[11]
+	dev.Protocol = p[12]
+	dev.Latitude, err = strconv.ParseFloat(p[13], 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Longitude, err = strconv.ParseFloat(p[14], 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Enabled, err = strconv.ParseBool(p[15])
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	ts, err := strconv.ParseInt(p[16], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	dev.Updated = time.Unix(ts, 0)
+	return nil
+}
+
+// Copy copies a device to dst, or returns a copy of the device when dst is nil.
+func (dev *Device) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var d *Device
+	if dst == nil {
+		d = new(Device)
+	} else {
+		var ok bool
+		d, ok = dst.(*Device)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*d = *dev
+	return d, nil
+}
+
+var devCache datastore.Cache = datastore.NewEntityCache()
+
+// GetCache returns the device cache.
+func (dev *Device) GetCache() datastore.Cache {
+	return nil
+}
+
+// Return the MAC address as a formated string, i.e., a wrapper for MacDecode(dev.Mac).
+func (dev *Device) MAC() string {
+	return MacDecode(dev.Mac)
+}
+
+// Return the MAC address as a hexadecimal string, i.e., essentially a MAC address without the colons.
+func (dev *Device) Hex() string {
+	return fmt.Sprintf("%012x", dev.Mac)
+}
+
+// Return the device status as text.
+func (dev *Device) StatusText() string {
+	switch dev.Status {
+	case 0:
+		return "ok"
+	case 1:
+		return "update"
+	case 2:
+		return "reboot"
+	case 3:
+		return "debug"
+	case 4:
+		return "upgrade"
+	case 5:
+		return "alarm"
+	case 6:
+		return "test"
+	default:
+		return "unknown"
+	}
+}
+
+// Return other data which is not persistent.
+func (dev *Device) Other(key string) string {
+	return dev.other[key]
+}
+
+// Set other data which is not persistent.
+func (dev *Device) SetOther(key, value string) {
+	if dev.other == nil {
+		dev.other = make(map[string]string)
+	}
+	dev.other[key] = value
+}
+
+// InputList returns device inputs as a list.
+func (dev *Device) InputList() []string {
+	return strings.Split(dev.Inputs, ",")
+}
+
+// OutputList returns device outputs as a list.
+func (dev *Device) OutputList() []string {
+	return strings.Split(dev.Outputs, ",")
+}
+
+// PutDevice creates or updates a device.
+func PutDevice(ctx context.Context, store datastore.Store, dev *Device) error {
+	dev.Updated = time.Now()
+	key := store.IDKey(typeDevice, dev.Mac)
+	_, err := store.Put(ctx, key, dev)
+	return err
+}
+
+// GetDevice returns a Device by its integer ID (which is the encoded
+// MAC address).
+func GetDevice(ctx context.Context, store datastore.Store, mac int64) (*Device, error) {
+	key := store.IDKey(typeDevice, mac)
+	dev := new(Device)
+	err := store.Get(ctx, key, dev)
+	if err != nil {
+		return nil, err
+	}
+	return dev, nil
+}
+
+// GetDevicesBySite returns all the devices for a given site.
+func GetDevicesBySite(ctx context.Context, store datastore.Store, skey int64) ([]Device, error) {
+	// FileStore queries must be handled specially.
+	_, filestore := store.(*datastore.FileStore)
+	if filestore {
+		return getDevicesBySiteFromFileStore(ctx, store, skey)
+	}
+
+	q := store.NewQuery(typeDevice, false)
+	q.Filter("Skey =", skey)
+	q.Order("Name")
+	var devs []Device
+	_, err := store.GetAll(ctx, q, &devs)
+	return devs, err
+}
+
+// getDevicesBySiteFromFileStore retrieves devices from a FileStore.
+// Since FileStore does not index devides by skey, this requires
+// retrieving all of the devices then filtering out the ones that
+// don't match.
+func getDevicesBySiteFromFileStore(ctx context.Context, store datastore.Store, skey int64) ([]Device, error) {
+	q := store.NewQuery(typeDevice, false)
+	var devices []Device
+	_, err := store.GetAll(ctx, q, &devices)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out devices that don't match the given skey.
+	for i := len(devices) - 1; i >= 0; i -= 1 {
+		if devices[i].Skey != skey {
+			if i == len(devices)-1 {
+				devices = devices[:i]
+			} else {
+				devices = append(devices[:i], devices[i+1:]...)
+			}
+		}
+	}
+
+	// Order by device ID.
+	sort.Slice(devices, func(i, j int) bool {
+		return devices[i].Name < devices[j].Name
+	})
+	return devices, nil
+}
+
+// DeleteDevice deletes a device.
+func DeleteDevice(ctx context.Context, store datastore.Store, mac int64) error {
+	key := store.IDKey(typeDevice, mac)
+	return store.DeleteMulti(ctx, []*datastore.Key{key})
+}
+
+// MacEncode encodes a MAC address string, optionally colon-separated,
+// as a network-endian int64, e.g., "00:00:00:00:00:01" and
+// "000000000001" are both encoded as 1. Returns 0 for an invalid
+// MAC address.
+func MacEncode(mac string) int64 {
+	mac = strings.ReplaceAll(mac, ":", "")
+	if len(mac) != 12 {
+		return 0
+	}
+	var enc int64
+	var shift uint
+	for i := 10; i >= 0; i -= 2 {
+		d1 := hexToDec(mac[i])
+		d2 := hexToDec(mac[i+1])
+		if d1 == -1 || d2 == -1 {
+			return 0
+		}
+		n := (d1 << 4) + d2
+		enc += n << shift
+		shift += 8
+	}
+	return enc
+}
+
+// hexToDec returns the decimal integer corresponding to a hex byte, or -1 if there is none.
+func hexToDec(hex byte) int64 {
+	switch hex := int64(hex | ' '); {
+	case '0' <= hex && hex <= '9':
+		return hex - '0'
+	case 'a' <= hex && hex <= 'f':
+		return hex - ('a' - 10)
+	default:
+		return -1
+	}
+}
+
+// MacDecode decodes a network-endian int64 as a colon-separated MAC
+// address string, e.g., 1 is decoded as "00:00:00:00:00:01". Zero is
+// an invalid encoding and the empty string is returned instead of
+// 00:00:00:00:00:00.
+func MacDecode(enc int64) string {
+	if enc == 0 {
+		return ""
+	}
+	const hexDigits = "0123456789ABCDEF"
+	bytes := make([]byte, 17)
+	for i := 5; i >= 0; i-- {
+		bytes[i*3] = hexDigits[(enc>>4)&0xF]
+		bytes[i*3+1] = hexDigits[enc&0xF]
+		if i != 5 {
+			bytes[i*3+2] = byte(':')
+		}
+		enc = enc >> 8
+	}
+	return string(bytes)
+}
+
+// CheckDevice returns a device if the supplied MAC address is valid,
+// the device key (supplied as a string) is correct and the device is enabled, else an error.
+func CheckDevice(ctx context.Context, store datastore.Store, mac string, dk string) (*Device, error) {
+	if !IsMacAddress(mac) {
+		return nil, ErrInvalidMACAddress
+	}
+
+	dev, err := GetDevice(ctx, store, MacEncode(mac))
+	if err != nil {
+		return nil, err
+	}
+	if dk == "" {
+		return dev, ErrMissingDeviceKey
+	}
+	dkey, err := strconv.ParseInt(dk, 10, 64)
+	if err != nil {
+		return dev, ErrMalformedDeviceKey
+	}
+	if dev.Dkey != dkey {
+		return dev, ErrInvalidDeviceKey
+	}
+	if !dev.Enabled {
+		return dev, ErrDeviceNotEnabled
+	}
+	return dev, nil
+}
+
+// IsMacAddress returns true if mac is a valid IPv4 MAC address,
+// optionally colon-separated, false otherwise. False is returned for
+// "00:00:00:00:00:00".
+func IsMacAddress(mac string) bool {
+	mac = strings.ReplaceAll(mac, ":", "")
+	if len(mac) != 12 || mac == "000000000000" {
+		return false
+	}
+	for i := 10; i >= 0; i -= 2 {
+		if hexToDec(mac[i]) == -1 {
+			return false
+		}
+		if hexToDec(mac[i+1]) == -1 {
+			return false
+		}
+	}
+	return true
+}
+
+// Retain these for the sensor/actuator migration then remove.
+func (dev *Device) InputListWithID() []string {
+	ins := strings.ReplaceAll(dev.Inputs, " ", "")
+	split := strings.Split(ins, ",")
+	var out []string
+	for _, s := range split {
+		out = append(out, dev.Name+"."+s)
+	}
+	return out
+}
+
+func (dev *Device) OutputListWithID() []string {
+	outs := strings.ReplaceAll(dev.Outputs, " ", "")
+	split := strings.Split(outs, ",")
+	var out []string
+	for _, s := range split {
+		out = append(out, dev.Name+"."+s)
+	}
+	return out
+}

--- a/model/entities.go
+++ b/model/entities.go
@@ -1,0 +1,48 @@
+/*
+DESCRIPTION
+  Datastore entity registrations.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2023 the Australian Ocean Lab (AusOcean).
+
+  This file is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"github.com/ausocean/openfish/datastore"
+)
+
+// RegisterEntities is a convenience function that registers all of
+// the datastore entities in one go.
+func RegisterEntities() {
+	datastore.RegisterEntity(typeActuator, func() datastore.Entity { return new(Actuator) })
+	datastore.RegisterEntity(typeActuatorV2, func() datastore.Entity { return new(ActuatorV2) })
+	datastore.RegisterEntity(typeCredential, func() datastore.Entity { return new(Credential) })
+	datastore.RegisterEntity(typeCron, func() datastore.Entity { return new(Cron) })
+	datastore.RegisterEntity(typeDevice, func() datastore.Entity { return new(Device) })
+	datastore.RegisterEntity(typeMedia, func() datastore.Entity { return new(Media) })
+	datastore.RegisterEntity(typeMtsMedia, func() datastore.Entity { return new(MtsMedia) })
+	datastore.RegisterEntity(typeScalar, func() datastore.Entity { return new(Scalar) })
+	datastore.RegisterEntity(typeSensor, func() datastore.Entity { return new(Sensor) })
+	datastore.RegisterEntity(typeSensorV2, func() datastore.Entity { return new(SensorV2) })
+	datastore.RegisterEntity(typeSite, func() datastore.Entity { return new(Site) })
+	datastore.RegisterEntity(typeText, func() datastore.Entity { return new(Text) })
+	datastore.RegisterEntity(typeUser, func() datastore.Entity { return new(User) })
+	datastore.RegisterEntity(typeVariable, func() datastore.Entity { return new(Variable) })
+}

--- a/model/media.go
+++ b/model/media.go
@@ -1,0 +1,102 @@
+/*
+DESCRIPTION
+  Datastore media type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, eitherc version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// typeMedia is the name of our datastore type.
+const typeMedia = "Media"
+
+// Media represents a unique media source. Each media has a unique
+// Media ID (MID) which serves as the datastore key. The description
+// is optional.
+type Media struct {
+	MID         int64
+	Description string
+	Updated     time.Time
+}
+
+// Encode serializes a Media into tab-separated values.
+func (m *Media) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%d", m.MID, m.Description, m.Updated.Unix()))
+}
+
+// Decode deserializes a Media from tab-separated values.
+func (m *Media) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 3 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	m.MID, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	m.Description = p[1]
+	ts, err := strconv.ParseInt(p[2], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	m.Updated = time.Unix(ts, 0)
+	return nil
+}
+
+// Copy is not currently implemented.
+func (m *Media) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (m *Media) GetCache() datastore.Cache {
+	return nil
+}
+
+// PutMedia creates or updates media.
+func PutMedia(ctx context.Context, store datastore.Store, m *Media) error {
+	key := store.IDKey(typeMedia, m.MID)
+	m.Updated = time.Now()
+	_, err := store.Put(ctx, key, m)
+	return err
+}
+
+// GetMedia returns media by its Media ID.
+func GetMedia(ctx context.Context, store datastore.Store, mid int64) (*Media, error) {
+	key := store.IDKey(typeMedia, mid)
+	var m Media
+	err := store.Get(ctx, key, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,0 +1,1356 @@
+/*
+DESCRIPTION
+  model tests.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+  Trek Hopton <trek@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019-2023 the Australian Ocean Lab (AusOcean).
+
+  This file is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ausocean/av/container/mts"
+	"github.com/ausocean/av/container/mts/meta"
+	"github.com/ausocean/av/container/mts/psi"
+	"github.com/ausocean/openfish/datastore"
+)
+
+const (
+	testSiteKey    = 1
+	testSiteKey2   = 2
+	testSiteName   = "OfficialTestSite"
+	testSiteLat    = -34.91805
+	testSiteLng    = 138.60475
+	testSiteTZ     = 9.5
+	testSiteEnc    = `{"Skey":1,"Name":"OfficialTestSite","OwnerEmail":"","Latitude":-34.91805,"Longitude":138.60475,"Timezone":9.5,"NotifyPeriod":0,"Enabled":true,"Confirmed":false,"Premium":false,"Public":false,"Created":"0001-01-01T00:00:00Z"}`
+	testDevMac     = "00:00:00:00:00:01"
+	testDevMa      = 1
+	testMID        = testDevMa << 4
+	testDevDkey    = 10000001
+	testDevID      = "TestDevice"
+	testDevInputs  = "A0,V0"
+	testDevEnc     = "1\t10000001\t1\tTestDevice\tX0,V0\t\t"
+	testDevEnc2    = "1\t10000001\t1\tTestDevice\t\t\t"
+	testDevEnc3    = "1\t10000001\t1\tTestDevice\tX0,V0\t\t\t0\t0\t0\ttag\tprotocol\t-34.918050\t138.604750\ttrue\t"
+	testUserEmail  = "test@ausocean.org"
+	testUserEmail2 = "test@testdomain.org"
+	testUserPerm   = ReadPermission
+	testUserPerm2  = ReadPermission | WritePermission
+	testUserTime   = 1572157457
+	testUserTime2  = 1572157475
+	testUserEnc    = "1\ttest@ausocean.org\t\t1\t1572157457"
+	testUserEnc2   = "2\ttest@ausocean.org\t\t3\t1572157475"
+	testDevMac2    = "00:00:00:00:00:0F"
+	testDevMac3    = "1A:2B:3C:4F:50:61"
+	testDevMa2     = 15
+	testMID2       = testDevMa2 << 4
+	testMIDAll     = 0
+	testDevPin     = "V0"
+	testDevPin2    = "S1"
+	testMetadata   = "loc:-34.91805,138.60475"
+	testTimestamp  = datastore.EpochStart
+	testGeohash    = "r1f9652gs"
+	testTextMID    = (testDevMa << 4) | 0x08
+	testDomain     = "@ausocean.org"
+	testDomain2    = "@testdomain.org"
+	testOtherUser  = "other@ausocean.org"
+	testJunkUser   = "someone@junk.com"
+	anyDomain      = "@"
+	testCronEnc    = "1\tTest\t0\tSunrise\tfalse\t0\tset\tPower\toff\tfalse"
+)
+
+// TestEncoding tests various encoding and decoding functions.
+func TestEncoding(t *testing.T) {
+	// Test IsMacAddress
+	if !IsMacAddress(testDevMac) {
+		t.Errorf("IsMacAddress(%s) failed: expected true, got false", testDevMac)
+	}
+	if IsMacAddress("00:00:00:00:00:00") {
+		t.Errorf("IsMacAddress(00:00:00:00:00:00) failed: expected false, got true")
+	}
+	if IsMacAddress("00:00:00:00:00:0G") {
+		t.Errorf("IsMacAddress(00:00:00:00:0G) failed: expected false, got true")
+	}
+	if IsMacAddress("00:00:00:00:01") {
+		t.Errorf("IsMacAddress(00:00:00:00:01) failed: expected false, got true")
+	}
+	if IsMacAddress("") {
+		t.Errorf("IsMacAddress() failed: expected false, got true")
+	}
+
+	// MAC address encoding/decoding.
+	ma := MacEncode(testDevMac)
+	if ma != testDevMa {
+		t.Errorf("MacEncode failed: expected %d, got %d", testDevMa, ma)
+	}
+	mac := MacDecode(testDevMa)
+	if mac != testDevMac {
+		t.Errorf("MacDecode failed: expected %s, got %s", testDevMac, mac)
+	}
+	ma = MacEncode(testDevMac3)
+	mac3 := strings.ReplaceAll(testDevMac3, ":", "")
+	ma2 := MacEncode(mac3)
+	if ma != ma2 {
+		t.Errorf("MacEncode failed: expected %d, got %d", ma, ma2)
+	}
+	mac = MacDecode(ma)
+	if mac != testDevMac3 {
+		t.Errorf("MacDecode failed: expected %s, got %s", testDevMac3, mac)
+	}
+
+	// MID encoding/ecoding
+	mid := ToMID(testDevMac, testDevPin2)
+	expect := testDevMa<<4 | int64(putMtsPin(testDevPin2))
+	if mid != expect {
+		t.Errorf("ToMID failed: expected %d, got %d", expect, mid)
+	}
+	mac, pin := FromMID(mid)
+	if mac != testDevMac && pin != testDevPin2 {
+		t.Errorf("FromMID failed: expected %s,%s, got %s,%s", testDevMac, testDevPin2, mac, pin)
+	}
+
+	// Device encoding/decoding.
+	dev := Device{Skey: testSiteKey, Dkey: testDevDkey, Mac: 1, Name: "TestDevice", Inputs: "X0,V0", Enabled: true}
+	enc := dev.Encode()
+	if !strings.HasPrefix(string(enc), testDevEnc) {
+		t.Errorf("Device.Encode failed: expected %s, got %s", testDevEnc, enc)
+	}
+	var dev2 Device
+	err := dev2.Decode(enc)
+	if err != nil {
+		t.Errorf("Device.Decode failed with error: %s", err)
+	}
+	enc2 := dev2.Encode()
+	if !strings.HasPrefix(string(enc2), testDevEnc) {
+		t.Errorf("Device.Encode 2 failed: expected %s, got %s", testDevEnc, enc2)
+	}
+
+	dev2.Inputs = ""
+	enc2 = dev2.Encode()
+	if !strings.HasPrefix(string(enc2), testDevEnc2) {
+		t.Errorf("Device.Decode failed: expected %s, got %s", testDevEnc2, enc2)
+	}
+	var dev3 Device
+	err = dev3.Decode(enc2)
+	if err != nil {
+		t.Errorf("Device.Decode failed with error: %s", err)
+	}
+	if dev3.Inputs != "" {
+		t.Errorf("Device.Decode returned non-empty Inputs")
+	}
+
+	// Site encoding/decoding.
+	site := Site{Skey: testSiteKey, Name: testSiteName, Latitude: testSiteLat, Longitude: testSiteLng, Timezone: testSiteTZ, Enabled: true}
+	enc = site.Encode()
+	if string(enc) != testSiteEnc {
+		t.Errorf("Site.Encode failed: expected %s, got %s", testSiteEnc, enc)
+	}
+	var site2 Site
+	err = site2.Decode(enc)
+	if err != nil {
+		t.Errorf("Site.Decode failed with error: %s", err)
+	}
+	enc2 = site2.Encode()
+	if string(enc2) != testSiteEnc {
+		t.Errorf("Site.Encode 2 failed: expected %s, got %s", testSiteEnc, enc2)
+	}
+
+	// User encoding/decoding.
+	user := User{Skey: testSiteKey, Email: testUserEmail, Perm: testUserPerm, Created: time.Unix(testUserTime, 0)}
+	enc = user.Encode()
+	if string(enc) != testUserEnc {
+		t.Errorf("User.Encode failed: expected %s, got %s", testUserEnc, enc)
+	}
+
+	var user2 User
+	err = user2.Decode(enc)
+	if err != nil {
+		t.Errorf("User.Decode failed with error: %s", err)
+	}
+	enc2 = user2.Encode()
+	if string(enc2) != testUserEnc {
+		t.Errorf("User.Encode 2 failed: expected %s, got %s", testUserEnc, enc2)
+	}
+
+	// MtsMedia encoding/decoding.
+	m := MtsMedia{MID: testMID, Geohash: testGeohash, Timestamp: testTimestamp, PTS: 1, Duration: 2, Metadata: testMetadata, Clip: []byte{'A', 'B', 'C', 'D', 'E', 'F', 'G'}}
+	enc = m.Encode()
+	var m2 MtsMedia
+	err = m2.Decode(enc)
+	if err != nil {
+		t.Errorf("MtsMedia.Decode failed with error: %s", err)
+	}
+	if m2.MID != testMID || m2.Geohash != testGeohash || m2.Timestamp != testTimestamp || m2.Metadata != testMetadata {
+		t.Errorf("MtsMedia.Decode failed to decode correctly")
+	}
+	enc2 = m2.Encode()
+	if string(enc) != string(enc2) {
+		t.Errorf("MtsMedia.Encode 2 failed")
+	}
+
+	// Test MtsMedia:ID()
+	tests := []struct {
+		input MtsMedia
+		count int64
+		want  int64
+	}{
+		{
+			input: MtsMedia{MID: 0, Timestamp: datastore.EpochStart},
+			count: 0,
+			want:  0,
+		},
+		{
+			input: MtsMedia{MID: 0, Timestamp: datastore.EpochStart - 1},
+			count: 0,
+			want:  0,
+		},
+		{
+			input: MtsMedia{MID: testMID, Timestamp: datastore.EpochStart + 1},
+			count: 0,
+			want:  testMID<<32 | 1<<3,
+		},
+		{
+			input: MtsMedia{MID: testMID, Timestamp: datastore.EpochStart + 1},
+			count: 1,
+			want:  testMID<<32 | 1<<3 | 1,
+		},
+		{
+			input: MtsMedia{MID: testMID + 1, Timestamp: datastore.EpochStart + 1},
+			count: 0,
+			want:  (testMID+1)<<32 | 1<<3,
+		},
+	}
+
+	for i, test := range tests {
+		id := datastore.IDKey(test.input.MID, test.input.Timestamp, test.count)
+		if id != test.want {
+			t.Errorf("IDKey %d failed: expected %d, got %d", i, test.want, id)
+		}
+	}
+}
+
+// TestFragmentMTSMedia tests the FragmentMTSMedia funtion.
+func TestFragmentMTSMedia(t *testing.T) {
+	const u = mts.PTSFrequency // MTS Frequency units.
+	const ptsTolerance = 12000 // 133ms (this is the tolerance that vidgrind uses)
+
+	type frag struct {
+		len  int   // How long the MTSFragment's media slice should be.
+		dur  int64 // Desired duration of fragment.
+		cont bool  // Desired continues flag.
+	}
+
+	tests := []struct {
+		input  [][2]int64
+		period int64
+		want   []frag
+	}{
+		// Whole second durations, 5s period.
+		{
+			input:  [][2]int64{{0, 1}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}, {6, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {12, 1}, {13, 1}, {14, 1}},
+			period: 5,
+			want:   []frag{{5, 5 * u, true}, {5, 5 * u, true}, {5, 5 * u, true}},
+		},
+		{
+			input:  [][2]int64{{1, 1}, {2, 1}, {3, 1}, {4, 1}, {7, 1}, {8, 1}, {9, 1}, {10, 1}, {11, 1}, {13, 1}, {14, 1}},
+			period: 5,
+			want:   []frag{{4, 4 * u, true}, {5, 5 * u, false}, {2, 2 * u, false}},
+		},
+		{
+			input:  [][2]int64{{1, 1}, {2, 1}, {3, 1}, {13, 1}, {14, 1}},
+			period: 5,
+			want:   []frag{{3, 3 * u, true}, {2, 2 * u, false}},
+		},
+		// Ten-second durations, 30-second period.
+		{
+			input:  [][2]int64{{0, 10}, {10, 10}, {20, 10}, {30, 10}, {40, 10}, {50, 10}, {60, 10}, {70, 10}, {80, 10}, {90, 10}},
+			period: 30,
+			want:   []frag{{3, 30 * u, true}, {3, 30 * u, true}, {3, 30 * u, true}, {1, 10 * u, true}},
+		},
+		{
+			input:  [][2]int64{{0, 10}, {10, 10}, {20, 10}, {130, 10}, {140, 10}},
+			period: 30,
+			want:   []frag{{3, 30 * u, true}, {2, 20 * u, false}},
+		},
+	}
+
+	// Messy real-world data with missing timestamps (from Big_buck_bunny_01.ts).
+	realInput := []MtsMedia{
+		{Timestamp: 11, PTS: 0, Duration: 0, Continues: true},
+		{Timestamp: 11, PTS: 0, Duration: 688501, Continues: true},
+		{Timestamp: 16, PTS: 688501, Duration: 213000, Continues: true},
+		{Timestamp: 21, PTS: 901501, Duration: 189001, Continues: true},
+		{Timestamp: 22, PTS: 1090502, Duration: 213001, Continues: true},
+		{Timestamp: 25, PTS: 1303503, Duration: 226500, Continues: true},
+		{Timestamp: 26, PTS: 1530003, Duration: 225001, Continues: true},
+		{Timestamp: 28, PTS: 1755004, Duration: 55500, Continues: true},
+		{Timestamp: 30, PTS: 1810504, Duration: 454501, Continues: true},
+		{Timestamp: 35, PTS: 2265005, Duration: 351000, Continues: true},
+		{Timestamp: 30, PTS: 2616005, Duration: 94501, Continues: true},
+		{Timestamp: 41, PTS: 2710506, Duration: 166501, Continues: true},
+		{Timestamp: 41, PTS: 2877007, Duration: 193501, Continues: true},
+		{Timestamp: 43, PTS: 3070508, Duration: 199501, Continues: true},
+		{Timestamp: 47, PTS: 3270009, Duration: 211500, Continues: true},
+		{Timestamp: 40, PTS: 3481509, Duration: 124500, Continues: true},
+	}
+
+	// These tests use the MTS media values extracted from Big_buck_bunny_01.ts.
+	tests2 := []struct {
+		input  []MtsMedia
+		period int64
+		want   []frag
+	}{
+		{
+			input:  realInput,
+			period: 10,
+			want:   []frag{{3, 901501, true}, {5, 909003, true}, {3, 900002, true}, {5, 895503, true}},
+		},
+		{
+			input:  realInput,
+			period: 20,
+			want:   []frag{{8, 1810504, true}, {8, 1795505, true}},
+		},
+		{
+			input:  realInput,
+			period: 40,
+			want:   []frag{{16, 3606009, true}},
+		},
+	}
+
+	for i, test := range tests {
+		in := generateTestMtsMedia(test.input)
+		out := FragmentMTSMedia(in, test.period, 0)
+		if len(out) != len(test.want) {
+			t.Fatalf("FragmentMTSMedia test %d failed, expected %d fragments, got %d", i, len(test.want), len(out))
+		}
+
+		for j, f := range out {
+			if len(f.Medias) != test.want[j].len {
+				t.Errorf("FragmentMTSMedia test %d failed; expected frag %v to contain %v MtsMedias, got %v", i, j, test.want[j].len, len(f.Medias))
+			}
+			if f.Duration != test.want[j].dur {
+				t.Errorf("FragmentMTSMedia test %d failed; expected frag %v duration: %v, got %v", i, j, test.want[j].dur, f.Duration)
+			}
+			if f.Continues != test.want[j].cont {
+				t.Errorf("FragmentMTSMedia test %d failed; expected continues flag for frag %v to be set to: %v, got %v", i, j, test.want[j].cont, f.Continues)
+			}
+		}
+	}
+
+	for i, test := range tests2 {
+		out := FragmentMTSMedia(test.input, test.period, ptsTolerance)
+		if len(out) != len(test.want) {
+			t.Fatalf("FragmentMTSMedia test %d failed, expected %d fragments, got %d", i, len(test.want), len(out))
+		}
+
+		for j, f := range out {
+			if len(f.Medias) != test.want[j].len {
+				t.Errorf("FragmentMTSMedia test %d failed; expected frag %v to contain %v MtsMedias, got %v", i, j, test.want[j].len, len(f.Medias))
+			}
+			if f.Duration != test.want[j].dur {
+				t.Errorf("FragmentMTSMedia test %d failed; expected frag %v duration: %v, got %v", i, j, test.want[j].dur, f.Duration)
+			}
+			if f.Continues != test.want[j].cont {
+				t.Errorf("FragmentMTSMedia test %d failed; expected continues flag for frag %v to be set to: %v, got %v", i, j, test.want[j].cont, f.Continues)
+			}
+		}
+	}
+
+	// Empty case.
+	out := FragmentMTSMedia([]MtsMedia{}, 10, 0)
+	if len(out) != 0 {
+		t.Errorf("FragmentMTSMedia emtpy case failed")
+	}
+}
+
+// generateTestMtsMedia generates dummy []MtsMedia from timestamps and durations.
+func generateTestMtsMedia(in [][2]int64) (out []MtsMedia) {
+
+	for _, i := range in {
+		out = append(out, MtsMedia{Timestamp: i[0], PTS: i[0] * mts.PTSFrequency, Duration: i[1] * mts.PTSFrequency, Continues: true})
+	}
+	return
+}
+
+// init registers our datastore entities.
+func init() {
+	RegisterEntities()
+}
+
+// TestNetreceiverAccess tests access to NetReceiver's datastore.
+func TestNetreceiverFileAccess(t *testing.T) {
+	testEntities(t, "file")
+	testDevice(t, "file")
+	testVariable(t, "file")
+	testCron(t, "file")
+}
+
+func TestNetreceiverCloudAccess(t *testing.T) {
+	if os.Getenv("NETRECEIVER_CREDENTIALS") == "" {
+		t.Skip("NETRECEIVER_CREDENTIALS required to access NetReceiver datastore")
+	}
+	testEntities(t, "cloud")
+	testDevice(t, "cloud")
+	testVariable(t, "cloud")
+	testCron(t, "cloud")
+}
+
+// testEntities tests access to various entities in NetReceiver's datastore.
+func testEntities(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	store, err := datastore.NewStore(ctx, kind, "netreceiver", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, netreceiver) failed with error: %v", kind, err)
+	}
+
+	// If we're testing FileStore we first need to create some entities.
+	var site Site
+	if kind == "file" {
+		// Create a site.
+		site = Site{Skey: testSiteKey, Name: testSiteName, Latitude: testSiteLat, Longitude: testSiteLng, Timezone: testSiteTZ, Enabled: true}
+		err = PutSite(ctx, store, &site)
+		if err != nil {
+			t.Errorf("store.Put(Site) failed with error: %v", err)
+		}
+		// Create a user of 2 sites.
+		err = PutUser(ctx, store, &User{Skey: testSiteKey, Email: testUserEmail, Perm: testUserPerm, Created: time.Unix(testUserTime, 0)})
+		if err != nil {
+			t.Errorf("store.Put(User) #1 failed with error: %v", err)
+		}
+		err = PutUser(ctx, store, &User{Skey: testSiteKey2, Email: testUserEmail, Perm: testUserPerm2, Created: time.Unix(testUserTime2, 0)})
+		if err != nil {
+			t.Errorf("store.Put(User) #2 failed with error: %v", err)
+		}
+	}
+
+	s, err := GetSite(ctx, store, testSiteKey)
+	if err != nil {
+		t.Errorf("GetSite failed with error: %v", err)
+	}
+	enc := string(s.Encode())
+	if enc != testSiteEnc {
+		t.Errorf("GetSite failed: expected %s, got %s", testSiteEnc, enc)
+	}
+
+	if kind == "file" {
+		allSites, err := GetAllSites(ctx, store)
+		if err != nil {
+			t.Errorf("unexpected error getting all sites: %v", err)
+		}
+		if len(allSites) != 1 || allSites[0] != site {
+			t.Errorf("unexpected result from GetAllSites:\ngot: %#v\nwant:%#v",
+				allSites, site)
+		}
+	}
+
+	user, err := GetUser(ctx, store, testSiteKey, testUserEmail)
+	if err != nil {
+		t.Errorf("GetUser failed with error: %v", err)
+	}
+	enc = string(user.Encode())
+	if enc != testUserEnc {
+		t.Errorf("GetUser failed: expected %s, got %s", testUserEnc, enc)
+	}
+
+	// Attempt to get a user that does not exist.
+	_, err = GetUser(ctx, store, testSiteKey, testJunkUser)
+	if err != datastore.ErrNoSuchEntity {
+		t.Errorf("GetUser failed to return ErrNoSuchdatastore.Entity error")
+	}
+}
+
+// testDevice tests Device methods.
+func testDevice(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	store, err := datastore.NewStore(ctx, kind, "netreceiver", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, netreceiver) failed with error: %v", kind, err)
+	}
+
+	dev := &Device{Skey: testSiteKey, Dkey: testDevDkey, Mac: testDevMa, Name: testDevID, Inputs: testDevInputs, Enabled: true}
+	err = PutDevice(ctx, store, dev)
+	if err != nil {
+		t.Errorf("PutDevice failed with error: %v", err)
+	}
+	dev, err = GetDevice(ctx, store, testDevMa)
+	if err != nil {
+		t.Errorf("GetDevice failed with error: %v", err)
+	}
+	if dev.Skey != testSiteKey || dev.Dkey != testDevDkey || dev.Inputs != testDevInputs || !dev.Enabled {
+		t.Errorf("GetDevice returned wrong values; got %v", dev)
+	}
+
+	// Test checking
+	_, err = CheckDevice(ctx, store, testDevMac, strconv.Itoa(testDevDkey))
+	if err != nil {
+		t.Errorf("checkDevice failed with error: %v", err)
+	}
+
+	// Test deletion.
+	err = DeleteDevice(ctx, store, testDevMa)
+	if err != nil {
+		t.Errorf("DeleteDevice failed with error: %v", err)
+	}
+	dev, err = GetDevice(ctx, store, testDevMa)
+	if err == nil {
+		t.Errorf("GetDevice failed to fail")
+	}
+}
+
+// testVariable tests Variable methods.
+func testVariable(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	store, err := datastore.NewStore(ctx, kind, "netreceiver", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, netreceiver) failed with error: %v", kind, err)
+	}
+
+	tests := []struct {
+		name     string
+		value    string
+		scope    string
+		basename string
+	}{
+		{
+			name:     "foo",
+			value:    "bar",
+			scope:    "",
+			basename: "foo",
+		},
+		{
+			name:     "_foo",
+			value:    "bar",
+			scope:    "",
+			basename: "_foo",
+		},
+		{
+			name:     "dev.foo",
+			value:    "bar",
+			scope:    "dev",
+			basename: "foo",
+		},
+		{
+			name:     "_sys.foo",
+			value:    "bar",
+			scope:    "_sys",
+			basename: "foo",
+		},
+		{
+			name:     "_sys.foo2",
+			value:    "bar2",
+			scope:    "_sys",
+			basename: "foo2",
+		},
+		{
+			name:     "01:23:45:67:89:AB.foo",
+			value:    "bar",
+			scope:    "0123456789AB",
+			basename: "foo",
+		},
+	}
+
+	for i, test := range tests {
+		err = PutVariable(ctx, store, 0, test.name, test.value)
+		if err != nil {
+			t.Errorf("PutVariable %d failed with error: %v", i, err)
+		}
+		v, err := GetVariable(ctx, store, 0, test.name)
+		if err != nil {
+			t.Errorf("GetVariable %d failed with error: %v", i, err)
+		}
+		v, err = GetVariable(ctx, store, 0, strings.ReplaceAll(test.name, ":", ""))
+		if err != nil {
+			t.Errorf("GetVariable#2 %d failed with error: %v", i, err)
+		}
+		if v.Value != test.value {
+			t.Errorf("GetVariable %d returned wrong value; expected %s, got %s", i, test.value, v.Value)
+		}
+		if v.Scope != test.scope {
+			t.Errorf("GetVariable %d returned wrong scope; expected %s, got %s", i, test.scope, v.Scope)
+		}
+		bn := v.Basename()
+		if bn != test.basename {
+			t.Errorf("Basename returned wrong value; expected %s, got %s", test.basename, bn)
+		}
+	}
+
+	vars, err := GetVariablesBySite(ctx, store, 0, "dev")
+	if len(vars) != 1 {
+		t.Errorf("GetVariablesBySite(dev) returned wrong number of variables; expected 1, got %d", len(vars))
+	}
+	vars, err = GetVariablesBySite(ctx, store, 0, "_sys")
+	if len(vars) != 2 {
+		t.Errorf("GetVariablesBySite(.sys) returned wrong number of variables; expected 2, got %d", len(vars))
+	}
+	vars, err = GetVariablesBySite(ctx, store, 0, "")
+	if len(vars) < len(tests) {
+		t.Errorf("GetVariablesBySite() returned wrong number of variables; expected at least %d, got %d", len(tests), len(vars))
+	}
+
+	for i, test := range tests[:2] {
+		err = DeleteVariable(ctx, store, 0, test.name)
+		if err != nil {
+			t.Errorf("DeleteVariable %d failed with error: %v", i, err)
+		}
+	}
+	err = DeleteVariables(ctx, store, 0, "_sys")
+	if err != nil {
+		t.Errorf("DeleteVariables failed with error: %v", err)
+	}
+}
+
+// TestVidgrindAccess tests access to VidGrind's datastore.
+// VIDGRIND_CREDENTIALS is required in order to access the datastore.
+func TestVidgrindFileAccess(t *testing.T) {
+	testMtsMedia(t, "file")
+	testText(t, "file")
+	testScalar(t, "file")
+	testActuator(t, "file")
+	testMtsDurations(t, "file")
+}
+
+func TestVidgrindCloudAccess(t *testing.T) {
+	if os.Getenv("VIDGRIND_CREDENTIALS") == "" {
+		t.Skip("VIDGRIND_CREDENTIALS required to test VidGrind datastore")
+	}
+
+	testMtsMedia(t, "cloud")
+	testText(t, "cloud")
+	testScalar(t, "cloud")
+	testActuator(t, "cloud")
+	testMtsDurations(t, "cloud")
+}
+
+// testMtsMedia tests MtsMedia methods.
+func testMtsMedia(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, vidgrind) failed with error: %v", kind, err)
+	}
+
+	// Write MtsMedia.
+	p := mts.Packet{PID: mts.PIDVideo}
+	pmtBytes := psi.NewPMTPSI().Bytes()
+	mts.Meta = meta.New()
+	mts.Meta.Add(mts.WriteRateKey, "25")
+	pmtBytes, err = updateMeta(pmtBytes)
+	if err != nil {
+		t.Errorf("WriteMtsMedia #2 failed with unexpected error: %v", err)
+	}
+	patPkt := mts.Packet{
+		PUSI: true,
+		PID:  mts.PatPid,
+	}
+	pmtPkt := mts.Packet{
+		PUSI:    true,
+		PID:     mts.PmtPid,
+		Payload: psi.AddPadding(pmtBytes),
+	}
+	pkt := append(patPkt.Bytes(nil), pmtPkt.Bytes(nil)...)
+	pkt = append(pkt, p.Bytes(nil)...)
+	l := len(pkt)
+	err = WriteMtsMedia(ctx, store, &MtsMedia{MID: testMID2, Geohash: testGeohash, Timestamp: testTimestamp, Clip: pkt})
+	if err != nil {
+		t.Errorf("WriteMtsMedia failed with error: %v", err)
+	}
+
+	// Get MtsMedia.
+	ts := []int64{testTimestamp}
+	m, err := GetMtsMedia(ctx, store, testMID2, nil, ts)
+	if err != nil {
+		t.Errorf("GetMtsMedia failed with error: %v", err)
+	}
+	if len(m) == 0 {
+		t.Errorf("GetMtsMedia failed to return anything")
+	}
+	if m[0].MID != testMID2 || m[0].Geohash != testGeohash || m[0].Timestamp != testTimestamp || len(m[0].Clip) != l {
+		t.Errorf("GetMtsMedia returned incorrect data")
+	}
+
+	// Delete MtsMedia.
+	err = DeleteMtsMedia(ctx, store, testMID2)
+	if err != nil {
+		t.Errorf("DeleteMtsMedia failed with error: %v", err)
+	}
+
+	// Write/delete large MtsMedia, just under the 1MB limit.
+	// Insert valid PID into all packets.
+	data := make([]byte, 996400)
+	head := mtsHeadWithPID(mts.PIDVideo)
+	for i := 0; i < len(data); i += mts.PacketSize {
+		copy(head, data[i:i+3])
+	}
+	p2 := mts.Packet{
+		PID:     mts.PIDVideo,
+		Payload: data,
+	}
+	pkt2 := append(patPkt.Bytes(nil), pmtPkt.Bytes(nil)...)
+	pkt2 = append(pkt2, p2.Bytes(nil)...)
+	err = WriteMtsMedia(ctx, store, &MtsMedia{MID: testMID2, Geohash: testGeohash, Timestamp: testTimestamp, Clip: pkt2})
+	if err != nil {
+		t.Errorf("WriteMtsMedia #2 failed with error: %v", err)
+	}
+	err = DeleteMtsMedia(ctx, store, testMID2)
+	if err != nil {
+		t.Errorf("DeleteMtsMedia #2 failed with error: %v", err)
+	}
+
+	testBigBuckBunny(t, store)
+	//	testGeohashes(t, store)
+}
+
+// updateMeta adds/updates a metaData descriptor in the given psi bytes using data
+// contained in the global mts.Meta struct.
+func updateMeta(b []byte) ([]byte, error) {
+	p := psi.PSIBytes(b)
+	err := p.AddDescriptor(psi.MetadataTag, mts.Meta.Encode())
+	return []byte(p), err
+}
+
+// testBigBuckBunny write/gets/real large MTS data real(-ish) timestamps.
+func testBigBuckBunny(t *testing.T, store datastore.Store) {
+	ctx := context.Background()
+	dir := os.Getenv("BIG_BUCK_BUNNY")
+	if dir == "" {
+		return
+	}
+
+	files := []string{"Big_buck_bunny_01.ts", "Big_buck_bunny_02.ts", "Big_buck_bunny_07.ts"}
+	times := []int64{datastore.EpochStart + 10, datastore.EpochStart + 20, datastore.EpochStart + 70}
+	for i, file := range files {
+		data, err := ioutil.ReadFile(filepath.Join(dir, file))
+		if err != nil {
+			t.Errorf("ReadFile #3 failed with error: %v", err)
+		}
+		err = WriteMtsMedia(ctx, store, &MtsMedia{MID: testMID2, Geohash: testGeohash, Timestamp: times[i], Clip: data})
+		if err != nil {
+			t.Errorf("WriteMtsMedia #3 failed with error: %v", err)
+		}
+	}
+
+	ts := []int64{datastore.EpochStart, datastore.EpochStart + 100}
+	m, err := GetMtsMedia(ctx, store, testMID2, nil, ts)
+	if err != nil {
+		t.Errorf("GetMtsMedia #3 failed with error: %v", err)
+	}
+	if len(m) < 9 {
+		t.Errorf("GetMtsMedia #3 returned wrong number of results; expected 9 got %d", len(m))
+	}
+	// Test the key IDs and durations are as expected.
+	// See datastore.IDKey for an explanation of how key IDs are formed.
+	ids := []int64{
+		testMID2<<32 | (10 << 3),
+		testMID2<<32 | (10<<3 + 1),
+		testMID2<<32 | (20 << 3),
+		testMID2<<32 | (20<<3 + 1),
+		testMID2<<32 | (20<<3 + 2),
+		testMID2<<32 | (20<<3 + 3),
+		testMID2<<32 | (20<<3 + 4),
+		testMID2<<32 | (70 << 3),
+		testMID2<<32 | (70<<3 + 1),
+	}
+	durations := []int64{690000, 208500, 192000, 214500, 213000, 228000, 53999, 667500, 235500}
+	for i := range ids {
+		if m[i].Key.ID != ids[i] {
+			t.Errorf("GetMtsMedia #4.%d expected ID of %d, got %d", i, ids[i], m[i].Key.ID)
+		}
+		if m[i].Duration != durations[i] {
+			t.Errorf("GetMtsMedia #4.%d expected duration of %d, got %d", i, durations[i], m[i].Duration)
+		}
+	}
+
+	// Attempt invalid query with both a geo range and a time range.
+	_, err = GetMtsMedia(ctx, store, testMID2, []string{"r1g", "r1h"}, ts)
+	if err == nil {
+		t.Errorf("GetMtsMedia #5 expected error, got nil")
+	}
+
+	// Key only queries:
+	// Get keys without a timestamp.
+	keys, err := GetMtsMediaKeys(ctx, store, testMID2, nil, nil)
+	if err != nil {
+		t.Errorf("GetMtsMediaKeys #1 failed with error: %v", err)
+	}
+	if len(keys) != 9 {
+		t.Errorf("GetMtsMediaKeys #1 returned wrong number of results; expected 9, got %d", len(keys))
+	}
+
+	// Get keys with a matching timestamp.
+	keys, err = GetMtsMediaKeys(ctx, store, testMID2, nil, ts)
+	if err != nil {
+		t.Errorf("GetMtsMediaKeys #2 failed with error: %v", err)
+	}
+	if len(keys) != 9 {
+		t.Errorf("GetMtsMediaKeys #2 returned wrong number of results; expected 9, got %d", len(keys))
+	}
+
+	for i, k := range keys {
+		m, err := GetMtsMediaByKey(ctx, store, uint64(k.ID))
+		if err != nil {
+			t.Errorf("GetMtsMediaByKey %d failed with error: %v", i, err)
+		}
+		mid, ts, _ := datastore.SplitIDKey(k.ID)
+		if m.MID&0xffffff != mid {
+			t.Errorf("GetMtsMediaByKey %d expected MID of %d, got %d", i, m.MID, mid)
+		}
+		if m.Timestamp != ts {
+			t.Errorf("GetMtsMediaByKey %d expected Timestamp of %d, got %d", i, m.Timestamp, ts)
+		}
+	}
+
+	// Get keys without a matching timestamp.
+	ts = []int64{datastore.EpochStart + 100}
+	keys, err = GetMtsMediaKeys(ctx, store, testMID2, nil, ts)
+	if err != nil {
+		t.Errorf("GetMtsMediaKeys #3 failed with error: %v", err)
+	}
+	if len(keys) != 0 {
+		t.Errorf("GetMtsMediaKeys #3 returned wrong number of results; expected 0, got %d", len(keys))
+	}
+
+	// Get media by a range of keys.
+	m, err = GetMtsMediaByKeys(ctx, store, []uint64{uint64(ids[0]), uint64(ids[7])})
+	if err != nil {
+		t.Errorf("GetMtsMediaKeys #1 failed with error: %v", err)
+	}
+	if len(m) != 2 {
+		t.Errorf("GetMtsMediaByKeys #1 returned wrong number of results; expected 2, got %d", len(m))
+	}
+	m, err = GetMtsMediaByKeys(ctx, store, []uint64{uint64(ids[0])})
+	if err != nil {
+		t.Errorf("GetMtsMediaKeys #2 failed with error: %v", err)
+	}
+	if len(m) != 1 {
+		t.Errorf("GetMtsMediaByKeys #2 returned wrong number of results; expected 1, got %d", len(m))
+	}
+
+	DeleteMtsMedia(ctx, store, testMID2)
+}
+
+// testGeohashes tests MtsMedia with geohashes
+func testGeohashes(t *testing.T, store datastore.Store) {
+	ctx := context.Background()
+
+	_, filestore := store.(*datastore.FileStore)
+	if filestore {
+		// FileStore not implement geohash queries.
+		return
+	}
+
+	// First, create some records with geohashes.
+	hashes := []string{
+		"r1f9652gs", // -34.91805,138.60475 = Benham Lab, University of Adelaide
+		"r1f965203", // -34.91864,138.60358 = Union House, University of Adelaide
+		"r1f93fzsn", // -34.92069,138.60311 = The South Australian Museum
+		"r1f93fexs", // -34.92150,138.59754 = Adelaide Railway Station
+		"r1f93cmqr", // -34.92857,138.60006 = Victoria Square
+	}
+
+	pkt := make([]byte, mts.PacketSize)
+	for i, gh := range hashes {
+		err := WriteMtsMedia(ctx, store, &MtsMedia{MID: testMID2, Geohash: gh, Timestamp: testTimestamp + int64(i), Clip: pkt})
+		if err != nil {
+			t.Errorf("WriteMtsMedia #4 failed with error: %v", err)
+		}
+	}
+
+	// Second, perform some searches.
+	tests := []struct {
+		gh   []string
+		want []string
+	}{
+		// Zero match.
+		{
+			gh:   []string{"r1g", "r1h"},
+			want: []string{},
+		},
+		// Exact match.
+		{
+			gh:   []string{"r1f9652gs"},
+			want: []string{"r1f9652gs"},
+		},
+		// 2-location match.
+		{
+			gh:   []string{"r1f9652", "r1f9653"},
+			want: []string{"r1f965203", "r1f9652gs"},
+		},
+		// 3-location match.
+		{
+			gh:   []string{"r1f93", "r1f94"},
+			want: []string{"r1f93cmqr", "r1f93fexs", "r1f93fzsn"},
+		},
+		// 5-location match.
+		{
+			gh:   []string{"r1f9", "r1fb"},
+			want: []string{"r1f93cmqr", "r1f93fexs", "r1f93fzsn", "r1f965203", "r1f9652gs"},
+		},
+	}
+
+	for i, test := range tests {
+		m, err := GetMtsMedia(ctx, store, testMID2, test.gh, []int64{})
+		if err != nil {
+			t.Errorf("GetMtsMedia #%d failed with error: %v", 5+i, err)
+		}
+		if len(test.want) != len(m) {
+			t.Errorf("GetMtsMedia #%d expected %d results, got %d results", 5+i, len(test.want), len(m))
+			continue
+		}
+		for j := range test.want {
+			if test.want[j] != m[j].Geohash {
+				t.Errorf("GetMtsMedia #%d.%d expected %s, got %s", 5+i, j, test.want[j], m[j].Geohash)
+			}
+		}
+	}
+
+	// Tidy up.
+	DeleteMtsMedia(ctx, store, testMID2)
+}
+
+// testText tests Text
+func testText(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, vidgrind) failed with error: %v", kind, err)
+	}
+
+	texts := []Text{
+		Text{Timestamp: datastore.EpochStart, Type: "text/plain", Data: "Hello world"},
+		Text{Timestamp: datastore.EpochStart + 1, Type: "text/plain", Data: "Hallo Welt"},
+		Text{Timestamp: datastore.EpochStart + 2, Type: "text/plain", Data: "Hola Mundo"},
+	}
+	// First, write some text
+	for i, text := range texts {
+		err := WriteText(ctx, store, &Text{MID: testTextMID, Timestamp: text.Timestamp, Type: text.Type, Data: text.Data})
+		if err != nil {
+			t.Errorf("WriteText #%d failed with error: %v", i, err)
+		}
+	}
+
+	tests := []struct {
+		ts   []int64
+		want []string
+	}{
+		{
+			ts:   []int64{datastore.EpochStart},
+			want: []string{"Hello world"},
+		},
+		{
+			ts:   []int64{datastore.EpochStart, datastore.EpochStart + 4},
+			want: []string{"Hello world", "Hallo Welt", "Hola Mundo"},
+		},
+		{
+			ts:   []int64{datastore.EpochStart + 4},
+			want: []string{},
+		},
+	}
+
+	for i, test := range tests {
+		texts, err := GetText(ctx, store, testTextMID, test.ts)
+		if err != nil {
+			t.Errorf("GetText #%d failed with error: %v", i, err)
+		}
+		for j := range test.want {
+			if texts[j].Data != test.want[j] {
+				t.Errorf("GetText #%d returned wrong data: expected %s, got %s", i, test.want[j], texts[j].Data)
+			}
+		}
+	}
+
+	// Tidy up.
+	DeleteText(ctx, store, testTextMID)
+}
+
+// testActuator checks that we successfully add actuators to the datastore and then get them.
+func testActuator(t *testing.T, kind string) {
+	ctx := context.Background()
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, vidgrind) failed with error: %v", kind, err)
+	}
+
+	tests := []struct {
+		want Actuator
+	}{
+		{want: Actuator{AID: "testActuator1", Var: "testActuatorVar1", Pin: "testDevice1" + ".D1"}},
+		{want: Actuator{AID: "testActuator2", Var: "testActuatorVar2", Pin: "testDevice2" + ".D2"}},
+		{want: Actuator{AID: "testActuator3", Var: "testActuatorVar3", Pin: "testDevice3" + ".D3"}},
+		{want: Actuator{AID: "testActuator4", Var: "testActuatorVar4", Pin: "testDevice4" + ".D4"}},
+	}
+
+	// Write actuators to datastore.
+	for i := range tests {
+		err := PutActuator(ctx, store, &tests[i].want)
+		if err != nil {
+			t.Errorf("WriteActuator #%d failed with error: %v", i, err)
+		}
+	}
+
+	// Retrieve by pin.
+	for i := range tests {
+		act, err := GetActuatorByPin(ctx, store, 0, "testDevice"+strconv.Itoa(i+1), "D"+strconv.Itoa(i+1))
+		if err != nil {
+			t.Errorf("GetActuatorByPin #%d failed with error: %v", i, err)
+		}
+
+		if !reflect.DeepEqual(act[0], tests[i].want) {
+			t.Errorf("Did not get expected result.\nGot: %v\nWant: %v", act, tests[i].want)
+		}
+	}
+
+	// Clean up.
+	for i := range tests {
+		DeleteActuator(ctx, store, tests[i].want.AID)
+	}
+}
+
+// testScalar tests scalars.
+func testScalar(t *testing.T, kind string) {
+	ctx := context.Background()
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Errorf("datastore.NewStore(%s, vidgrind) failed with error: %v", kind, err)
+	}
+
+	tests := []struct {
+		scalar Scalar
+		want   Scalar
+	}{
+		{
+			scalar: Scalar{ID: ToSID(testDevMac, "A0"), Timestamp: datastore.EpochStart, Value: 1},
+			want:   Scalar{ID: (testDevMa << 8) | 100, Timestamp: datastore.EpochStart, Value: 1},
+		},
+		{
+			scalar: Scalar{ID: ToSID(testDevMac, "D12"), Timestamp: datastore.EpochStart, Value: 2},
+			want:   Scalar{ID: (testDevMa << 8) | 13, Timestamp: datastore.EpochStart, Value: 2},
+		},
+		{
+			scalar: Scalar{ID: ToSID(testDevMac, "X22"), Timestamp: datastore.EpochStart, Value: 3},
+			want:   Scalar{ID: (testDevMa << 8) | (128 + 22), Timestamp: datastore.EpochStart, Value: 3},
+		},
+		{
+			scalar: Scalar{ID: ToSID(testDevMac, "X22"), Timestamp: datastore.EpochStart + 1, Value: 4},
+			want:   Scalar{ID: (testDevMa << 8) | (128 + 22), Timestamp: datastore.EpochStart + 1, Value: 4},
+		},
+		{
+			scalar: Scalar{ID: ToSID(testDevMac, "X22"), Timestamp: datastore.EpochStart + 2, Value: 4.12345},
+			want:   Scalar{ID: (testDevMa << 8) | (128 + 22), Timestamp: datastore.EpochStart + 2, Value: 4.123},
+		},
+		{
+			scalar: Scalar{ID: ToSID(testDevMac, ""), Timestamp: datastore.EpochStart + 3, Value: 5},
+			want:   Scalar{ID: testDevMa << 8, Timestamp: datastore.EpochStart + 3, Value: 5},
+		},
+	}
+
+	// First, write some scalars
+	for i := range tests {
+		err := PutScalar(ctx, store, &tests[i].scalar)
+		if err != nil {
+			t.Errorf("WriteScalar #%d failed with error: %v", i, err)
+		}
+	}
+
+	// Second, retrieve with a single timestamp.
+	for i := range tests {
+		s, err := GetScalar(ctx, store, tests[i].scalar.ID, tests[i].scalar.Timestamp)
+		if err != nil {
+			t.Errorf("GetScalars #%d failed with error: %v", i, err)
+		}
+		if tests[i].want.ID != s.ID {
+			t.Errorf("GetScalars #%d expected ID %d, got %d", i, tests[i].want.ID, s.ID)
+		}
+		if tests[i].want.Timestamp != s.Timestamp {
+			t.Errorf("GetScalars #%d expected Timestamp %d, got %d", i, tests[i].want.Timestamp, s.Timestamp)
+		}
+		if tests[i].want.FormatValue(3) != s.FormatValue(3) {
+			t.Errorf("GetScalars #%d expected Value %f, got %f", i, tests[i].want.Value, s.Value)
+		}
+	}
+
+	// Third, retrieve using a timestamp range.
+	s, err := GetScalars(ctx, store, ToSID(testDevMac, "X22"), []int64{datastore.EpochStart, datastore.EpochStart + 2})
+	if err != nil {
+		t.Errorf("GetScalars failed with error: %v", err)
+	}
+	if len(s) != 2 {
+		t.Errorf("GetScalars expected 2 results, got %d results", len(s))
+	}
+
+	// Tidy up.
+	for i := range tests {
+		DeleteScalars(ctx, store, tests[i].scalar.ID)
+	}
+}
+
+func testMtsDurations(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	testDataPath := "../../test/test-data/av/input/audio"
+	_, err := os.Stat(testDataPath)
+	if err != nil {
+		t.Skipf("skipping testMtsDurations")
+		return
+	}
+
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Fatalf("could not create new store: %v", err)
+	}
+
+	tests := []struct {
+		file string
+		want int64
+	}{
+		{"test_audio_mts1.ts", 3 * mts.PTSFrequency},
+		{"test_audio_mts2.ts", 3 * mts.PTSFrequency},
+		{"test_audio_mts3.ts", 2 * mts.PTSFrequency},
+		{"test_audio_mts4.ts", 3 * mts.PTSFrequency},
+	}
+
+	const tolerance = 3
+	for i, dt := range tests {
+		// Read input MTS audio.
+		data, err := ioutil.ReadFile(filepath.Join(testDataPath, dt.file))
+		if err != nil {
+			t.Errorf("Unable to read MTS test file %v for test %v: %v", dt.file, i, err)
+			continue
+		}
+
+		ts := time.Now().Unix()
+		m := &MtsMedia{
+			MID:       testMID,
+			Timestamp: ts,
+			Clip:      data,
+			FramePTS:  mts.PTSFrequency,
+		}
+		err = WriteMtsMedia(ctx, store, m)
+		if err != nil {
+			t.Errorf("write failed for test %v: %v", i, err)
+			continue
+		}
+
+		media, err := GetMtsMedia(ctx, store, m.MID, nil, []int64{ts})
+		if err != nil {
+			t.Errorf("could not get media for test %v: %v", i, err)
+			continue
+		}
+		if len(media) == 0 {
+			t.Errorf("no media in store for test %v", i)
+			continue
+		}
+		if media[0].Duration < dt.want-tolerance || media[0].Duration > dt.want+tolerance {
+			t.Errorf("failed to calculate correct duration for test %v, expected %v, got %v", i, dt.want, media[0].Duration)
+		}
+	}
+}
+
+// TestFirstMediaPID tests the functionality of firstMediaPID.
+func TestFirstMediaPID(t *testing.T) {
+	// MTS packet types.
+	const (
+		pat = iota
+		pmt
+		vid
+		aud
+	)
+
+	tests := []struct {
+		wantPID  uint16 // The PID that is expected to be found.
+		pass     bool   // True if the test should pass without error.
+		order    []int  // Odd index ints represent a packet type, even indices represent the number of that packet type to append to the test data.
+		nPackets int    // The number of packets in the test data.
+	}{
+		{
+			wantPID:  0,
+			pass:     false,
+			order:    []int{pat, 1},
+			nPackets: 1,
+		},
+		{
+			wantPID:  0,
+			pass:     false,
+			order:    []int{pmt, 1},
+			nPackets: 1,
+		},
+		{
+			wantPID:  mts.PIDAudio,
+			pass:     true,
+			order:    []int{aud, 1},
+			nPackets: 1,
+		},
+		{
+			wantPID:  mts.PIDAudio,
+			pass:     true,
+			order:    []int{pat, 1, pmt, 1, aud, 10},
+			nPackets: 12,
+		},
+		{
+			wantPID:  mts.PIDVideo,
+			pass:     true,
+			order:    []int{vid, 6},
+			nPackets: 6,
+		},
+		{
+			wantPID:  mts.PIDVideo,
+			pass:     true,
+			order:    []int{pat, 1, pmt, 1, vid, 1},
+			nPackets: 3,
+		},
+		{
+			wantPID:  mts.PIDVideo,
+			pass:     true,
+			order:    []int{pat, 1, pmt, 1, vid, 30, pat, 1},
+			nPackets: 33,
+		},
+	}
+	for i, test := range tests {
+		packets := make([]byte, test.nPackets*mts.PacketSize)
+		for i := 0; i < len(test.order)/2; i++ {
+			switch test.order[i*2] {
+			case pat:
+				for j := 0; j < test.order[i*2+1]; j++ {
+					p := mts.Packet{PID: mts.PatPid}
+					packets = append(packets, p.Bytes(nil)...)
+				}
+			case pmt:
+				for j := 0; j < test.order[i*2+1]; j++ {
+					p := mts.Packet{PID: mts.PmtPid}
+					packets = append(packets, p.Bytes(nil)...)
+				}
+			case vid:
+				for j := 0; j < test.order[i*2+1]; j++ {
+					p := mts.Packet{PID: mts.PIDVideo}
+					packets = append(packets, p.Bytes(nil)...)
+				}
+			case aud:
+				for j := 0; j < test.order[i*2+1]; j++ {
+					p := mts.Packet{PID: mts.PIDAudio}
+					packets = append(packets, p.Bytes(nil)...)
+				}
+			}
+		}
+		pid, err := firstMediaPID(packets)
+		if err != nil {
+			if test.pass {
+				t.Errorf("test %d failed: %v", i, err)
+			}
+		}
+		if pid != test.wantPID {
+			t.Errorf("test %d failed, got PID: %d, want PID: %d", i, pid, test.wantPID)
+		}
+	}
+}
+
+// mtsHeadWithPID returns first 3 bytes of a valid mts packet header containing given PID for test purposes.
+func mtsHeadWithPID(pid uint16) []byte {
+	return []byte{0x47, byte((pid & 0xFF00) >> 8), byte(pid & 0x00FF)}
+}
+
+func TestGotsPacket(t *testing.T) {
+	b := make([]byte, mts.PacketSize)
+	p := gotsPacket(b)
+	p.SetPID(256)
+	if p.PID() != 256 {
+		t.Error("failed to set PID in gots Packet")
+	}
+}
+
+// testCron tests Cron.
+func testCron(t *testing.T, kind string) {
+	ctx := context.Background()
+
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Fatalf("could not create new store: %v", err)
+	}
+
+	c1 := Cron{Skey: 1, ID: "Test", Time: time.Unix(0, 0), TOD: "Sunrise", Action: "set", Var: "Power", Data: "off"}
+	err = PutCron(ctx, store, &c1)
+	enc := string(c1.Encode())
+	if enc != testCronEnc {
+		t.Errorf("Cron.Encode(1) failed: expected %s, got %s", testCronEnc, enc)
+	}
+	if err != nil {
+		t.Errorf("PutCron failed with error %v", err)
+	}
+	c2, err := GetCron(ctx, store, 1, "Test")
+	if err != nil {
+		t.Errorf("GetCron failed with error %v", err)
+	}
+	enc = string(c2.Encode())
+	if enc != testCronEnc {
+		t.Errorf("Cron.Encode(2) failed: expected %s, got %s", testCronEnc, enc)
+	}
+	err = DeleteCron(ctx, store, 1, "Test")
+	if err != nil {
+		t.Errorf("DeleteCron failed with error %v", err)
+	}
+}
+
+// Benchmarks follow.
+// These are executed by running "go test -bench=."
+
+// BenchmarkSiteWithCaching benchmarks site retrieval with caching.
+func BenchmarkSiteWithCaching(b *testing.B) {
+	benchmarkSite(b)
+}
+
+// BenchmarkSiteWithoutCaching benchmarks site retrieval without caching.
+func BenchmarkSiteWithoutCaching(b *testing.B) {
+	siteCache = nil // Disable caching.
+	benchmarkSite(b)
+}
+
+func benchmarkSite(b *testing.B) {
+	ctx := context.Background()
+	store, err := datastore.NewStore(ctx, "cloud", "vidgrind", "")
+	if err != nil {
+		b.Errorf("could not get store: %v", err)
+	}
+	site := Site{Skey: testSiteKey, Name: testSiteName, Latitude: testSiteLat, Longitude: testSiteLng, Timezone: testSiteTZ, Enabled: true}
+	err = PutSite(ctx, store, &site)
+	if err != nil {
+		b.Errorf("could not put site: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := GetSite(ctx, store, testSiteKey)
+		if err != nil {
+			b.Fatalf("could not get site: %v", err)
+		}
+	}
+}

--- a/model/mtsmedia.go
+++ b/model/mtsmedia.go
@@ -1,0 +1,597 @@
+/*
+DESCRIPTION
+  MtsMedia datastore type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+  Trek Hopton <trek@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019-2021 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+	"unsafe"
+
+	"github.com/Comcast/gots/packet"
+	"github.com/ausocean/av/container/mts"
+	"github.com/ausocean/av/container/mts/pes"
+	"github.com/ausocean/openfish/datastore"
+)
+
+const (
+	typeMtsMedia = "MtsMedia" // MtsMedia datastore type.
+)
+
+var (
+	ErrInvalidMID          = errors.New("invalid MID")
+	ErrIdenticalTimestamps = errors.New("too many identical timestamps")
+	ErrInvalidRanges       = errors.New("cannot have both geohash and timestamp ranges")
+	ErrInvalidKeyName      = errors.New("malformed MtsMedia key name")
+	ErrMediaNotFound       = errors.New("media not found")
+	ErrInvalidMtsPackets   = errors.New("clip contains invalid MTS packets")
+	ErrNoMtsPackets        = errors.New("clip contains no MTS packets")
+	ErrNoMediaPID          = errors.New("no media PID found")
+)
+
+// MtsMedia represents a clip of continuous audio/video media data in
+// MPEG-TS (MTS) format. Continues is true if the clip is continuous
+// in time with respect to the previous one, false otherwise.
+//
+// The Media ID (MID) can be any identifier that uniquely identifies
+// the media source, but conventionally it is formed from the 48-bit
+// MAC address followed by the 4-bit encoding of the pin of the
+// source device. See ToMID.
+//
+// NB: Since App Engine stores []byte as a blob, the clip cannot
+// exceed 1MB in size. The "noindex" datastore attribute prevents the
+// datastore from attempting to index the clip (and failing).
+type MtsMedia struct {
+	MID       int64          // Media ID.
+	Geohash   string         // Geohash, if any.
+	Timestamp int64          // Timestamp (in seconds).
+	PTS       int64          // Presentation timestamp (in MTS frequency units).
+	Duration  int64          // Duration of clip (in MTS frequency units).
+	Continues bool           // True if this clip continues from the previous one, false if there a discontinuity.
+	Type      string         // MIME type.
+	Metadata  string         // Other metadata, if any.
+	Date      time.Time      // Date/time this record was created.
+	Clip      []byte         `datastore:",noindex"` // Media data.
+	Key       *datastore.Key `datastore:"__key__"`  // Not persistent but populated upon reading from the datastore.
+	FramePTS  int64          `datastore:"-"`        // Frame period in PTS frequency units (not persistent).
+}
+
+// MTSFragment is a series of continuous MtsMedia clips.
+// MTSFragment does not have a limit on how many MtsMedias it can contain, whereas MtsMedia clips must be under 1MB.
+type MTSFragment struct {
+	Medias      []*MtsMedia // MtsMedias that make up fragment.
+	Type        string      // MIME type of all this fragment's MtsMedias.
+	Duration    int64       // Total duration of media that makes up the fragment in MTS frequency units.
+	DurationSec int64       // Total duration of media that makes up the fragment in seconds.
+	TSRange     [2]int64    // Contains the timestamp of the first MtsMedia and the timestamp directly after the the duration of the last MtsMedia.
+	Continues   bool        // True if this fragment continues from the previous fragment, false if there a discontinuity.
+}
+
+// Encode serializes an MtsMedia entity as follows:
+//
+//   - Octet(s)  Value
+//   - 0-2       Reserved
+//   - 3         Continues
+//   - 4-11      MID (8 octets)
+//   - 12-23     Geohash (12 octets)
+//   - 24-31     Timestamp (8 octets)
+//   - 32-37     PTS (6 octets)
+//   - 38-43     Duration (6 octets)
+//   - 44-47     Type length (4 octets)
+//   - 48-51     Metadata length (4 octets)
+//   - 52-55     Clip length (4 octets)
+//   - >=56      Type, metadata, and clip data
+func (m *MtsMedia) Encode() []byte {
+	lenType := len(m.Type)
+	lenMeta := len(m.Metadata)
+	lenClip := len(m.Clip)
+	b := make([]byte, 56+lenType+lenMeta+lenClip)
+	if m.Continues {
+		b[3] |= 0x01
+	}
+	binary.BigEndian.PutUint64(b[4:12], uint64(m.MID))
+	copy(b[12:24], m.Geohash)
+	binary.BigEndian.PutUint64(b[24:32], uint64(m.Timestamp))
+	putUint48(b[32:38], uint64(m.PTS))
+	putUint48(b[38:44], uint64(m.Duration))
+	binary.BigEndian.PutUint32(b[44:48], uint32(lenType))
+	binary.BigEndian.PutUint32(b[48:52], uint32(lenMeta))
+	binary.BigEndian.PutUint32(b[52:56], uint32(lenClip))
+	copy(b[56:56+lenType], m.Type)
+	copy(b[56+lenType:56+lenType+lenMeta], m.Metadata)
+	copy(b[56+lenType+lenMeta:], m.Clip)
+	return b
+}
+
+// Decode deserializes a MtsMedia.
+func (m *MtsMedia) Decode(b []byte) error {
+	if b[3]&0x01 == 1 {
+		m.Continues = true
+	}
+	m.MID = int64(binary.BigEndian.Uint64(b[4:12]))
+	m.Geohash = string(bytes.Trim(b[12:24], "\x00"))
+	m.Timestamp = int64(binary.BigEndian.Uint64(b[24:32]))
+	m.PTS = int64(getUint48(b[32:38]))
+	m.Duration = int64(getUint48(b[38:44]))
+	lenType := binary.BigEndian.Uint32(b[44:48])
+	lenMeta := binary.BigEndian.Uint32(b[48:52])
+	lenClip := binary.BigEndian.Uint32(b[52:56])
+	m.Type = string(b[56 : 56+lenType])
+	m.Metadata = string(b[56+lenType : 56+lenType+lenMeta])
+	m.Clip = b[56+lenType+lenMeta : 56+lenType+lenMeta+lenClip]
+	return nil
+}
+
+// Copy is not currently implemented.
+func (m *MtsMedia) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (m *MtsMedia) GetCache() datastore.Cache {
+	return nil
+}
+
+// KeyID returns the MtsMedia key ID as an unsigned integer.
+func (m *MtsMedia) KeyID() uint64 {
+	return uint64(m.Key.ID)
+}
+
+// split finds a point to split the MTS data in m.Clip so that the LHS is
+// a clip with a size less that 1MB (App Engine's maximum blob size).
+// m.Clip is replaced with that new clip and m's PTS and calculated duration are set to match.
+//
+// The split will happen at a PAT boundary or at the last MTS packet
+// boundary, unless discontinuities are found, in which case the split will
+// happen at the discontinuity.
+// The clip's PTS is the PTS of the first media PES packet.
+// The clip's duration is calculated by finding the difference between the clip's
+// PTS and the PTS of the clip's last PES packet with a matching PID, plus one PES frame period.
+// It is expected that when this function is called, m.Clip should contain at least one PAT and PMT.
+func (m *MtsMedia) split() error {
+	const maxSize = int(datastore.MaxBlob/mts.PacketSize) * mts.PacketSize
+	sz := len(m.Clip)
+
+	if sz > maxSize {
+		_, i, err := mts.LastPid(m.Clip[:maxSize], mts.PatPid)
+		if err != nil || i == 0 {
+			log.Printf("could not find suitable PAT at which to split")
+			i = maxSize
+		}
+		log.Printf("splitting large clip of %d bytes at %d", sz, i)
+		sz = i
+	}
+
+	pid, err := firstMediaPID(m.Clip[:sz])
+	if err != nil {
+		return fmt.Errorf("could not find media PID: %w", err)
+	}
+
+	m.Continues = true
+	var firstPTS int64 = -1
+	var currentPTS int64
+	var pkt *packet.Packet
+	for i := 0; i < sz; i += mts.PacketSize {
+		pkt = gotsPacket(m.Clip[i : i+mts.PacketSize])
+
+		// Read PID, skip packet if no match.
+		id := pkt.PID()
+		if id != int(pid) {
+			continue
+		}
+		var pts int64
+		if pkt.PayloadUnitStartIndicator() {
+			pts, err = mts.GetPTS(m.Clip[i:])
+			if err != nil {
+				return fmt.Errorf("could not find PTS where expected: %w", err)
+			}
+		} else {
+			continue
+		}
+		currentPTS = pts
+		if firstPTS == -1 {
+			firstPTS = currentPTS
+			m.PTS = firstPTS
+		}
+
+		// Read AFC, an AFC of 3 indicates an adaptation field followed by a
+		// payload in which case we would like to check for discontinuity.
+		if pkt.AdaptationFieldControl() == packet.PayloadAndAdaptationFieldFlag {
+			af, err := pkt.AdaptationField()
+			if err != nil {
+				return err
+			}
+			d, err := af.Discontinuity()
+			if err != nil {
+				return fmt.Errorf("could not get discontinuity indicator from adaptation field: %w", err)
+			}
+			if d {
+				if i == 0 {
+					// Segment starts with a discontinuity.
+					m.Continues = false
+					// Clear discontinuity indicator if clip is H264.
+					s, err := pes.SIDToMIMEType(pes.H264SID)
+					if err != nil {
+						panic(fmt.Errorf("could not get type from H264 SID: %w", err))
+					}
+					if m.Type == s {
+						err = af.SetDiscontinuity(false)
+						if err != nil {
+							return fmt.Errorf("could not set discontinuity indicator: %w", err)
+						}
+					}
+					continue
+				}
+				// Ending segment at discontinuity.
+				log.Printf("splitting at discontinuity")
+				sz = i
+				break
+			}
+		}
+	}
+	// Check if PTS rollover has occurred.
+	var adj int64
+	if currentPTS < firstPTS {
+		adj = mts.MaxPTS
+	}
+
+	m.Duration = adj + currentPTS - firstPTS + m.FramePTS
+
+	m.Clip = m.Clip[:sz]
+
+	return nil
+}
+
+// WriteMtsMedia stores MTS (MPEG-TS) data (i.e, audio/video data),
+// splitting it into 1MB chunks and/or at discontinuities.
+// Note: this function currently will only write media from one elementary stream in the program.
+func WriteMtsMedia(ctx context.Context, store datastore.Store, m *MtsMedia) error {
+	if len(m.Clip) == 0 {
+		return ErrNoMtsPackets
+	}
+	if (len(m.Clip) % mts.PacketSize) != 0 {
+		return ErrInvalidMtsPackets
+	}
+	pid, err := firstMediaPID(m.Clip)
+	if err != nil {
+		return ErrMediaNotFound
+	}
+
+	var st int64
+	media := m
+	for i := 0; i < len(m.Clip); i += len(media.Clip) {
+		media.Clip = m.Clip[i:]
+		media.FramePTS = m.FramePTS
+		err := media.split()
+		if err != nil {
+			return fmt.Errorf("could not split MTS media: %w", err)
+		}
+		media.Date = time.Now()
+		key := store.IDKey(typeMtsMedia, datastore.IDKey(media.MID, media.Timestamp, st))
+		_, err = store.Put(ctx, key, media)
+		if err != nil {
+			return fmt.Errorf("error writing MTS media with PID %d and length %d bytes: %w", pid, len(media.Clip), err)
+		}
+		st++
+		if st == 1<<datastore.SubTimeBits {
+			return ErrIdenticalTimestamps
+		}
+	}
+	return nil
+}
+
+// gotsPacket takes a byte slice and returns a Packet as defined in github.com/comcast/gots/packet.
+// TODO: replace this with a type conversion as described here: https://github.com/golang/go/issues/395
+// when it becomes available in Go 1.17.
+func gotsPacket(b []byte) *packet.Packet {
+	if len(b) != packet.PacketSize {
+		panic("invalid packet size")
+	}
+	return *(**packet.Packet)(unsafe.Pointer(&b))
+}
+
+// firstMediaPID will iterate over the MTS packets of the given clip and find and return the first
+// PID that is not for a PAT or PMT packet.
+func firstMediaPID(clip []byte) (pid uint16, err error) {
+	if len(clip) == 0 {
+		return 0, ErrNoMtsPackets
+	}
+	if (len(clip) % mts.PacketSize) != 0 {
+		return 0, ErrInvalidMtsPackets
+	}
+	for i := 0; i < len(clip); i += mts.PacketSize {
+		pid, err = mts.PID(clip[i : i+mts.PacketSize])
+		if err != nil {
+			return 0, fmt.Errorf("could not get media PID: %w", err)
+		}
+		if pid != mts.PatPid && pid != mts.PmtPid {
+			return pid, nil
+		}
+	}
+	return 0, ErrNoMediaPID
+}
+
+// GetMtsMedia retrieves MTS media data for a given Media ID,
+// optionally filtered by timestamp(s) and geohash(es). One timestamp
+// represents an instant in time whereas two represents a time
+// range. Similarly one geohash represents a single location whereas
+// two represents a neighborhood of locations. Results are ordered by
+// geohash, then timestamp, and then creation time. It is invalid to
+// specify ranges for both geohashes and timestamps, since the
+// datastore prohibits inequality filters on different properties.
+//
+// NB: FileStore queries are are limited to information encoded in the
+// key, namely MID and Timestamp.
+func GetMtsMedia(ctx context.Context, store datastore.Store, mid int64, gh []string, ts []int64) ([]MtsMedia, error) {
+	q, err := newMtsMediaQuery(store, mid, gh, ts, false)
+	if err != nil {
+		return nil, err
+	}
+	var clips []MtsMedia
+	_, err = store.GetAll(ctx, q, &clips)
+	return clips, err
+}
+
+// GetMtsMediaKeys retrieves MtsMedia keys for a given Media ID,
+// optionally filtered by timestamp(s) and geohash(es).
+func GetMtsMediaKeys(ctx context.Context, store datastore.Store, mid int64, gh []string, ts []int64) ([]*datastore.Key, error) {
+	q, err := newMtsMediaQuery(store, mid, gh, ts, true)
+	if err != nil {
+		return nil, err
+	}
+	return store.GetAll(ctx, q, nil)
+}
+
+// newMtsMediaQuery constructs an MtsMedia query.
+func newMtsMediaQuery(store datastore.Store, mid int64, gh []string, ts []int64, keysOnly bool) (datastore.Query, error) {
+	if len(gh) > 1 && len(ts) > 1 {
+		return nil, ErrInvalidRanges
+	}
+
+	q := store.NewQuery(typeMtsMedia, keysOnly, "MID", "Timestamp")
+	q.Filter("MID =", mid)
+
+	if gh != nil {
+		if len(gh) > 1 {
+			q.Filter("Geohash >=", gh[0])
+			q.Filter("Geohash <", gh[1])
+			q.Order("Geohash")
+		} else if len(gh) > 0 {
+			q.Filter("Geohash =", gh[0])
+		}
+	}
+
+	if ts != nil {
+		if len(ts) > 1 {
+			q.Filter("Timestamp >=", ts[0])
+			if ts[1] < datastore.EpochEnd {
+				q.Filter("Timestamp <", ts[1])
+			}
+			q.Order("Timestamp")
+		} else if len(ts) > 0 {
+			q.Filter("Timestamp =", ts[0])
+		}
+	}
+	q.Order("Date")
+	return q, nil
+}
+
+// GetMtsMediaByKey retrieves a single MTS media entity by key ID.
+func GetMtsMediaByKey(ctx context.Context, store datastore.Store, ky uint64) (*MtsMedia, error) {
+	key := store.IDKey(typeMtsMedia, int64(ky))
+	m := new(MtsMedia)
+	err := store.Get(ctx, key, m)
+	if err != nil {
+		return nil, ErrMediaNotFound
+	}
+	m.Key = key // Populate the key.
+	return m, nil
+}
+
+// GetMtsMediaByKeys returns multiple MTS media given a range of key
+// IDs, skipping over missing keys and fractional times. An error is
+// returned only if nothing is found at all. This function is O(N)
+// with the number of keys and should not be used with large numbers
+// of keys. Use GetMtsMedia instead.
+func GetMtsMediaByKeys(ctx context.Context, store datastore.Store, ky []uint64) ([]MtsMedia, error) {
+	if len(ky) == 0 {
+		return nil, ErrMediaNotFound
+	}
+
+	if len(ky) == 1 {
+		m, err := GetMtsMediaByKey(ctx, store, ky[0])
+		if err != nil {
+			return nil, err
+		}
+		return []MtsMedia{*m}, nil
+	}
+
+	var media []MtsMedia
+	step := uint64(1) << datastore.SubTimeBits
+	for id := ky[0]; id < ky[len(ky)-1]; id += step {
+		m, err := GetMtsMediaByKey(ctx, store, id)
+		if err != nil {
+			continue
+		}
+		media = append(media, *m)
+	}
+	if len(media) == 0 {
+		return nil, ErrMediaNotFound
+	}
+	return media, nil
+}
+
+// FragmentMTSMedia returns a slice of MTSFragments from the given MtsMedia
+// every period seconds or whenever there is a discontinutity.
+// Tolerance, which is specified in MTS frequency units (90kHz), controls how
+// strictly discontinuities are enforced and how strictly the period is adhered to.
+func FragmentMTSMedia(in []MtsMedia, period, tolerance int64) (out []*MTSFragment) {
+	if len(in) == 0 {
+		return
+	}
+
+	// Convert seconds in MTS period units.
+	period *= mts.PTSFrequency
+
+	// Divide MtsMedia slice into fragments.
+	var prev, start *MtsMedia
+	frag := &MTSFragment{Continues: in[0].Continues}
+	for i := 0; i < len(in); {
+		m := &in[i]
+		if frag.Duration == 0 {
+			frag.Medias = append(frag.Medias, m)
+			frag.Type = m.Type
+			frag.Duration = m.Duration
+			frag.TSRange[0] = m.Timestamp
+			start = m
+			prev = m
+			i++
+			continue
+		}
+
+		if m.Duration == 0 {
+			i++
+			continue
+		}
+
+		// Check for PTS roll over.
+		if m.PTS < start.PTS {
+			m.PTS += mts.MaxPTS
+		}
+
+		// Check for discontinuity.
+		continues := true
+		if m.PTS > prev.PTS+prev.Duration+tolerance || !m.Continues {
+			continues = false
+		}
+
+		// If the period has elapsed, type has changed, or there is a discontinuity, add this fragment to the output.
+		if (m.PTS > prev.PTS && frag.Duration+m.Duration > period+tolerance) || !continues || m.Type != start.Type {
+			frag.DurationSec = frag.Duration / mts.PTSFrequency
+			frag.TSRange[1] = frag.Medias[len(frag.Medias)-1].Timestamp + frag.Medias[len(frag.Medias)-1].Duration/mts.PTSFrequency
+			out = append(out, frag)
+			frag = &MTSFragment{Continues: continues}
+			continue
+		}
+		frag.Medias = append(frag.Medias, m)
+		frag.Duration += m.Duration
+		prev = m
+		i++
+	}
+
+	// Emit the remainder, if any.
+	if frag.Duration > 0 {
+		frag.DurationSec = frag.Duration / mts.PTSFrequency
+		frag.TSRange[1] = frag.Medias[len(frag.Medias)-1].Timestamp + frag.Medias[len(frag.Medias)-1].Duration/mts.PTSFrequency
+		out = append(out, frag)
+	}
+
+	return
+}
+
+// DeleteMtsMedia deletes all MTS media for a given Media ID.
+func DeleteMtsMedia(ctx context.Context, store datastore.Store, mid int64) error {
+	keys, err := GetMtsMediaKeys(ctx, store, mid, nil, nil)
+	if err != nil {
+		return err
+	}
+	return store.DeleteMulti(ctx, keys)
+}
+
+// UpdateMtsMedia deletes a MTS media and creates a new one in its place.
+func UpdateMtsMedia(ctx context.Context, store datastore.Store, m MtsMedia, pid uint16) error {
+	store.DeleteMulti(ctx, []*datastore.Key{m.Key})
+	_, err := store.Put(ctx, m.Key, &m)
+	return err
+}
+
+// ToMID returns a Media ID given a MAC address and a pin. It is
+// formed from the 48-bit integer encoding of the mac (see MacEncode)
+// followed by the 4-bit encoding of the pin.
+func ToMID(mac, pin string) int64 {
+	return MacEncode(mac)<<4 | int64(putMtsPin(pin))
+}
+
+// FromMID returns a MAC address and pin given a Media ID.
+func FromMID(mid int64) (string, string) {
+	return MacDecode(mid >> 4), getMtsPin(byte(mid & 0x0f))
+}
+
+// putMtsPin encodes a pin string, such as "V0" or "S3", into a nibble.
+// Bits 0-1 represent the pin number and bits 2-3 represents the pin
+// type.
+func putMtsPin(pin string) byte {
+	var b byte
+	switch pin[0] {
+	case 'S':
+		b = 0x04
+	case 'T':
+		b = 0x08
+	}
+	pn := int(pin[1] - '0')
+	b |= byte(pn)
+	return b
+}
+
+// getMtsPin decodes a nibble into a pin string.
+func getMtsPin(b byte) string {
+	s := make([]byte, 2)
+	pn := int(b & 0x03)
+	s[1] = byte('0' + pn)
+	switch (b >> 2) & 0x03 {
+	case 0:
+		s[0] = 'V'
+	case 1:
+		s[0] = 'S'
+	case 2:
+		s[0] = 'T'
+	}
+	return string(s)
+}
+
+// putUint48 encodes a 48-bit integer into 6 bytes in big-endian order.
+func putUint48(b []byte, val uint64) {
+	b[0] = byte(val >> 40)
+	b[1] = byte(val >> 32)
+	b[2] = byte(val >> 24)
+	b[3] = byte(val >> 16)
+	b[4] = byte(val >> 8)
+	b[5] = byte(val)
+}
+
+// getUint48 decodes 6 bytes in big-endian order into a 48-bit integer.
+func getUint48(b []byte) uint64 {
+	return uint64(b[0])<<40 | uint64(b[1])<<32 | uint64(b[2])<<24 | uint64(b[3])<<16 | uint64(b[4])<<8 | uint64(b[5])
+}
+
+// PTSToSeconds converts a duration in MPEG-TS Presentation Time Stamp (PTS) units to seconds.
+func PTSToSeconds(pts int64) float64 {
+	return float64(pts) / mts.PTSFrequency
+}

--- a/model/scalar.go
+++ b/model/scalar.go
@@ -1,0 +1,229 @@
+/*
+DESCRIPTION
+  Scalar datastore type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+const typeScalar = "Scalar" // Scalar datastore type.
+
+// Scalar represents scalar data, such as a single analog (A) or
+// digital (D) value.
+//
+// The ID can be any identifier that uniquely identifies the data
+// source, but conventionally it is formed from the 48-bit MAC address
+// followed by the 8-bit encoding of the pin of the source device. See
+// ToSID.
+type Scalar struct {
+	ID        int64
+	Timestamp int64
+	Value     float64
+	Key       *datastore.Key `datastore:"__key__" json:"-"` // Not persistent but populated upon reading from the datastore.
+}
+
+// Encode serializes a Scalar entity into tab-separated values.
+func (s *Scalar) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%d\t%s", s.ID, s.Timestamp, s.FormatValue(3)))
+}
+
+// Decode deserializes a Scalar entity from tab-separated values.
+func (s *Scalar) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 3 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	s.ID, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	s.Timestamp, err = strconv.ParseInt(p[1], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	s.Value, err = strconv.ParseFloat(p[2], 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	return nil
+}
+
+// Copy is not currently implemented.
+func (s *Scalar) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (s *Scalar) GetCache() datastore.Cache {
+	return nil
+}
+
+// KeyID returns the scalar's key ID as an unsigned integer.
+func (s *Scalar) KeyID() uint64 {
+	return uint64(s.Key.ID)
+}
+
+// FormatValue formats a scalar's value as a string to the specified precision.
+func (s *Scalar) FormatValue(prec int) string {
+	if prec < 0 {
+		panic(fmt.Sprintf("Scalar.FormatValue: negative precision: %d", prec))
+	}
+	if s.Value == float64(int64(s.Value)) {
+		return strconv.FormatInt(int64(s.Value), 10)
+	} else {
+		return strconv.FormatFloat(s.Value, 'f', prec, 64)
+	}
+}
+
+// PutScalar writes a scalar.
+func PutScalar(ctx context.Context, store datastore.Store, s *Scalar) error {
+	key := store.IDKey(typeScalar, datastore.IDKey(s.ID, s.Timestamp, 0))
+	_, err := store.Put(ctx, key, s)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetScalar gets a single scalar by ID and timestamp.
+func GetScalar(ctx context.Context, store datastore.Store, id int64, ts int64) (*Scalar, error) {
+	key := store.IDKey(typeScalar, datastore.IDKey(id, ts, 0))
+	s := new(Scalar)
+	err := store.Get(ctx, key, s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// GetScalars returns scalar data.
+// When ts is a non-identical pair, it represents a time range.
+// A value of -1 for the second value indicates no upper bound to the time range.
+// When ts is a singleton or identical pair, it represents an exact time.
+func GetScalars(ctx context.Context, store datastore.Store, id int64, ts []int64) ([]Scalar, error) {
+	q := store.NewQuery(typeScalar, false, "ID", "Timestamp")
+	q.Filter("ID =", id)
+	filterByTime(q, ts)
+
+	var data []Scalar
+	_, err := store.GetAll(ctx, q, &data)
+	return data, err
+}
+
+// GetScalarKeys is similiar to GetScalars, but returns the keys rather than the entities.
+func GetScalarKeys(ctx context.Context, store datastore.Store, id int64, ts []int64) ([]*datastore.Key, error) {
+	q := store.NewQuery(typeScalar, true, "ID", "Timestamp")
+	q.Filter("ID =", id)
+	filterByTime(q, ts)
+
+	return store.GetAll(ctx, q, nil)
+}
+
+// filterByTime optionally adds timestamp filters to a Scalar query.
+func filterByTime(q datastore.Query, ts []int64) {
+	if ts == nil {
+		return
+	}
+	if len(ts) > 1 && ts[1] != ts[0] {
+		q.Filter("Timestamp >=", ts[0])
+		if ts[1] > 0 && ts[1] < datastore.EpochEnd {
+			q.Filter("Timestamp <", ts[1])
+		}
+		q.Order("Timestamp")
+	} else if len(ts) > 0 {
+		q.Filter("Timestamp =", ts[0])
+	} else {
+		panic(fmt.Sprintf("filterByTime: unexpected ts length: %d", len(ts)))
+	}
+}
+
+// DeleteScalar deletes all scalars for a given ID.
+func DeleteScalars(ctx context.Context, store datastore.Store, id int64) error {
+	q := store.NewQuery(typeScalar, true, "ID")
+	q.Filter("ID =", id)
+	keys, err := store.GetAll(ctx, q, nil)
+	if err != nil {
+		return err
+	}
+
+	return store.DeleteMulti(ctx, keys)
+}
+
+// ToSID produces a Scalar ID from a MAC address and pin.  Unlike
+// Media IDs, the pin is represented by 8 bits in order to accommodate
+// 2-digit pin numbers.
+func ToSID(mac, pin string) int64 {
+	return MacEncode(mac)<<8 | int64(putScalarPin(pin))
+}
+
+// FromSID returns a MAC address and pin given a Scalar ID.
+func FromSID(id int64) (string, string) {
+	return MacDecode(id >> 8), getScalarPin(byte(id & 0xff))
+}
+
+// putScalarPin encodes a pin string, such as "A0", "D10" or "X22",
+// into a byte. The most signifcant bit encodes the pin type, namely 0
+// for A or D, or 1 for X. The remaining bits encode the 2-digit pin
+// number, with numbers between 1 and 99 (inclusive) representing
+// digital pins, e.g, 1 for D0, 2 for D1 and 100 and 127 (inclusive)
+// representing analog pins, e.g., 100 for A0, 101 for A1, etc.
+func putScalarPin(pin string) byte {
+	if pin == "" {
+		return 0
+	}
+	pn, _ := strconv.Atoi(pin[1:])
+	switch pin[0] {
+	case 'A':
+		return byte(pn + 100)
+	case 'D':
+		return byte(pn + 1)
+	case 'X':
+		return 0x80 | byte(pn)
+	}
+	return 0
+}
+
+// getScalarPin decodes a byte into a pin string.
+func getScalarPin(b byte) string {
+	pn := int(b & 0x7f)
+	if b&0x80 == 0 {
+		if pn >= 100 {
+			return "A" + strconv.Itoa(pn-100)
+		} else if pn >= 1 {
+			return "D" + strconv.Itoa(pn-1)
+		} else {
+			return ""
+		}
+
+	} else {
+		return "X" + strconv.Itoa(pn)
+	}
+}

--- a/model/sensor.go
+++ b/model/sensor.go
@@ -1,0 +1,426 @@
+/*
+AUTHORS
+  Saxon Nelson-Milton <saxon@ausocean.org>
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2022 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/Knetic/govaluate"
+	"github.com/ausocean/openfish/datastore"
+)
+
+// The entitiy type as named in the datastore.
+const (
+	typeSensor   = "Sensor"
+	typeSensorV2 = "SensorV2"
+)
+
+// Number of arguments for each function type.
+const (
+	nArgsScale     = 1
+	nArgsLinear    = 2
+	nArgsQuadratic = 3
+)
+
+// The keys for the function types.
+// See also SensorFuncs below.
+const (
+	keyNone      = "none"
+	keyScale     = "scale"
+	keyLinear    = "linear"
+	keyQuadratic = "quadratic"
+	keyCustom    = "custom"
+)
+
+// Exported errors.
+var (
+	ErrUnexpectedArgs      = errors.New("unexpected number of args")
+	ErrArgParse            = errors.New("could not parse argument")
+	ErrUnrecognisedFunc    = errors.New("unrecognised function key")
+	ErrEvaluableExpression = &errEvaluableExpression{}
+	ErrEvaluate            = &errEvaluate{}
+)
+
+// errEvaluableExpression is intended to wrap any error from govaluate.NewEvaluableExpression
+// and implements the Is method so that we can check for this error using errors.Is.
+type errEvaluableExpression struct{ err error }
+
+func (e *errEvaluableExpression) Error() string {
+	msg := "could not create evaluable expression from args string"
+	if e.err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %s", msg, e.err.Error())
+}
+func (e *errEvaluableExpression) Is(err error) bool {
+	_, ok := err.(*errEvaluableExpression)
+	return ok
+}
+
+// errEvaluate is intended to wrap any error from govaluate.EvaluableExpression.Evaluate
+// and implements the Is method so that we can check for this kind of error using
+// errors.Is.
+type errEvaluate struct{ err error }
+
+func (e *errEvaluate) Error() string {
+	msg := "could not evaluate expression"
+	if e.err == nil {
+		return msg
+	}
+	return fmt.Sprintf("%s: %s", msg, e.err.Error())
+}
+func (e *errEvaluate) Is(err error) bool {
+	_, ok := err.(*errEvaluate)
+	return ok
+}
+
+// funcs holds a map of func names to the operations to be performed.
+var funcs = map[string]func(x float64, args string) (float64, error){
+	keyScale: func(x float64, args string) (float64, error) {
+		argFlts, err := parseArgs(args, nArgsScale)
+		if err != nil {
+			return 0.0, err
+		}
+		return x * argFlts[0], nil
+	},
+
+	keyLinear: func(x float64, args string) (float64, error) {
+		argFlts, err := parseArgs(args, nArgsLinear)
+		if err != nil {
+			return 0.0, err
+		}
+		return x*argFlts[0] + argFlts[1], nil
+	},
+
+	keyQuadratic: func(x float64, args string) (float64, error) {
+		argFlts, err := parseArgs(args, nArgsQuadratic)
+		if err != nil {
+			return 0.0, err
+		}
+		return argFlts[0]*math.Pow(x, 2) + argFlts[1]*x + argFlts[2], nil
+	},
+
+	// It is expected that the args string contains the custom function, and only
+	// the custom function, otherwise errors will likely follow from govaluate.
+	// The value to be transformed is represented by x e.g. (x + 3)/2.
+	keyCustom: func(x float64, args string) (float64, error) {
+		exp, err := govaluate.NewEvaluableExpression(args)
+		if err != nil {
+			return 0.0, &errEvaluableExpression{err}
+		}
+		params := map[string]interface{}{"x": x}
+
+		res, err := exp.Evaluate(params)
+		if err != nil {
+			return 0.0, &errEvaluate{err}
+		}
+		return res.(float64), nil
+	},
+}
+
+// parseArgs is used in the func maps above to firstly check that the user has
+// provided the correct number of CSV values given the type of function selected,
+// and then secondly creates a float64 slice to house the parsed out numerical
+// args to be passed into the selected function.
+func parseArgs(args string, n int) ([]float64, error) {
+	args = strings.ReplaceAll(args, " ", "")
+	split := strings.Split(args, ",")
+	if len(split) != n {
+		return nil, fmt.Errorf("%w, got: %d, want: %d", ErrUnexpectedArgs, len(split), n)
+	}
+	argFlts := make([]float64, n)
+	for i, v := range split {
+		vf, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse arg no. %d: %w", i, err)
+		}
+		argFlts[i] = vf
+	}
+	return argFlts, nil
+}
+
+// Sensor repsents a sensor datastore type. Sensors take raw measured
+// values and transform them based on a few predefined functions, or
+// by a custom function specified by a string expression.
+// NB: This type is deprecated. See SensorV2.
+type Sensor struct {
+	SKey     int64   `datastore:"skey"`
+	SID      string  `datastore:"sid"`
+	Pin      string  `datastore:"pin"`
+	Quantity string  `datastore:"quantity"`
+	Func     string  `datastore:"func"`
+	Args     string  `datastore:"args"`
+	Scale    float64 `datastore:"scale"`
+	Offset   float64 `datastore:"offset"`
+	Units    string  `datastore:"units"`
+	Format   string  `datastore:"format"`
+}
+
+// Transform applies the transformation specified in s.Func to the passed value v.
+func (s *Sensor) Transform(v float64) (float64, error) {
+	if s.Func == "" || s.Func == "none" || s.Func == "None" {
+		return v, nil
+	}
+	f, ok := funcs[s.Func]
+	if !ok {
+		return 0.0, ErrUnrecognisedFunc
+	}
+	res, err := f(v, s.Args)
+	if err != nil {
+		return 0.0, fmt.Errorf("could not transform value: %w", err)
+	}
+	return res, nil
+}
+
+// Encode serializes a Sensor into tab-separated values.
+func (s *Sensor) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%s\t%s\t%s\t%s\t%f\t%f\t%s\t%s", s.SKey, s.SID, s.Pin, s.Quantity, s.Func, s.Args, s.Scale, s.Offset, s.Units, s.Format))
+}
+
+// Decode deserializes a Sensor from tab-separated values.
+func (s *Sensor) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 10 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	s.SKey, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	s.SID = p[1]
+	s.Pin = p[2]
+	s.Quantity = p[3]
+	s.Func = p[4]
+	s.Args = p[5]
+	s.Scale, err = strconv.ParseFloat(p[6], 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	s.Offset, err = strconv.ParseFloat(p[7], 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	s.Units = p[8]
+	s.Format = p[9]
+	return nil
+}
+
+// Copy is not currently implemented.
+func (s *Sensor) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (s *Sensor) GetCache() datastore.Cache {
+	return nil
+}
+
+// SensorFuncs returns a list of the funcs that can be selected for value
+// transformation through Sensor entities.
+func SensorFuncs() []string {
+	return []string{keyNone, keyScale, keyLinear, keyQuadratic, keyCustom}
+}
+
+// SensorFormats returns a list of available formats for formatting sensor values.
+func SensorFormats() []string {
+	return []string{"bool", "round", "round1", "round2", "compass", "hex"}
+}
+
+// GetSensor gets a Sensor from the datastore given the site key and sensor id.
+func GetSensor(ctx context.Context, store datastore.Store, sKey int64, sid string) (*Sensor, error) {
+	key := store.NameKey(typeSensor, strconv.Itoa(int(sKey))+"."+sid)
+	var sensor *Sensor
+	err := store.Get(ctx, key, sensor)
+	if err != nil {
+		return nil, err
+	}
+	return sensor, nil
+}
+
+// PutSensor puts a Sensor entity into the datastore.
+func PutSensor(ctx context.Context, store datastore.Store, s *Sensor) error {
+	key := store.NameKey(typeSensor, strconv.FormatInt(s.SKey, 10)+"."+s.SID)
+	_, err := store.Put(ctx, key, s)
+	return err
+}
+
+// DeleteSensor deletes a Sensor entity given the site key and sensor ID.
+func DeleteSensor(ctx context.Context, store datastore.Store, sKey int64, sid string) error {
+	key := store.NameKey(typeSensor, strconv.FormatInt(sKey, 10)+"."+sid)
+	err := store.DeleteMulti(ctx, []*datastore.Key{key})
+	return err
+}
+
+// GetSensorByPin gets a Sensor from the datastore given the site key and the
+// pin for which the sensor is applied.
+func GetSensorByPin(ctx context.Context, store datastore.Store, sKey int64, did, pin string) (*Sensor, error) {
+	q := store.NewQuery(typeSensor, false)
+	q.Filter("skey =", sKey)
+	q.Filter("pin =", did+"."+pin)
+	var sensors []Sensor
+	_, err := store.GetAll(ctx, q, &sensors)
+	if err != nil {
+		return nil, fmt.Errorf("could not get sensors: %w", err)
+	}
+
+	if len(sensors) == 0 {
+		return nil, datastore.ErrNoSuchEntity
+	}
+
+	if len(sensors) > 1 {
+		return nil, fmt.Errorf("unexpected number of sensors found, wanted 1 but got: %d", len(sensors))
+	}
+
+	return &sensors[0], nil
+}
+
+// GetSensorsBySite returns sensors associated with a site optionally filter by
+// device with the provided device ID.
+func GetSensorsBySite(ctx context.Context, store datastore.Store, skey int64, devID string) ([]Sensor, error) {
+	q := store.NewQuery(typeSensor, false, "skey", "sid")
+	q.Filter("skey =", skey)
+	q.Order("sid")
+	var all, toOut []Sensor
+	_, err := store.GetAll(ctx, q, &all)
+	if err != nil {
+		return nil, err
+	}
+
+	if devID == "" {
+		return all, nil
+	}
+
+	for _, s := range all {
+		if strings.Split(s.Pin, ".")[0] == devID {
+			toOut = append(toOut, s)
+		}
+	}
+	return toOut, nil
+}
+
+// SensorV2 defines a version 2 sensor. A sensor formats the value
+// obtained from a device input pin. The key is the MAC address
+// concatenated with the pin. Version 2 sensors do not have a site
+// key, but are linked to a site indirectly via their device.
+type SensorV2 struct {
+	Name     string  // Name of sensor (mutable).
+	Mac      int64   // MAC address of associated device (immutable).
+	Pin      string  // Pin of associated device (immutable).
+	Quantity string  // NMEA quantity code.
+	Func     string  // Transformation function.
+	Args     string  // Transformation args.
+	Scale    float64 // Deprecated.
+	Offset   float64 // Deprecated.
+	Units    string  // Units of transformed value.
+	Format   string  // Format of transformed value.
+}
+
+// Encode encodes a sensor as JSON.
+func (s *SensorV2) Encode() []byte {
+	bytes, _ := json.Marshal(s)
+	return bytes
+}
+
+// Decode decodes a sensor from JSON.
+func (s *SensorV2) Decode(b []byte) error {
+	return json.Unmarshal(b, s)
+}
+
+// Copy copies a sensor to dst, or returns a copy of the sensor when dst is nil.
+func (s *SensorV2) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var s2 *SensorV2
+	if dst == nil {
+		s2 = new(SensorV2)
+	} else {
+		var ok bool
+		s2, ok = dst.(*SensorV2)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*s2 = *s
+	return s2, nil
+}
+
+var sensorCache datastore.Cache = datastore.NewEntityCache()
+
+// GetCache returns the sensor cache.
+func (s *SensorV2) GetCache() datastore.Cache {
+	return sensorCache
+}
+
+// Transform applies the transformation specified in s.Func to the passed value v.
+func (s *SensorV2) Transform(v float64) (float64, error) {
+	if s.Func == "" || s.Func == "none" || s.Func == "None" {
+		return v, nil
+	}
+	f, ok := funcs[s.Func]
+	if !ok {
+		return 0.0, ErrUnrecognisedFunc
+	}
+	res, err := f(v, s.Args)
+	if err != nil {
+		return 0.0, fmt.Errorf("could not transform value: %w", err)
+	}
+	return res, nil
+}
+
+// PutSensorV2 creates/updates a sensor.
+func PutSensorV2(ctx context.Context, store datastore.Store, s *SensorV2) error {
+	k := store.NameKey(typeSensorV2, strconv.FormatInt(s.Mac, 10)+"."+s.Pin)
+	_, err := store.Put(ctx, k, s)
+	return err
+}
+
+// GetSensorV2 gets a sensor.
+func GetSensorV2(ctx context.Context, store datastore.Store, mac int64, pin string) (*SensorV2, error) {
+	k := store.NameKey(typeSensorV2, strconv.FormatInt(mac, 10)+"."+pin)
+	s := new(SensorV2)
+	err := store.Get(ctx, k, s)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// GetSensorsV2 gets all sensors for a device.
+func GetSensorsV2(ctx context.Context, store datastore.Store, mac int64) ([]SensorV2, error) {
+	q := store.NewQuery(typeSensorV2, false, "Mac", "Pin")
+	q.Filter("Mac =", mac)
+	var sensors []SensorV2
+	_, err := store.GetAll(ctx, q, &sensors)
+	return sensors, err
+}
+
+// DeleteSensorV2 deletes a sensor.
+func DeleteSensorV2(ctx context.Context, store datastore.Store, mac int64, pin string) error {
+	k := store.NameKey(typeSensorV2, strconv.FormatInt(mac, 10)+"."+pin)
+	return store.Delete(ctx, k)
+}

--- a/model/sensor_test.go
+++ b/model/sensor_test.go
@@ -1,0 +1,183 @@
+package model
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// TestParseArgs tests the helper function parseArgs.
+func TestParseArgs(t *testing.T) {
+	tests := []struct {
+		args string
+		n    int
+		want []float64
+		err  error
+	}{
+		{args: "3.0,num,2.0", n: 3, want: nil, err: strconv.ErrSyntax},
+		{args: "3.0,2.0", n: 3, want: nil, err: ErrUnexpectedArgs},
+		{args: "3.0,2.1,6.7", n: 3, want: []float64{3.0, 2.1, 6.7}, err: nil},
+		{args: "3.0, 2.1,6.7", n: 3, want: []float64{3.0, 2.1, 6.7}, err: nil},
+	}
+
+	for i, test := range tests {
+		fltArgs, err := parseArgs(test.args, test.n)
+		if !errors.Is(err, test.err) {
+			t.Errorf("did not get expected error for test no. %d, \ngot: %v, \nwant: %v", i, err, test.err)
+		}
+
+		if !equal(fltArgs, test.want) {
+			t.Errorf("did not get expected result for test no. %d, \ngot: %v, \nwant: %v", i, fltArgs, test.want)
+		}
+	}
+}
+
+func equal(a, b []float64) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestTransform tests the Sensor.Transform method.
+func TestTransform(t *testing.T) {
+	tests := []struct {
+		sensor Sensor
+		val    float64
+		want   float64
+		err    error
+	}{
+		{sensor: Sensor{Func: "afunction", Args: "0.5"}, err: ErrUnrecognisedFunc},
+		{sensor: Sensor{Func: keyScale, Args: "0.5"}, val: 20.0, want: 10.0},
+		{sensor: Sensor{Func: keyScale, Args: "0.5 "}, val: 20.0, want: 10.0},
+		{sensor: Sensor{Func: keyScale, Args: "0.5,9.5"}, err: ErrUnexpectedArgs},
+		{sensor: Sensor{Func: keyScale, Args: "num"}, err: strconv.ErrSyntax},
+		{sensor: Sensor{Func: keyLinear, Args: "2.0,3.0"}, val: 10.0, want: 23.0},
+		{sensor: Sensor{Func: keyLinear, Args: "2.0 ,3.0 "}, val: 10.0, want: 23.0},
+		{sensor: Sensor{Func: keyLinear, Args: "2.0,3.0,4.0"}, err: ErrUnexpectedArgs},
+		{sensor: Sensor{Func: keyLinear, Args: "2.0,num"}, err: strconv.ErrSyntax},
+		{sensor: Sensor{Func: keyQuadratic, Args: "2.0,3.0,4.0"}, val: 2.0, want: 18.0},
+		{sensor: Sensor{Func: keyQuadratic, Args: "2.0,3.0 ,4.0"}, val: 2.0, want: 18.0},
+		{sensor: Sensor{Func: keyQuadratic, Args: "2.0,3.0"}, err: ErrUnexpectedArgs},
+		{sensor: Sensor{Func: keyQuadratic, Args: "2.0,3.0,num"}, err: strconv.ErrSyntax},
+		{sensor: Sensor{Func: keyCustom, Args: "(x+10.0)/2.0"}, val: 20.0, want: 15.0},
+		{sensor: Sensor{Func: keyCustom, Args: "+_FHK+-="}, err: ErrEvaluableExpression},
+		{sensor: Sensor{Func: keyCustom, Args: "asdfasdf"}, err: ErrEvaluate},
+	}
+
+	for i, test := range tests {
+		got, err := test.sensor.Transform(test.val)
+		if !errors.Is(err, test.err) {
+			t.Errorf("did not get expected error for test no. %d, \ngot: %v, \nwant: %v", i, err, test.err)
+		}
+
+		if got != test.want {
+			t.Errorf("did not get expected result for test no. %d, \ngot: %v, \nwant: %v", i, got, test.want)
+		}
+	}
+}
+
+func TestSensorEncode(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Sensor *Sensor
+		want   []byte
+	}{
+		{
+			Name:   "default",
+			Sensor: &Sensor{SKey: 0, SID: "Test", Pin: "localdevice.S0", Quantity: "AUD", Func: "scale", Args: "0.1, 0.5", Scale: 0.000000, Offset: 0.000000, Units: "unit", Format: "hex"},
+			want:   []byte("0\tTest\tlocaldevice.S0\tAUD\tscale\t0.1, 0.5\t0.000000\t0.000000\tunit\thex"),
+		},
+		{
+			Name:   "empty",
+			Sensor: &Sensor{},
+			want:   []byte("0\t\t\t\t\t\t0.000000\t0.000000\t\t"),
+		},
+		{
+			Name:   "skey only",
+			Sensor: &Sensor{SKey: 64},
+			want:   []byte("64\t\t\t\t\t\t0.000000\t0.000000\t\t"),
+		},
+		{
+			Name:   "tab seperated args",
+			Sensor: &Sensor{SKey: 64, Args: "0.1,	0.5"},
+			want:   []byte("64\t\t\t\t\t0.1,	0.5\t0.000000\t0.000000\t\t"),
+		},
+	}
+
+	for _, test := range tests {
+		got := test.Sensor.Encode()
+		if !bytes.Equal(got, test.want) {
+			t.Errorf("Got\n%s \nWanted\n%s", got, test.want)
+		}
+	}
+}
+
+func TestSensorDecode(t *testing.T) {
+	tests := []struct {
+		Name    string
+		Input   []byte
+		Want    *Sensor
+		WantErr error
+	}{
+		{
+			Name:    "default",
+			Input:   []byte("0\tTest\tlocaldevice.S0\tAUD\tscale\t0.1, 0.5\t0.000000\t0.000000\tunit\thex"),
+			Want:    &Sensor{SKey: 0, SID: "Test", Pin: "localdevice.S0", Quantity: "AUD", Func: "scale", Args: "0.1, 0.5", Scale: 0.000000, Offset: 0.000000, Units: "unit", Format: "hex"},
+			WantErr: nil,
+		},
+		{
+			Name:    "invalid input",
+			Input:   []byte("invalid input"),
+			Want:    new(Sensor),
+			WantErr: datastore.ErrDecoding,
+		},
+		{
+			Name:    "invalid scale",
+			Input:   []byte("0\tTest\tlocaldevice.S0\tAUD\tscale\t0.1, 0.5\tinvalid\t0.000000\tunit\thex"),
+			Want:    nil,
+			WantErr: datastore.ErrDecoding,
+		},
+		{
+			Name:    "missing value",
+			Input:   []byte("0\tTest\tlocaldevice.S0\t\tscale\t0.1, 0.5\t0.000000\t0.000000\tunit\thex"),
+			Want:    &Sensor{SKey: 0, SID: "Test", Pin: "localdevice.S0", Quantity: "", Func: "scale", Args: "0.1, 0.5", Scale: 0.000000, Offset: 0.000000, Units: "unit", Format: "hex"},
+			WantErr: nil,
+		},
+		{
+			Name:    "missing term",
+			Input:   []byte("0\tTest\tlocaldevice.S0\tscale\t0.1, 0.5\t0.000000\t0.000000\tunit\thex"),
+			Want:    nil,
+			WantErr: datastore.ErrDecoding,
+		},
+		{
+			Name:    "extra term",
+			Input:   []byte("0\tTest\tlocaldevice.S0\tscale\t0.1, 0.5\t0.000000\t0.000000\tunit\thex\textra term"),
+			Want:    nil,
+			WantErr: datastore.ErrDecoding,
+		},
+		{
+			Name:    "empty",
+			Input:   []byte(""),
+			Want:    nil,
+			WantErr: datastore.ErrDecoding,
+		},
+	}
+
+	for _, test := range tests {
+		var got = new(Sensor)
+		err := got.Decode(test.Input)
+		if err != test.WantErr {
+			t.Errorf("%s: unexpected error, wanted: %v got: %v", test.Name, test.WantErr, err)
+		} else if !reflect.DeepEqual(got, test.Want) && err == nil {
+			t.Errorf("%s: error decoding\nwanted:\n%v\ngot\n%v", test.Name, test.Want, got)
+		}
+	}
+
+}

--- a/model/site.go
+++ b/model/site.go
@@ -1,0 +1,144 @@
+/*
+DESCRIPTION
+  Site type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019-2023 the Australian Ocean Lab (AusOcean).
+
+  This file is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// typeSite is the name of the datastore site type.
+const typeSite = "Site"
+
+// Site represents a cloud site.
+type Site struct {
+	Skey         int64
+	Name         string
+	OwnerEmail   string
+	Latitude     float64
+	Longitude    float64
+	Timezone     float64
+	NotifyPeriod int64
+	Enabled      bool
+	Confirmed    bool
+	Premium      bool
+	Public       bool
+	Created      time.Time
+}
+
+// Encode serializes a Site into JSON.
+func (site *Site) Encode() []byte {
+	bytes, _ := json.Marshal(site)
+	return bytes
+}
+
+// Decode deserializes a Site from JSON.
+func (site *Site) Decode(b []byte) error {
+	return json.Unmarshal(b, site)
+}
+
+// Copy copies a site to dst, or returns a copy of the site when dst is nil.
+func (site *Site) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var s *Site
+	if dst == nil {
+		s = new(Site)
+	} else {
+		var ok bool
+		s, ok = dst.(*Site)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*s = *site
+	return s, nil
+}
+
+var siteCache datastore.Cache = datastore.NewEntityCache()
+
+// GetCache returns the site cache.
+func (site *Site) GetCache() datastore.Cache {
+	return siteCache
+}
+
+// PutSite creates or updates a site.
+func PutSite(ctx context.Context, store datastore.Store, site *Site) error {
+	key := store.IDKey(typeSite, site.Skey)
+	_, err := store.Put(ctx, key, site)
+	return err
+}
+
+// CreateSite creates a site, or returns an error if a site with the given key exists.
+func CreateSite(ctx context.Context, store datastore.Store, site *Site) error {
+	key := store.IDKey(typeSite, site.Skey)
+	return store.Create(ctx, key, site)
+}
+
+// GetSite returns a site by its site key.
+func GetSite(ctx context.Context, store datastore.Store, skey int64) (*Site, error) {
+	key := store.IDKey(typeSite, skey)
+	var site Site
+	err := store.Get(ctx, key, &site)
+	if err != nil {
+		return nil, err
+	}
+
+	return &site, err
+}
+
+// GetAllSites returns all sites.
+func GetAllSites(ctx context.Context, store datastore.Store) ([]Site, error) {
+	q := store.NewQuery(typeSite, false)
+	var sites []Site
+	_, err := store.GetAll(ctx, q, &sites)
+	return sites, err
+}
+
+// GetPublicSites returns all public sites.
+func GetPublicSites(ctx context.Context, store datastore.Store) ([]Site, error) {
+	q := store.NewQuery(typeSite, false)
+	q.Filter("Public=", true)
+	var sites []Site
+	_, err := store.GetAll(ctx, q, &sites)
+	return sites, err
+}
+
+// DeleteSite deletes a site.
+func DeleteSite(ctx context.Context, store datastore.Store, skey int64) error {
+	key := store.IDKey(typeSite, skey)
+	return store.DeleteMulti(ctx, []*datastore.Key{key})
+}
+
+// GetSiteName is a helper function that returns the site name string given the site key.
+func GetSiteName(ctx context.Context, store datastore.Store, skey int64) (string, error) {
+	s, err := GetSite(ctx, store, skey)
+	if err != nil {
+		return "", fmt.Errorf("could not get site for site key %v: %w", skey, err)
+	}
+	return s.Name, nil
+}

--- a/model/text.go
+++ b/model/text.go
@@ -1,0 +1,163 @@
+/*
+DESCRIPTION
+  Text datastore type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+const (
+	typeText = "Text" // Text datastore type.
+)
+
+// Text represents text data.
+//
+// The Media ID (MID) can be any identifier that uniquely identifies
+// the media source, but conventionally it is formed from the 48-bit
+// MAC address followed by the 4-bit encoding of the pin of the
+// source device. See ToMID.
+type Text struct {
+	MID       int64          // Media ID.
+	Timestamp int64          // Timestamp (in seconds).
+	Type      string         // Text type.
+	Data      string         `datastore:",noindex"` // Text data.
+	Date      time.Time      // Date/time last updated.
+	Key       *datastore.Key `datastore:"__key__"` // Not persistent but populated upon reading from the datastore.
+}
+
+// Encode serializes a Text entity into tab-separated values.
+func (t *Text) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%d\t%s\t%s\t%d", t.MID, t.Timestamp, t.Type, t.Data, t.Date.Unix()))
+}
+
+// Decode deserializes a Text entity from tab-separated values.
+func (t *Text) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 5 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	t.MID, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	t.Timestamp, err = strconv.ParseInt(p[1], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	t.Type = p[2]
+	t.Data = p[3]
+	ts, err := strconv.ParseInt(p[4], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	t.Date = time.Unix(ts, 0)
+	return nil
+}
+
+// Copy is not currently implemented.
+func (t *Text) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (t *Text) GetCache() datastore.Cache {
+	return nil
+}
+
+// KeyID returns the Text key ID as an unsigned integer.
+func (t *Text) KeyID() uint64 {
+	return uint64(t.Key.ID)
+}
+
+// WriteText writes text to the datastore.
+func WriteText(ctx context.Context, store datastore.Store, t *Text) error {
+	if len(t.Data) == 0 {
+		return nil
+	}
+	key := store.IDKey(typeText, datastore.IDKey(t.MID, t.Timestamp, 0))
+	t.Date = time.Now()
+	_, err := store.Put(ctx, key, t)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetText retrieves text for a given Media ID, optionally filtered by
+// timestamp(s).
+func GetText(ctx context.Context, store datastore.Store, mid int64, ts []int64) ([]Text, error) {
+	q, err := newTextQuery(store, mid, ts, false)
+	if err != nil {
+		return nil, err
+	}
+	var texts []Text
+	_, err = store.GetAll(ctx, q, &texts)
+	return texts, err
+}
+
+// GetTextKeys retrieves text keys for a given Media ID, optionally
+// filtered by timestamp(s).
+func GetTextKeys(ctx context.Context, store datastore.Store, mid int64, ts []int64) ([]*datastore.Key, error) {
+	q, err := newTextQuery(store, mid, ts, true)
+	if err != nil {
+		return nil, err
+	}
+	return store.GetAll(ctx, q, nil)
+}
+
+// DeleteText deletes all text for a given Media ID.
+func DeleteText(ctx context.Context, store datastore.Store, mid int64) error {
+	keys, err := GetTextKeys(ctx, store, mid, nil)
+	if err != nil {
+		return err
+	}
+	return store.DeleteMulti(ctx, keys)
+}
+
+// newTextQuery constructs a text query.
+func newTextQuery(store datastore.Store, mid int64, ts []int64, keysOnly bool) (datastore.Query, error) {
+	q := store.NewQuery(typeText, keysOnly, "MID", "Timestamp")
+	q.Filter("MID =", mid)
+
+	if ts != nil {
+		if len(ts) > 1 {
+			q.Filter("Timestamp >=", ts[0])
+			if ts[1] < datastore.EpochEnd {
+				q.Filter("Timestamp <", ts[1])
+			}
+			q.Order("Timestamp")
+		} else if len(ts) > 0 {
+			q.Filter("Timestamp =", ts[0])
+		}
+	}
+	return q, nil
+}

--- a/model/user.go
+++ b/model/user.go
@@ -1,0 +1,171 @@
+/*
+DESCRIPTION
+  Datastore user type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019-2023 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, eitherc version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// typeUser is the name of the datastore user type.
+const typeUser = "User"
+
+// User represents a cloud user. One user exists for
+// each site that a Google account is associated with. The same Google
+// account may have different permissions for different sites, or none
+// at all.
+type User struct {
+	Skey    int64     // Site key.
+	Email   string    // User email address.
+	UserID  string    // Google account ID. Not currently used.
+	Perm    int64     // User's site permissions.
+	Created time.Time // Date/time created.
+}
+
+// Encode serializes a User into tab-separated values.
+func (user *User) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%s\t%d\t%d", user.Skey, user.Email, user.UserID, user.Perm, user.Created.Unix()))
+}
+
+// Decode deserializes a User from tab-separated values.
+func (user *User) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 5 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	user.Skey, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	user.Email = p[1]
+	user.UserID = p[2]
+	user.Perm, err = strconv.ParseInt(p[3], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	ts, err := strconv.ParseInt(p[4], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	user.Created = time.Unix(ts, 0)
+	return nil
+}
+
+// Copy copies a user to dst, or returns a copy of the user when dst is nil.
+func (user *User) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var u *User
+	if dst == nil {
+		u = new(User)
+	} else {
+		var ok bool
+		u, ok = dst.(*User)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*u = *user
+	return u, nil
+}
+
+var userCache datastore.Cache = datastore.NewEntityCache()
+
+// GetCache returns the user cache.
+func (user *User) GetCache() datastore.Cache {
+	return userCache
+}
+
+// PermissionText returns text describing the user's permissions.
+func (user *User) PermissionText() string {
+	switch user.Perm {
+	case 0:
+		return "No Permission"
+	case ReadPermission:
+		return "Read Only"
+	case ReadPermission | WritePermission:
+		return "Read Write"
+	case ReadPermission | WritePermission | AdminPermission:
+		return "Admin"
+	default:
+		return "Unknown Permission"
+	}
+}
+
+// PutUser creates or updates a user.
+func PutUser(ctx context.Context, store datastore.Store, user *User) error {
+	key := store.NameKey(typeUser, strconv.FormatInt(user.Skey, 10)+"."+user.Email)
+	_, err := store.Put(ctx, key, user)
+	return err
+}
+
+// GetUser returns a user by its key, which is the concatenated
+// Skey.Email.
+func GetUser(ctx context.Context, store datastore.Store, skey int64, email string) (*User, error) {
+	key := store.NameKey(typeUser, strconv.FormatInt(skey, 10)+"."+email)
+	var user User
+	err := store.Get(ctx, key, &user)
+	if err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
+// GetUsers returns all users corresponding to a given email or domain, sorted
+// by site key.
+func GetUsers(ctx context.Context, store datastore.Store, email string) ([]User, error) {
+	var users []User
+	for _, v := range []string{email, email[strings.Index(email, "@"):]} {
+		q := store.NewQuery(typeUser, false, "Skey", "Email")
+		q.Filter("Email =", v)
+		_, err := store.GetAll(ctx, q, &users)
+		if err != nil {
+			return nil, fmt.Errorf("could not find users for %s, %w", v, err)
+		}
+	}
+	sort.Slice(users, func(i, j int) bool { return users[i].Skey < users[j].Skey })
+	return users, nil
+}
+
+// GetUsersBySite returns all of the users for a given site.
+func GetUsersBySite(ctx context.Context, store datastore.Store, skey int64) ([]User, error) {
+	var users []User
+	q := store.NewQuery(typeUser, false, "Skey", "Email")
+	q.Filter("Skey =", skey)
+	_, err := store.GetAll(ctx, q, &users)
+	return users, err
+}
+
+// DeleteUser deletes a user.
+func DeleteUser(ctx context.Context, store datastore.Store, skey int64, email string) error {
+	key := store.NameKey(typeUser, strconv.FormatInt(skey, 10)+"."+email)
+	return store.DeleteMulti(ctx, []*datastore.Key{key})
+}

--- a/model/variable.go
+++ b/model/variable.go
@@ -1,0 +1,279 @@
+/*
+DESCRIPTION
+  Variable datastore type and functions.
+
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2019 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License in
+  gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+const typeVariable = "Variable" // Variable datastore type.
+
+// Variable represents a cloud variable, which stores abitrary
+// string information. When the variable name includes a period, the
+// portion to the left of the dot represents the scope. The scope is
+// used to create namespaces, e.g., <MAC>.<var> represents a
+// variable for a given device, whereas <var> represents a global
+// variable for the entire site. Variables that start with an underscore,
+// e.g., _<var>, are system variables which are typically hidden from
+// users.
+type Variable struct {
+	Skey    int64     // Site key.
+	Scope   string    // Scope, if any.
+	Name    string    // Variable name, which is any ID.
+	Value   string    `datastore:",noindex"` // Variable value.
+	Updated time.Time // Date/time last updated.
+}
+
+// Encode serializes a Variable into tab-separated values.
+func (v *Variable) Encode() []byte {
+	return []byte(fmt.Sprintf("%d\t%s\t%s\t%s\t%d", v.Skey, v.Scope, v.Name, v.Value, v.Updated.Unix()))
+}
+
+// Decode deserializes a Variable from tab-separated values.
+func (v *Variable) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 5 {
+		return datastore.ErrDecoding
+	}
+	var err error
+	v.Skey, err = strconv.ParseInt(p[0], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	v.Scope = p[1]
+	v.Name = p[2]
+	v.Value = p[3]
+	ts, err := strconv.ParseInt(p[4], 10, 64)
+	if err != nil {
+		return datastore.ErrDecoding
+	}
+	v.Updated = time.Unix(ts, 0)
+	return nil
+}
+
+// Copy is not currently implemented.
+func (v *Variable) Copy(datastore.Entity) (datastore.Entity, error) {
+	return nil, datastore.ErrUnimplemented
+}
+
+// GetCache returns nil, indicating no caching.
+func (v *Variable) GetCache() datastore.Cache {
+	return nil
+}
+
+// Basename returns the name of the variable without the scope.
+func (v *Variable) Basename() string {
+	parts := strings.SplitN(v.Name, ".", 2)
+	return parts[len(parts)-1]
+}
+
+// IsSystemVariable returns true if the variable is a system variable, false otherwise.
+func (v *Variable) IsSystemVariable() bool {
+	if v.Name[0] == '_' {
+		return true
+	} else {
+		return false
+	}
+}
+
+// IsLink returns true if the variable is an HTTP or HTTPS URL.
+func (v *Variable) IsLink() bool {
+	if strings.HasPrefix(v.Value, "http://") || strings.HasPrefix(v.Value, "https://") {
+		return true
+	} else {
+		return false
+	}
+}
+
+// PutVariable creates or updates a variable
+// Strip any colons from the scope.
+func PutVariable(ctx context.Context, store datastore.Store, skey int64, name, value string) error {
+	sep := strings.Index(name, ".")
+	scope := ""
+	if sep >= 0 {
+		scope = strings.ReplaceAll(name[:sep], ":", "")
+		name = scope + name[sep:]
+	}
+	v := &Variable{Skey: skey, Name: name, Scope: scope, Value: value, Updated: time.Now()}
+	key := store.NameKey(typeVariable, strconv.FormatInt(skey, 10)+"."+name)
+	_, err := store.Put(ctx, key, v)
+	if err == nil {
+		invalidateVarSum(ctx, store, skey, name)
+	}
+	return err
+}
+
+// GetVariable gets a variable.
+// Ignore colons in the scope.
+func GetVariable(ctx context.Context, store datastore.Store, skey int64, name string) (*Variable, error) {
+	sep := strings.Index(name, ".")
+	if sep >= 0 {
+		name = strings.ReplaceAll(name[:sep], ":", "") + name[sep:]
+	}
+	key := store.NameKey(typeVariable, strconv.FormatInt(skey, 10)+"."+name)
+	v := new(Variable)
+	return v, store.Get(ctx, key, v)
+}
+
+// GetVariablesBySite returns all the variables for a given site, optionally filtered by scope.
+// Ignore colons in the scope.
+func GetVariablesBySite(ctx context.Context, store datastore.Store, skey int64, scope string) ([]Variable, error) {
+	var q datastore.Query
+	if scope != "" {
+		scope = strings.ReplaceAll(scope, ":", "")
+		q = store.NewQuery(typeVariable, false, "Skey", "Scope", "Name")
+		q.Filter("Skey =", skey)
+		q.Filter("Scope =", scope)
+	} else {
+		q = store.NewQuery(typeVariable, false, "Skey", "Name")
+		q.Filter("Skey =", skey)
+	}
+	q.Order("Name")
+	var vars []Variable
+	_, err := store.GetAll(ctx, q, &vars)
+	return vars, err
+}
+
+// DeleteVariable deletes a variable.
+// Ignore colons in the scope.
+func DeleteVariable(ctx context.Context, store datastore.Store, skey int64, name string) error {
+	sep := strings.Index(name, ".")
+	if sep >= 0 {
+		scope := strings.ReplaceAll(name[:sep], ":", "")
+		name = scope + name[sep:]
+	}
+	key := store.NameKey(typeVariable, strconv.FormatInt(skey, 10)+"."+name)
+	err := store.DeleteMulti(ctx, []*datastore.Key{key})
+	if err == nil {
+		invalidateVarSum(ctx, store, skey, name)
+	}
+	return err
+}
+
+// DeleteVariables deletes all variables for a given scope.
+// Ignore colons in the scope.
+func DeleteVariables(ctx context.Context, store datastore.Store, skey int64, scope string) error {
+	scope = strings.ReplaceAll(scope, ":", "")
+	q := store.NewQuery(typeVariable, true, "Skey", "Scope", "Name")
+	q.Filter("Skey =", skey)
+	q.Filter("Scope =", scope)
+	keys, err := store.GetAll(ctx, q, nil)
+	if err != nil {
+		return err
+	}
+	return store.DeleteMulti(ctx, keys)
+}
+
+// ComputeVarSum computes the var sum from a slice of variables. The
+// var sum is a IEEE CRC checksum 32-bit signed integer of the
+// name/value variable pairs concanentated with ampersands, i.e.,
+// var1=val1&var2=val2&var3=val3...
+func ComputeVarSum(vars []Variable) int64 {
+	s := ""
+	for _, v := range vars {
+		if v.Name[0] == '_' {
+			continue // Ignore system variables.
+		}
+		s += v.Name + "=" + v.Value + "&"
+	}
+	s = strings.TrimRight(s, "&")
+	return (int64(crc32.Checksum([]byte(s), crc32.MakeTable(crc32.IEEE))) ^ 0x80000000) - 0x80000000
+}
+
+// GetVarSum gets the varsum for a given scope, and saves it as the
+// system variable named "_varsum.<scope>". Note that the varsum is
+// itself stored in the datastore not in memory, since it can be
+// mutated any time by another datastore client. If the var sum is not
+// found it is recomputed and saved.
+func GetVarSum(ctx context.Context, store datastore.Store, skey int64, scope string) (int64, error) {
+	name := "_varsum." + scope
+	v, err := GetVariable(ctx, store, skey, name)
+	if err == nil && v.Value != "" {
+		vs, err := strconv.ParseInt(v.Value, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("could not parse int from varsum: %w", err)
+		}
+		return vs, nil
+	}
+
+	if err != nil && err != datastore.ErrNoSuchEntity {
+		return 0, fmt.Errorf("unexpected error getting varsum: %w", err)
+	}
+
+	vars, err := GetVariablesBySite(ctx, store, skey, scope)
+	if err != nil {
+		return 0, fmt.Errorf("could not get variables for site: %w", err)
+	}
+
+	vs := ComputeVarSum(vars)
+	err = PutVariable(ctx, store, skey, name, strconv.Itoa(int(vs)))
+	if err != nil {
+		return 0, fmt.Errorf("could not put new varsum: %w", err)
+	}
+
+	return vs, nil
+}
+
+// invalidateVarSum invalidates varsum(s) resulting from a change to a
+// variable (unless the variable is a system variable). If the
+// variable is scoped, we delete the varsum just for that scope, else
+// we delete all variables for the site.
+func invalidateVarSum(ctx context.Context, store datastore.Store, skey int64, name string) error {
+	if name[0] == '_' {
+		return nil // Ignore system variables.
+	}
+
+	sep := strings.Index(name, ".")
+	if sep >= 0 {
+		scope := name[:sep]
+		err := PutVariable(ctx, store, skey, "_varsum."+scope, "")
+		if err != nil {
+			return fmt.Errorf("could not clear varsum for: %s: %w", scope, err)
+		}
+		return nil
+	}
+
+	// Else clear all varsums for this site.
+	vars, err := GetVariablesBySite(ctx, store, skey, "_varsum")
+	if err != nil {
+		return fmt.Errorf("could not get varsums for site: %w", err)
+	}
+
+	for _, v := range vars {
+		err = PutVariable(ctx, store, skey, v.Name, "")
+		if err != nil {
+			return fmt.Errorf("could not clear varsum: %s: %w", v.Name, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Datastore models ported from https://bitbucket.org/ausocean/iotsvc/iotds.

Models now use https://github.com/ausocean/openfish/datastore directly and the shim has been removed.