### PR TITLE
Notifier options

### DIFF
--- a/cmd/oceanbench/api.go
+++ b/cmd/oceanbench/api.go
@@ -258,7 +258,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 
 // siteHealthStatus collects health status for devices at the given site. If id is not
 // empty, only the device with the specified ID is queried. If any queried device
-// is not healthy an email notification is sent to $OPS_EMAIL.
+// is not healthy an email notification is sent.
 func siteHealthStatus(ctx context.Context, site, id string) (h map[string]health, err error) {
 	skey, err := strconv.ParseInt(site, 10, 64)
 	if err != nil {
@@ -288,7 +288,7 @@ func siteHealthStatus(ctx context.Context, site, id string) (h map[string]health
 			msg = fmt.Sprintf("Device %d/%s is unhealthy", skey, id)
 		}
 		log.Print(msg)
-		err := notifier.SendOps(ctx, skey, "health", msg)
+		err := notifier.Send(ctx, skey, "health", msg)
 		if err != nil {
 			log.Printf("unable to notify ops: %v", err)
 		}

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -326,7 +326,12 @@ func setup(ctx context.Context) {
 
 	model.RegisterEntities()
 
-	err = notifier.Init(ctx, projectID, senderEmail, notify.NewTimeStore(settingsStore))
+	secrets, err := gauth.GetSecrets(ctx, projectID, nil)
+	if err != nil {
+		log.Fatalf("could not get secrets: %v", err)
+	}
+	recipient, period := notify.GetOpsEnvVars()
+	err = notifier.Init(notify.WithSecrets(secrets), notify.WithRecipient(recipient), notify.WithStore(notify.NewTimeStore(settingsStore, period)))
 	if err != nil {
 		log.Fatalf("could not set up email notifier: %v", err)
 	}

--- a/cmd/oceancron/cron.go
+++ b/cmd/oceancron/cron.go
@@ -142,7 +142,7 @@ func (s *scheduler) Set(job *model.Cron) error {
 	// Build a job from the action, var and data values.
 	ctx := context.Background()
 	var action func()
-	notify := func(msg string) error { return notifier.SendOps(ctx, job.Skey, "health", msg) }
+	notify := func(msg string) error { return notifier.Send(ctx, job.Skey, "health", msg) }
 	switch strings.ToLower(job.Action) {
 	case "set":
 		action = func() {
@@ -207,7 +207,7 @@ func (s *scheduler) Set(job *model.Cron) error {
 	case "email":
 		action = func() {
 			log.Printf("cron run: email sent at %v\nvar=%s\ndata=%q", time.Now(), job.Var, job.Data)
-			err := notifier.SendOps(ctx, job.Skey, "cron",
+			err := notifier.Send(ctx, job.Skey, "cron",
 				fmt.Sprintf("cron email sent at %v\nvar=%s\ndata=%q",
 					time.Now(), job.Var, job.Data))
 			if err != nil {

--- a/cmd/oceancron/main.go
+++ b/cmd/oceancron/main.go
@@ -41,7 +41,6 @@ const (
 	projectID          = "oceancron"
 	cronServiceURL     = "https://oceancron.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
-	senderEmail        = "vidgrindservice@gmail.com"
 )
 
 var (
@@ -131,7 +130,12 @@ func setup(ctx context.Context) {
 		log.Fatalf("could not set up cron scheduler: %v", err)
 	}
 
-	err = notifier.Init(ctx, projectID, senderEmail, notify.NewTimeStore(settingsStore))
+	secrets, err := gauth.GetSecrets(ctx, projectID, nil)
+	if err != nil {
+		log.Fatalf("could not get secrets: %v", err)
+	}
+	recipient, period := notify.GetOpsEnvVars()
+	err = notifier.Init(notify.WithSecrets(secrets), notify.WithRecipient(recipient), notify.WithStore(notify.NewTimeStore(settingsStore, period)))
 	if err != nil {
 		log.Fatalf("could not set up email notifier: %v", err)
 	}

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -169,7 +169,7 @@ func (s *vidforwardPermanentLiveUnhealthy) exit()  {}
 func (s *vidforwardPermanentLiveUnhealthy) fix() {
 	const resetInterval = 5 * time.Minute
 	if time.Since(s.LastResetAttempt) > resetInterval {
-		notifier.SendOps(
+		notifier.Send(
 			context.Background(),
 			s.cfg.SKey,
 			"health",
@@ -203,7 +203,7 @@ func (s *vidforwardPermanentSlateUnhealthy) exit()  {}
 func (s *vidforwardPermanentSlateUnhealthy) fix() {
 	const resetInterval = 5 * time.Minute
 	if time.Since(s.LastResetAttempt) > resetInterval {
-		notifier.SendOps(
+		notifier.Send(
 			context.Background(),
 			s.cfg.SKey,
 			"health",
@@ -609,7 +609,7 @@ func onFailureClosure(ctx *broadcastContext, cfg *BroadcastConfig) func(err erro
 				if _cfg.StartFailures >= maxStartFailures {
 					_cfg.StartFailures = 0
 					_cfg.Enabled = false
-					notifier.SendOps(
+					notifier.Send(
 						context.Background(),
 						_cfg.SKey,
 						"health",

--- a/cmd/oceantv/health.go
+++ b/cmd/oceantv/health.go
@@ -38,7 +38,7 @@ import (
 // opsHealthNotify sends a health email notification for site with skey and message
 // msg.
 func opsHealthNotify(ctx context.Context, sKey int64, msg string) error {
-	return notifier.SendOps(ctx, sKey, "health", msg)
+	return notifier.Send(ctx, sKey, "health", msg)
 }
 
 // opsHealthNotifyFunc returns a closure using opsHealthNotify to be given to the

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -44,7 +44,6 @@ const (
 	projectID          = "oceantv"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
-	senderEmail        = "vidgrindservice@gmail.com" // TODO: Change this.
 	locationID         = "Australia/Adelaide"        // TODO: Use site location.
 )
 
@@ -134,7 +133,13 @@ func setup(ctx context.Context) {
 		log.Printf("could not get cronSecret: %v", err)
 	}
 
-	err = notifier.Init(ctx, projectID, senderEmail, notify.NewTimeStore(settingsStore))
+	secrets, err := gauth.GetSecrets(ctx, projectID, nil)
+	if err != nil {
+		log.Fatalf("could not get secrets: %v", err)
+	}
+	recipient, period := notify.GetOpsEnvVars()
+
+	err = notifier.Init(notify.WithSecrets(secrets), notify.WithRecipient(recipient), notify.WithStore(notify.NewTimeStore(settingsStore, period)))
 	if err != nil {
 		log.Fatalf("could not set up email notifier: %v", err)
 	}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -20,118 +20,89 @@ package notify
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
-	"os"
-	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	mailjet "github.com/mailjet/mailjet-apiv3-go"
-
-	"github.com/ausocean/cloud/gauth"
 )
 
 const (
-	defaultOpsPeriod = 60
+	defaultSender    = "vidgrindservice@gmail.com"
+	defaultRecipient = "ops@ausocean.org"
 )
 
-// TimeStore is an interface for getting and setting notification times.
-type TimeStore interface {
-	Set(int64, string, time.Time) error   // Set a time for a key.
-	Get(int64, string) (time.Time, error) // Get a time for a key.
-}
-
-// Notifier represents a notifier.
+// Notifier represents a notifier that uses the MailJet API to send email.
 type Notifier struct {
 	mutex       sync.Mutex // Lock access.
-	initialized bool       // True if initialized.
 	sender      string     // Sender email address.
-	store       TimeStore  // Notification persistence (optional).
+	recipient   string     // Recipient email address.
+	store       TimeStore  // Notification store (optional).
+	filters     []string   // Message filters (optional).
 	publicKey   string     // Public key for accessing MailJet API.
 	privateKey  string     // Public key for accessing MailJet API.
 }
 
-// Init initializes a notifier for use with the given project. It
-// looks up secrets from either a file or Google Storage bucket
-// specified by the <PROJECTID>_SECRETS environment variable. The
-// optional (non-nil) timestore keeps track of notification times, to
-// avoid sending too frequently.
-// For testing, projectID and sender should be empty strings.
-func (n *Notifier) Init(ctx context.Context, projectID string, sender string, store TimeStore) error {
+// Init initializes a notifier with the supplied options. See
+// WithSender, WithRecipient, WithFilter, WithStore and WithSecrets
+// for a description of the various options. Secrets are required to
+// send actual emails using the MailJet API, but can be omitted during
+// testing. It is permissable to re-initalize a Notifier with
+// different options, however missing options will revert to their
+// defaults.
+func (n *Notifier) Init(options ...Option) error {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	if n.initialized {
-		return nil
+	// Set default values.
+	n.sender = defaultSender
+	n.recipient = defaultRecipient
+	n.store = nil
+	n.filters = nil
+	n.publicKey = ""
+	n.privateKey = ""
+
+	// Apply options.
+	for i, opt := range options {
+		err := opt(n)
+		if err != nil {
+			return fmt.Errorf("could not apply option # %d, %v", i, err)
+		}
 	}
 
-	n.sender = sender
-	n.store = store
-
-	if projectID == "" {
-		n.initialized = true
-		return nil
-	}
-
-	secrets, err := gauth.GetSecrets(ctx, projectID, nil)
-	if err != nil {
-		return fmt.Errorf("could not get secrets: %w", err)
-	}
-
-	var ok bool
-	n.publicKey, ok = secrets["mailjetPublicKey"]
-	if !ok {
-		return errors.New("mailjetPublicKey secret not found")
-	}
-	n.privateKey, ok = secrets["mailjetPrivateKey"]
-	if !ok {
-		return errors.New("mailjetPrivateKey secret not found")
-	}
-
-	n.initialized = true
 	return nil
 }
 
-// SendOps sends an email to the email address defined by the
-// OPS_EMAIL environment variable at most every OPS_PERIOD minutes.
-func (n *Notifier) SendOps(ctx context.Context, skey int64, kind, msg string) error {
-	recipient := os.Getenv("OPS_EMAIL")
-	if recipient == "" {
-		return errors.New("OPS_EMAIL undefined")
+// Send sends an email message, depending on what options are present.
+// With filters, then all filters must match in order to send.
+// With persistence, then the message is sent only if it was not sent to the same recipient recently.
+func (n *Notifier) Send(ctx context.Context, skey int64, kind, msg string) error {
+	for _, f := range n.filters {
+		if !strings.Contains(msg, f) {
+			log.Printf("filter '%s' applied: not sending %s message to %s", f, kind, n.recipient)
+			return nil
+		}
 	}
-	p := os.Getenv("OPS_PERIOD")
-	mins, err := strconv.Atoi(p)
-	if err != nil {
-		log.Printf("defaulting to default OPS_PERIOD %d", defaultOpsPeriod)
-		mins = defaultOpsPeriod
-	}
-	return n.Send(ctx, skey, kind, recipient, msg, mins)
-}
 
-// Send sends an email message to the given recipient, unless the same
-// kind of email was sent to the same recipient recently.
-func (n *Notifier) Send(ctx context.Context, skey int64, kind, recipient, msg string, mins int) error {
 	if n.store != nil {
-		t, err := n.store.Get(skey, kind+"."+recipient)
+		sendable, err := n.store.Sendable(ctx, skey, kind+"."+n.recipient)
 		if err != nil {
-			log.Printf("error getting time: %v", err)
+			log.Printf("store.IsSendable returned error: %v", err)
 		}
-		if time.Since(t) < time.Duration(mins)*time.Minute {
-			log.Printf("too soon to send %s a %s message", recipient, kind)
-			return nil // Recently notified.
+		if !sendable {
+			log.Printf("too soon to send %s a %s message", n.recipient, kind)
+			return nil
 		}
 	}
 
-	log.Printf("sending %s a %s message", recipient, kind)
+	log.Printf("sending %s a %s message", n.recipient, kind)
 
-	if n.sender != "" {
+	if n.publicKey != "" && n.privateKey != "" {
 		clt := mailjet.NewMailjetClient(n.publicKey, n.privateKey)
 		info := []mailjet.InfoMessagesV31{{
 			From:     &mailjet.RecipientV31{Email: n.sender},
-			To:       &mailjet.RecipientsV31{mailjet.RecipientV31{Email: recipient}},
+			To:       &mailjet.RecipientsV31{mailjet.RecipientV31{Email: n.recipient}},
 			Subject:  strings.Title(kind) + " notification",
 			TextPart: msg,
 		}}
@@ -144,9 +115,9 @@ func (n *Notifier) Send(ctx context.Context, skey int64, kind, recipient, msg st
 	}
 
 	if n.store != nil {
-		err := n.store.Set(skey, kind+"."+recipient, time.Now())
+		err := n.store.Sent(ctx, skey, kind+"."+n.recipient)
 		if err != nil {
-			log.Printf("error setting time: %v", err)
+			log.Printf("store.Sent returned error: %v", err)
 		}
 	}
 

--- a/notify/options.go
+++ b/notify/options.go
@@ -20,6 +20,7 @@ package notify
 
 import (
 	"errors"
+	"log"
 	"os"
 	"strconv"
 	"time"
@@ -96,7 +97,9 @@ func GetOpsEnvVars() (string, time.Duration) {
 	v := os.Getenv("OPS_PERIOD")
 	if v != "" {
 		n, err := strconv.Atoi(v)
-		if err == nil {
+		if err != nil {
+			log.Printf("could not convert OPS_PERIOD '%s' to an integer: %v", v, err)
+		} else {
 			period = n
 		}
 	}

--- a/notify/options.go
+++ b/notify/options.go
@@ -20,6 +20,9 @@ package notify
 
 import (
 	"errors"
+	"os"
+	"strconv"
+	"time"
 )
 
 type Option func(*Notifier) error
@@ -74,4 +77,29 @@ func WithSecrets(secrets map[string]string) Option {
 		}
 		return nil
 	}
+}
+
+// GetOpsEnvVars is a helper function that returns the values for
+// the OPS_EMAIL and OPS_PERIOD env vars or supplies their defaults instead.
+func GetOpsEnvVars() (string, time.Duration) {
+	const (
+		defaultEmail  = "ops@ausocean.org"
+		defaultPeriod = 60
+	)
+
+	email := os.Getenv("OPS_EMAIL")
+	if email == "" {
+		email = defaultEmail
+	}
+
+	period := defaultPeriod
+	v := os.Getenv("OPS_PERIOD")
+	if v != "" {
+		n, err := strconv.Atoi(v)
+		if err == nil {
+			period = n
+		}
+	}
+
+	return email, time.Duration(period) * time.Minute
 }

--- a/notify/options.go
+++ b/notify/options.go
@@ -1,0 +1,77 @@
+/*
+LICENSE
+  Copyright (C) 2024 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package notify
+
+import (
+	"errors"
+)
+
+type Option func(*Notifier) error
+
+// WithSender sets the sender email address.
+func WithSender(sender string) Option {
+	return func(n *Notifier) error {
+		n.sender = sender
+		return nil
+	}
+}
+
+// WithRecipient sets the recipient email address.
+func WithRecipient(recipient string) Option {
+	return func(n *Notifier) error {
+		n.recipient = recipient
+		return nil
+	}
+}
+
+// WithFilter applies a filter string. If multiple WithFilter options
+// are applied, they form a compound conjunctive filter.
+func WithFilter(filter string) Option {
+	return func(n *Notifier) error {
+		n.filters = append(n.filters, filter)
+		return nil
+	}
+}
+
+// WithStore applies a TimeStore for notification persistence.
+// See TimeStore.
+func WithStore(store TimeStore) Option {
+	return func(n *Notifier) error {
+		n.store = store
+		return nil
+	}
+}
+
+// WithSecrets applies the secrets necessary for sending email,
+// notably the public and private mail API keys. This is always
+// required, unless testing.
+func WithSecrets(secrets map[string]string) Option {
+	return func(n *Notifier) error {
+		var ok bool
+		n.publicKey, ok = secrets["mailjetPublicKey"]
+		if !ok {
+			return errors.New("mailjetPublicKey secret not found")
+		}
+		n.privateKey, ok = secrets["mailjetPrivateKey"]
+		if !ok {
+			return errors.New("mailjetPrivateKey secret not found")
+		}
+		return nil
+	}
+}

--- a/notify/timestore.go
+++ b/notify/timestore.go
@@ -26,31 +26,43 @@ import (
 	"github.com/ausocean/openfish/datastore"
 )
 
+// TimeStore is an interface for notification persistence
+type TimeStore interface {
+	Sendable(context.Context, int64, string) (bool, error) // Returns true if a message is sendable.
+	Sent(context.Context, int64, string) error             // Records the time a message was sent.
+}
+
 // timeStore implements a TimeStore that uses a datastore for persistence.
 type timeStore struct {
-	store datastore.Store
+	store  datastore.Store
+	period time.Duration
 }
 
-// NewTimeStore returns a TimeStore that uses a datastore for peristence.
-func NewTimeStore(store datastore.Store) TimeStore {
-	return &timeStore{store: store}
+// NewTimeStore returns a TimeStore that uses a datastore for peristence
+// and sends messages separated in time by the given least period.
+func NewTimeStore(store datastore.Store, period time.Duration) TimeStore {
+	return &timeStore{store: store, period: period}
 }
 
-// Get retrieves a notification time stored in a datastore variable.
-// We prepend an underscore to keep the variable private.
-func (ts *timeStore) Get(skey int64, key string) (time.Time, error) {
-	v, err := model.GetVariable(context.Background(), ts.store, skey, "_"+key)
+// Sendable retrieves a notification time stored in a datastore
+// variable and returns true either if (1) the specified period has
+// elapsed since the last time a message for the given site and key
+// was sent or (2) a message is being sent for the first time.
+func (ts *timeStore) Sendable(ctx context.Context, skey int64, key string) (bool, error) {
+	v, err := model.GetVariable(ctx, ts.store, skey, "_"+key) // Prepend an underscore to keep the variable private.
+
 	switch err {
 	case nil:
-		return v.Updated, nil
+		return time.Since(v.Updated) >= ts.period, nil
 	case datastore.ErrNoSuchEntity:
-		return time.Time{}, nil // We've never sent this kind of notice previously.
+		return true, nil // No record of sending this kind of message.
 	default:
-		return time.Time{}, err // Unexpected datastore error.
+		return true, err // Unexpected datastore error.
 	}
 }
 
-// Set updates a notification time stored in a datatore variable.
-func (ts *timeStore) Set(skey int64, key string, t time.Time) error {
-	return model.PutVariable(context.Background(), ts.store, skey, "_"+key, "")
+// Sent records the time that a message with the given site and key
+// was sent.
+func (ts *timeStore) Sent(ctx context.Context, skey int64, key string) error {
+	return model.PutVariable(ctx, ts.store, skey, "_"+key, "") // Automatically updates the time.
 }


### PR DESCRIPTION
This implements the Notify package support for Issue #77 .

Note that **SendOps** is now deprecated as the functionality can be readily achieved by initializing a **Notifier** with the _WithRecipient_ option set to the ops email address. The GetOpsEnvVars helper function has been added to make this a bit easier.