### PR TITLE
Fix direct state behaviour

### DIFF
--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -278,6 +278,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 				statusCheckDueEvent{},
 				chatMessageDueEvent{},
+				hardwareResetRequestEvent{},
 			},
 			expectedState: newDirectLiveUnhealthy(bCtx),
 			cfg: &BroadcastConfig{

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -403,7 +403,7 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 		},
 		{
 			desc: "directLiveUnhealthy",
-			s:    &directLiveUnhealthy{ctx},
+			s:    newDirectLiveUnhealthy(ctx),
 			equal: func(a, b state) bool {
 				return true
 			},


### PR DESCRIPTION
Depends on PR #95 

The behaviour has been incorrect. To start, we should not stop the broadcast on exit of the directLive state. Maybe once upon a time this worked because there was no state other than idle that we'd exit to, but now we have a directLiveUnhealthy. So, we only try to stop the broadcast (if exists) on entry to directIdle.

Secondly, the directLiveUnhealthy similarly should not try to stop the broadcast on exit. It should also implement the fixable state so that it can try to fix the hardware in this state.