### PR TITLE
Overhaul logging for broadcast code

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -239,9 +239,14 @@ func performChecksInternalThroughStateMachine(
 	cfg *BroadcastConfig,
 	timeNow func() time.Time,
 	store datastore.Store,
-	svc BroadcastService,
-	man BroadcastManager,
 ) error {
+	// Handy log wrapper that shims with interfaces that like the
+	// classic func(string, ...interface{}) signature.
+	// This can be used by a lot of the components here.
+	log := func(msg string, args ...interface{}) {
+		logForBroadcast(cfg, msg, args...)
+	}
+
 	// Don't do anything if not enabled.
 	if !cfg.Enabled {
 		// Also make sure it's in the idle state when not enabled, so we're not starting, transitioning or active.
@@ -259,13 +264,16 @@ func performChecksInternalThroughStateMachine(
 			},
 		)
 		if err != nil {
-			log.Printf("could not update config with callback: %v", err)
+			log("could not update config with callback: %v", err)
 		}
-		log.Printf("broadcast: %s, ID: %s, not enabled, not doing anything", cfg.Name, cfg.ID)
+		log("not enabled, not doing anything")
 		return nil
 	}
 
-	log.Printf("broadcast: %s, ID: %s, performing checks", cfg.Name, cfg.ID)
+	log("performing checks")
+
+	// We'll use this context to determine if anything happens after the handler
+	// has returned (we might need to store states for next time).
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -274,7 +282,7 @@ func performChecksInternalThroughStateMachine(
 	// is used to do a broadcast start and this function returns. We'll save them
 	// to the config and then load them next time we perform checks.
 	storeEventsAfterCtx := func(event event) {
-		log.Printf("broadcast: %s, ID: %s, storing event after cancel: %s", cfg.Name, cfg.ID, event.String())
+		log("storing event after cancel: %s", event.String())
 		err := updateConfigWithTransaction(
 			context.Background(),
 			store,
@@ -287,19 +295,18 @@ func performChecksInternalThroughStateMachine(
 			},
 		)
 		if err != nil {
-			log.Printf("could not update config with callback: %v", err)
+			log("could not update config with callback: %v", err)
 		}
 	}
 
-	// We'll provide a custom log wrapper to the bus so that we can add the
-	// broadcast name and ID to the log messages.
-	busLogFunc := func(msg string, args ...interface{}) {
-		idArgs := []interface{}{cfg.Name, cfg.ID}
-		idArgs = append(idArgs, args...)
-		log.Printf("(name: %s, id: %s) "+msg, idArgs...)
-	}
+	bus := newBasicEventBus(ctx, storeEventsAfterCtx, log)
 
-	bus := newBasicEventBus(ctx, storeEventsAfterCtx, busLogFunc)
+	// Create the youtube broadcast service. This will deal with the YouTube API bindings.
+	svc := newYouTubeBroadcastService(log)
+
+	// Create the broadcast manager. This will manage things between the broadcast, the
+	// hardware and the YouTube broadcast service.
+	man := newOceanBroadcastManager(log)
 
 	// This handler will subscribe to the event bus and perform checks corresponding
 	// to health, status and chat message events. It will also publish events to the
@@ -321,6 +328,7 @@ func performChecksInternalThroughStateMachine(
 					bus.publish(goodHealthEvent{})
 					return nil
 				},
+				log,
 			)
 		case statusCheckDueEvent:
 			err := man.HandleStatus(
@@ -337,7 +345,7 @@ func performChecksInternalThroughStateMachine(
 				return fmt.Errorf("could not handle status: %w", err)
 			}
 		case chatMessageDueEvent:
-			handleChatMessage(context.Background(), cfg)
+			man.HandleChatMessage(context.Background(), cfg)
 		}
 		return nil
 	}
@@ -345,7 +353,7 @@ func performChecksInternalThroughStateMachine(
 	bus.subscribe(healthStatusChatHandler)
 
 	// This context will be used by the state machines for access to our bits and bobs.
-	broadcastContext := &broadcastContext{cfg, man, store, svc, NewVidforwardService(), bus, &revidCameraClient{}}
+	broadcastContext := &broadcastContext{cfg, man, store, svc, NewVidforwardService(log), bus, &revidCameraClient{}}
 
 	// The hardware state machine will be responsible for the external camera hardware
 	// state.
@@ -364,10 +372,10 @@ func performChecksInternalThroughStateMachine(
 	for _, event := range cfg.Events {
 		e, err := stringToEvent(event)
 		if err != nil {
-			log.Printf("could not convert event string to event: %v", err)
+			log("could not convert event string to event: %v", err)
 			continue
 		}
-		log.Printf("broadcast: %s, ID: %s, publishing stored event: %s", cfg.Name, cfg.ID, e.String())
+		log("publishing stored event: %s", e.String())
 		bus.publish(e)
 	}
 
@@ -390,7 +398,7 @@ func performChecksInternalThroughStateMachine(
 	// start, stop etc.
 	bus.publish(timeEvent{time.Now()})
 
-	log.Printf("broadcast: %s, ID: %s, finishing check", cfg.Name, cfg.ID)
+	log("finishing check")
 	return nil
 }
 
@@ -403,8 +411,6 @@ func performChecks(ctx context.Context, cfg *BroadcastConfig, store datastore.St
 		cfg,
 		func() time.Time { return time.Now() },
 		store,
-		&YouTubeBroadcastService{},
-		&OceanBroadcastManager{},
 	)
 }
 
@@ -414,13 +420,13 @@ type BroadcastCallback func(context.Context, *BroadcastConfig, datastore.Store, 
 // relevant site and posts the message to the broadcast chat. This works by
 // searching the site for any registered ESP devices and looking at the latest
 // signal values on sensors which have been marked true to send a message.
-func handleChatMessage(ctx context.Context, cfg *BroadcastConfig) error {
+func handleChatMessage(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
 	if !cfg.SendMsg {
-		log.Printf("Broadcast: %s, ID: %s, ignoring sensors", cfg.Name, cfg.ID)
+		log("ignoring sensors")
 		return nil
 	}
 
-	log.Printf("Broadcast: %s, ID: %s, building message", cfg.Name, cfg.ID)
+	log("building message")
 	var msg string
 
 	for _, sensor := range cfg.SensorList {
@@ -459,7 +465,7 @@ func handleChatMessage(ctx context.Context, cfg *BroadcastConfig) error {
 	}
 
 	if msg == "" {
-		log.Printf("Broadcast: %s, ID: %s, chat message empty", cfg.Name, cfg.ID)
+		log("chat message empty")
 		return nil
 	}
 
@@ -490,13 +496,13 @@ func saveLinkFunc() func(string, string) error {
 // external streaming hardware startup. In addition, the RTMP key is obtained
 // from the broadcast's associated stream object and used to set the devices
 // RTMPKey variable.
-func extStart(ctx context.Context, cfg *BroadcastConfig, svc BroadcastService) error {
+func extStart(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
 	if cfg.OnActions == "" {
 		return nil
 	}
 
 	onActions := cfg.OnActions + "," + cfg.RTMPVar + "=" + rtmpDestinationAddress + cfg.RTMPKey
-	err := setActionVars(ctx, cfg.SKey, onActions, settingsStore)
+	err := setActionVars(ctx, cfg.SKey, onActions, settingsStore, log)
 	if err != nil {
 		return fmt.Errorf("could not set device variables required to start stream: %w", err)
 	}
@@ -506,12 +512,12 @@ func extStart(ctx context.Context, cfg *BroadcastConfig, svc BroadcastService) e
 
 // extStop uses the OffActions in the provided broadcast config to perform
 // external streaming hardware shutdown.
-func extStop(ctx context.Context, cfg *BroadcastConfig) error {
+func extStop(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
 	if cfg.OffActions == "" {
 		return nil
 	}
 
-	err := setActionVars(ctx, cfg.SKey, cfg.OffActions, settingsStore)
+	err := setActionVars(ctx, cfg.SKey, cfg.OffActions, settingsStore, log)
 	if err != nil {
 		return fmt.Errorf("could not set device variables to end stream: %w", err)
 	}
@@ -522,13 +528,13 @@ func extStop(ctx context.Context, cfg *BroadcastConfig) error {
 // saveBroadcast saves a broadcast configuration to the datastore with the
 // variable name as the broadcast name and if the broadcast uses vidforward
 // we update the vidforward configuration with a control request.
-func saveBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.Store) error {
+func saveBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.Store, log func(string, ...interface{})) error {
 	d, err := json.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("could not marshal JSON for broadcast save: %w", err)
 	}
 
-	log.Printf("broadcast: %s, ID: %s, saving, cfg: %s", cfg.Name, cfg.ID, provideConfig(cfg))
+	log("saving, cfg: %s", provideConfig(cfg))
 	err = model.PutVariable(ctx, store, cfg.SKey, broadcastScope+"."+cfg.Name, string(d))
 	if err != nil {
 		return fmt.Errorf("could not put broadcast data in store: %w", err)
@@ -544,7 +550,7 @@ func saveBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.St
 	return nil
 }
 
-func performRequestWithRetries(dest string, data any, maxRetries int) error {
+func performRequestWithRetries(dest string, data any, maxRetries int, log func(string, ...interface{})) error {
 	var retries int
 retry:
 	var buf bytes.Buffer
@@ -561,7 +567,7 @@ retry:
 
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		log.Printf("could not do http request, but retrying: %v", err)
+		log("could not do http request, but retrying: %v", err)
 		if retries <= maxRetries {
 			retries++
 			goto retry
@@ -577,8 +583,8 @@ retry:
 // in healthy operation) and if it is not, change to complete.
 // Then we change the broadcast configuration Active field to false, save this
 // and stop all external streaming hardware.
-func stopBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.Store, svc BroadcastService) error {
-	log.Printf("Broadcast: %s, ID: %s, stopping", cfg.Name, cfg.ID)
+func stopBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.Store, svc BroadcastService, log func(string, ...interface{})) error {
+	log("stopping")
 
 	status, err := svc.BroadcastStatus(ctx, cfg.ID)
 	if err != nil {
@@ -593,7 +599,7 @@ func stopBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.St
 	}
 
 	cfg.Active = false
-	err = saveBroadcast(ctx, cfg, store)
+	err = saveBroadcast(ctx, cfg, store, log)
 	if err != nil {
 		return fmt.Errorf("save broadcast error: %w", err)
 	}

--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -94,14 +94,14 @@ type basicEventBus struct {
 	ctx        context.Context
 	handlers   []handler
 	storeEvent func(event event)
-	log        func(msg string, args ...interface{})
+	log        func(string, ...interface{})
 }
 
 // newBasicEventBus creates a new basicEventBus.
 // The context must be cancellable.
 // The storeEventAfterCancel function is called on publish when the context
 // is cancelled.
-func newBasicEventBus(ctx context.Context, storeEventAfterCancel func(event event), log func(msg string, args ...interface{})) *basicEventBus {
+func newBasicEventBus(ctx context.Context, storeEventAfterCancel func(event event), log func(string, ...interface{})) *basicEventBus {
 	return &basicEventBus{storeEvent: storeEventAfterCancel, ctx: ctx, log: log}
 }
 

--- a/cmd/oceantv/broadcast_events_test.go
+++ b/cmd/oceantv/broadcast_events_test.go
@@ -18,7 +18,7 @@ func TestBasicEventBus(t *testing.T) {
 		storedEvents = append(storedEvents, event)
 	}
 
-	log := func(msg string, args ...interface{}) {}
+	log := func(string, ...interface{}) {}
 
 	bus := newBasicEventBus(ctx, storeMock, log)
 

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -256,7 +256,7 @@ type hardwareManager interface {
 type revidCameraClient struct{}
 
 func (c *revidCameraClient) start(ctx *broadcastContext) {
-	err := extStart(context.Background(), ctx.cfg, ctx.svc)
+	err := extStart(context.Background(), ctx.cfg, ctx.log)
 	if err != nil {
 		ctx.log("could not start external hardware: %v", err)
 		ctx.bus.publish(hardwareStartFailedEvent{})
@@ -265,7 +265,7 @@ func (c *revidCameraClient) start(ctx *broadcastContext) {
 }
 
 func (c *revidCameraClient) stop(ctx *broadcastContext) {
-	err := extStop(context.Background(), ctx.cfg)
+	err := extStop(context.Background(), ctx.cfg, ctx.log)
 	if err != nil {
 		ctx.log("could not stop external hardware: %v", err)
 		ctx.bus.publish(hardwareStopFailedEvent{})
@@ -273,7 +273,7 @@ func (c *revidCameraClient) stop(ctx *broadcastContext) {
 	}
 }
 
-func (c *revidCameraClient) publishEventIfStatus(event event, status bool, mac int64, store Store, log func(format string, args ...interface{}), publish func(event event)) {
+func (c *revidCameraClient) publishEventIfStatus(event event, status bool, mac int64, store Store, log func(string, ...interface{}), publish func(event event)) {
 	log("checking status of device with mac: %d", mac)
 	alive, err := getDeviceStatus(context.Background(), mac, store)
 	if err != nil {

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -67,7 +67,7 @@ func TestHandleHardwareStoppedEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -122,7 +122,7 @@ func TestHandleHardwareStopFailedEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -179,7 +179,7 @@ func TestHandleHardwareStartFailedEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -236,7 +236,7 @@ func TestHandleHardwareStartedEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -301,7 +301,7 @@ func TestHandleHardwareResetRequestEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -589,7 +589,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				return nil
 			}
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 			bus.subscribe(handler)
 
 			bCtx.man = NewDummyManager(t)
@@ -695,7 +695,7 @@ func TestHandleStartFailedEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -816,7 +816,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -937,7 +937,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -1040,7 +1040,7 @@ func TestHandleFinishEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -1149,7 +1149,7 @@ func TestHandleStartEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
@@ -1222,7 +1222,7 @@ func TestHandleStartedEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
-			bus := newBasicEventBus(ctx, nil, func(msg string, args ...interface{}) {})
+			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()

--- a/cmd/oceantv/broadcast_service.go
+++ b/cmd/oceantv/broadcast_service.go
@@ -82,6 +82,11 @@ func (y YouTubeResponse) HTTPHeader() http.Header { return googleapi.ServerRespo
 // YouTubeBroadcastService is a BroadcastService implementation for YouTube.
 type YouTubeBroadcastService struct {
 	limiter RateLimiter
+	log     func(string, ...interface{})
+}
+
+func newYouTubeBroadcastService(log func(string, ...interface{})) *YouTubeBroadcastService {
+	return &YouTubeBroadcastService{log: log}
 }
 
 // WithRateLimiter is a BroadcastOption that sets the rate limiter for a
@@ -140,6 +145,7 @@ func (s *YouTubeBroadcastService) CreateBroadcast(
 		framerate,
 		start,
 		end,
+		s.log,
 	)
 	if err != nil {
 		return YouTubeResponse{}, broadcast.IDs{}, "", fmt.Errorf("could not broadcast stream: %w response: %v", err, resp)
@@ -173,6 +179,7 @@ func (s *YouTubeBroadcastService) StartBroadcast(
 		extStop,
 		notify,
 		onLiveActions,
+		s.log,
 	)
 }
 
@@ -197,7 +204,7 @@ func (s *YouTubeBroadcastService) CompleteBroadcast(ctx context.Context, id stri
 	if err != nil {
 		return fmt.Errorf("get service error: %w", err)
 	}
-	err = broadcast.CompleteBroadcast(svc, id)
+	err = broadcast.CompleteBroadcast(svc, id, s.log)
 	if err != nil {
 		return fmt.Errorf("complete broadcast error: %w", err)
 	}

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"reflect"
 	"strings"
 	"time"
@@ -21,9 +20,7 @@ type broadcastContext struct {
 }
 
 func (ctx *broadcastContext) log(msg string, args ...interface{}) {
-	idArgs := []interface{}{ctx.cfg.Name, ctx.cfg.ID}
-	idArgs = append(idArgs, args...)
-	log.Printf("(name: %s, id: %s) "+msg, idArgs...)
+	logForBroadcast(ctx.cfg, msg, args...)
 }
 
 type state interface {
@@ -242,7 +239,7 @@ func (s *vidforwardSecondaryLive) enter() {}
 func (s *vidforwardSecondaryLive) exit() {
 	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
 	if err != nil {
-		log.Printf("broadcast: %s, ID: %s, could not stop broadcast", s.cfg.Name, s.cfg.ID)
+		s.log("could not stop broadcast")
 	}
 }
 
@@ -313,7 +310,7 @@ func (s *directLive) enter() {}
 func (s *directLive) exit() {
 	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
 	if err != nil {
-		log.Printf("broadcast: %s, ID: %s, could not stop broadcast", s.cfg.Name, s.cfg.ID)
+		s.log("could not stop broadcast")
 	}
 }
 
@@ -328,7 +325,7 @@ func (s *directLiveUnhealthy) enter() {}
 func (s *directLiveUnhealthy) exit() {
 	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
 	if err != nil {
-		log.Printf("broadcast: %s, ID: %s, could not stop broadcast", s.cfg.Name, s.cfg.ID)
+		s.log("could not stop broadcast", s.cfg.Name, s.cfg.ID)
 	}
 }
 

--- a/cmd/oceantv/health.go
+++ b/cmd/oceantv/health.go
@@ -29,7 +29,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
@@ -54,9 +53,9 @@ func opsHealthNotifyFunc(ctx context.Context, cfg *BroadcastConfig) func(string)
 // to resolve problems. Number of successive issues are stored in the broadcast
 // config, and if a maximum is reached the streaming hardware is power cycled
 // in an attempt to resolve issues.
-func handleHealth(ctx context.Context, cfg *BroadcastConfig) error {
-	log.Printf("broadcast: %s, ID: %s, handling health check", cfg.Name, cfg.ID)
-	hasIssue, err := checkIssues(ctx, cfg)
+func handleHealth(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
+	log("handling health check")
+	hasIssue, err := checkIssues(ctx, cfg, log)
 	if err != nil {
 		return fmt.Errorf("could not check for stream issues: %w", err)
 	}
@@ -72,9 +71,10 @@ func handleHealth(ctx context.Context, cfg *BroadcastConfig) error {
 		// We don't want to restart the hardware if slate is enabled, but we
 		// should notify ops given that this will be a problem with vidforward.
 		if cfg.Slate {
-			msg := fmt.Sprintf("Broadcast: %s, ID: %s, exceeded allowable successive issues, but slate is enabled, so not restarting hardware", cfg.Name, cfg.ID)
-			log.Println(msg)
-			err = opsHealthNotify(ctx, cfg.SKey, msg)
+			msg := "exceeded allowable successive issues, but slate is enabled, so not restarting hardware"
+			emailMsg := fmt.Sprintf("Broadcast: %s, ID: %s, %s", cfg.Name, cfg.ID, msg)
+			log(msg)
+			err = opsHealthNotify(ctx, cfg.SKey, emailMsg)
 			if err != nil {
 				return fmt.Errorf("could not send notification for poor stream health: %w", err)
 			}
@@ -83,8 +83,8 @@ func handleHealth(ctx context.Context, cfg *BroadcastConfig) error {
 			return nil
 		}
 
-		log.Printf("Broadcast: %s, ID: %s, exceeded allowable successive issues, restarting hardware", cfg.Name, cfg.ID)
-		err = extStop(ctx, cfg)
+		log("exceeded allowable successive issues, restarting hardware")
+		err = extStop(ctx, cfg, log)
 		if err != nil {
 			return fmt.Errorf("external hardware stop error: %w", err)
 		}
@@ -94,7 +94,7 @@ func handleHealth(ctx context.Context, cfg *BroadcastConfig) error {
 		const stopWait = 2 * time.Minute
 		time.Sleep(stopWait)
 
-		err = extStart(ctx, cfg, &YouTubeBroadcastService{})
+		err = extStart(ctx, cfg, log)
 		if err != nil {
 			return fmt.Errorf("external hardware start error: %w", err)
 		}
@@ -112,9 +112,9 @@ func handleHealth(ctx context.Context, cfg *BroadcastConfig) error {
 // successive issues are stored in the broadcast config, and if a maximum is reached
 // the badHealthCallback is called. The goodHealthCallback is called when the health
 // check is successful.
-func handleHealthWithCallback(ctx context.Context, cfg *BroadcastConfig, store Store, svc Svc, badHealthCallback, goodHealthCallback BroadcastCallback) error {
-	log.Printf("broadcast: %s, ID: %s, handling health check", cfg.Name, cfg.ID)
-	hasIssue, err := checkIssues(ctx, cfg)
+func handleHealthWithCallback(ctx context.Context, cfg *BroadcastConfig, store Store, svc Svc, badHealthCallback, goodHealthCallback BroadcastCallback, log func(string, ...interface{})) error {
+	log("handling health check")
+	hasIssue, err := checkIssues(ctx, cfg, log)
 	if err != nil {
 		return fmt.Errorf("could not check for stream issues: %w", err)
 	}
@@ -142,7 +142,7 @@ func handleHealthWithCallback(ctx context.Context, cfg *BroadcastConfig, store S
 // that are considered severe and/or might eventually require a hardware restart
 // in an attempt to resolve. We first check for configuration issues e.g. incorrect
 // resolution and then we check for basic issues, e.g. insufficient data.
-func checkIssues(ctx context.Context, cfg *BroadcastConfig) (bool, error) {
+func checkIssues(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) (bool, error) {
 	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope)
 	if err != nil {
 		return false, fmt.Errorf("could not get youtube service: %w", err)
@@ -155,7 +155,7 @@ func checkIssues(ctx context.Context, cfg *BroadcastConfig) (bool, error) {
 
 	var foundIssue bool
 	for _, v := range health.ConfigurationIssues {
-		log.Printf("broadcast: %s, ID: %s, configuration issue, reason: %s, severity: %s, type: %s, last updated (seconds): %d", cfg.Name, cfg.ID, v.Reason, v.Severity, v.Type, health.LastUpdateTimeSeconds)
+		log("configuration issue, reason: %s, severity: %s, type: %s, last updated (seconds): %d", v.Reason, v.Severity, v.Type, health.LastUpdateTimeSeconds)
 
 		if v.Severity == "error" {
 			msg := "broadcast: %s\n ID: %s\n, configuration issue:\n \tdescription: %s, \treason: %s, \tseverity: %s, \ttype: %s, \tlast updated (seconds): %d"
@@ -167,7 +167,7 @@ func checkIssues(ctx context.Context, cfg *BroadcastConfig) (bool, error) {
 		}
 	}
 
-	log.Printf("broadcast: %s, ID: %s, stream health check, status: %s", cfg.Name, cfg.ID, health.Status)
+	log("stream health check, status: %s", health.Status)
 	switch health.Status {
 	case "noData", "revoked":
 		foundIssue = true

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -181,12 +181,16 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = (&OceanBroadcastManager{}).SaveBroadcast(ctx, &cfg, settingsStore)
+	log := func(msg string, args ...interface{}) {
+		logForBroadcast(&cfg, msg, args...)
+	}
+
+	err = newOceanBroadcastManager(log).SaveBroadcast(ctx, &cfg, settingsStore)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	log.Printf("broadcast %s saved", cfg.Name)
+	log("broadcast saved")
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Addresses issue #16 

There were a lot of calls to "log.Printf" of the form "Broadcast: %s, id: %s ....", so we're factoring this pattern out. We're doing this by requiring that most interfaces that the broadcast code uses take a "log" parameter of type func(string,...interface{}). This means that we can pass around a log function that wraps any messages provided with the broadcast name and id.

We're now also using this in areas where the broadcast name and id were not specified. This means that all logging related to a particular broadcast is labelled as such.