### PR TITLE
Only email notify on consecutive bad health issues

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -319,7 +319,13 @@ func performChecksInternalThroughStateMachine(
 				context.Background(),
 				cfg,
 				func() { bus.publish(goodHealthEvent{}) },
-				func() { bus.publish(badHealthEvent{}) },
+				func(issue string) {
+					bus.publish(badHealthEvent{})
+					err := opsHealthNotify(ctx, cfg.SKey, fmt.Sprintf("broadcast: %s\n ID: %s\n, poor stream health, status: %s", cfg.Name, cfg.ID, issue))
+					if err != nil {
+						log("could not send notification for poor stream health: %v", err)
+					}
+				},
 			)
 			if err != nil {
 				return fmt.Errorf("could not handle health: %w", err)

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -60,7 +60,7 @@ type BroadcastManager interface {
 	// HandleHealth interprets the health of a broadcast and would perform any
 	// necessary actions based on this health. For example, if the health is
 	// bad, it might restart the broadcast.
-	HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback, badHealthCallback func()) error
+	HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback func(), badHealthCallback func(string)) error
 
 	SetupSecondary(ctx Ctx, cfg *Cfg, store Store) error
 }
@@ -217,14 +217,14 @@ func (m *OceanBroadcastManager) HandleChatMessage(ctx Ctx, cfg *Cfg) error {
 
 // HandleHealth interprets the health of a broadcast and calls the provided callbacks in response to the health.
 // For tolerance to temporary issues, we only call the badHealthCallback if the health is bad for more than 4 checks.
-func (m *OceanBroadcastManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback, badHealthCallback func()) error {
+func (m *OceanBroadcastManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback func(), badHealthCallback func(string)) error {
 	m.log("handling health check")
-	hasIssue, err := checkIssues(ctx, cfg, m.log)
+	issue, err := checkIssues(ctx, cfg, m.log)
 	if err != nil {
 		return fmt.Errorf("could not check for stream issues: %w", err)
 	}
 
-	if !hasIssue {
+	if issue == "" {
 		cfg.Issues = 0
 		goodHealthCallback()
 		return nil
@@ -233,7 +233,7 @@ func (m *OceanBroadcastManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallba
 
 	const maxHealthIssues = 4
 	if cfg.Issues > maxHealthIssues {
-		badHealthCallback()
+		badHealthCallback(issue)
 		cfg.Issues = 0
 	}
 

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -123,7 +123,7 @@ func (d *dummyManager) HandleChatMessage(ctx Ctx, cfg *Cfg) error {
 	d.chatHandled = true
 	return nil
 }
-func (d *dummyManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback, badHealthCallback func()) error {
+func (d *dummyManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback func(), badHealthCallback func(string)) error {
 	d.healthHandled = true
 	return nil
 }


### PR DESCRIPTION
Depends on PR #92 

Resolve issue #78 

We used to email on any issue, even if it might have been just temporary. This is uneccessary and creates false concerns. So now we're only performing email notification on consecutive issues.

This has involved modifying how we check for issues i.e. we return the string of the issue rather than a bool. We also provide this to the badHealthCallback, where we can handle with health notification if we wish.