### PR TITLE
Save broadcast issues tally

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -318,6 +318,7 @@ func performChecksInternalThroughStateMachine(
 			err := man.HandleHealth(
 				context.Background(),
 				cfg,
+				store,
 				func() { bus.publish(goodHealthEvent{}) },
 				func(issue string) {
 					bus.publish(badHealthEvent{})

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -123,7 +123,7 @@ func (d *dummyManager) HandleChatMessage(ctx Ctx, cfg *Cfg) error {
 	d.chatHandled = true
 	return nil
 }
-func (d *dummyManager) HandleHealth(ctx Ctx, cfg *Cfg, goodHealthCallback func(), badHealthCallback func(string)) error {
+func (d *dummyManager) HandleHealth(ctx Ctx, cfg *Cfg, store Store, goodHealthCallback func(), badHealthCallback func(string)) error {
 	d.healthHandled = true
 	return nil
 }


### PR DESCRIPTION
Depends on PR #94 

Resolves issue #75

It turns out that we weren't getting any badHealthEvents published and subsequently never transitioning to the Unhealthy states because we weren't actually saving the changes to the issues tally to the datastore. This change fixes this.

It has required that we alter the interface of HandleHealth slightly to require a parameter of Store interface type.