### PR TITLE
oceanbench/main.go: if environment is not appengine, use project level template path

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -332,7 +332,7 @@ func setup(ctx context.Context) {
 	}
 
 	templateDir := "cmd/oceanbench/t"
-	if standalone {
+	if standalone || os.Getenv("GAE_ENV") == "" {
 		templateDir = "t"
 	}
 	templates, err = template.New("").Funcs(templateFuncs).ParseGlob(templateDir + "/*.html")


### PR DESCRIPTION
This is done to support running oceanbench locally using the datstore (not standalone).