### PR TITLE
Use callback health handling in broadcast manager

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -315,21 +315,15 @@ func performChecksInternalThroughStateMachine(
 	healthStatusChatHandler := func(event event) error {
 		switch event.(type) {
 		case healthCheckDueEvent:
-			handleHealthWithCallback(
+			err := man.HandleHealth(
 				context.Background(),
 				cfg,
-				store,
-				svc,
-				func(Ctx, *Cfg, Store, Svc) error {
-					bus.publish(badHealthEvent{})
-					return nil
-				},
-				func(Ctx, *Cfg, Store, Svc) error {
-					bus.publish(goodHealthEvent{})
-					return nil
-				},
-				log,
+				func() { bus.publish(goodHealthEvent{}) },
+				func() { bus.publish(badHealthEvent{}) },
 			)
+			if err != nil {
+				return fmt.Errorf("could not handle health: %w", err)
+			}
 		case statusCheckDueEvent:
 			err := man.HandleStatus(
 				context.Background(),

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -123,7 +123,7 @@ func (d *dummyManager) HandleChatMessage(ctx Ctx, cfg *Cfg) error {
 	d.chatHandled = true
 	return nil
 }
-func (d *dummyManager) HandleHealth(ctx Ctx, cfg *Cfg) error {
+func (d *dummyManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback, badHealthCallback func()) error {
 	d.healthHandled = true
 	return nil
 }


### PR DESCRIPTION
We're essentially copying handleHealthWithCallback into the HandleHealth method of the OceanBroadcastManager and changing the interface to follow the callback pattern. Subsequently we're now using HandleHealth instead for the healthStatusCheckEvent handling.

We're also removing the old handleHealth function which is now dead code.