### PR TITLE
Implement stateWithTimeout for hardwareStarting

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -129,6 +129,7 @@ type BroadcastConfig struct {
 	StartFailures     int           // The number of times the broadcast has failed to start.
 	Transitioning     bool          // If the broadcast is transition from live to slate, or vice versa.
 	StateData         []byte        // States will be marshalled and their data stored here.
+	HardwareStateData []byte        // Hardware states will be marshalled and their data stored here.
 }
 
 // SensorEntry contains the information for each sensor.


### PR DESCRIPTION
Depends on PR #96 

Up until this point there has been no way to know if a start failure happened specifically because the hardware failed to start.

We're fixing this by having the hardwareStarting state implement the stateWithTimeout interface so that when it times out we can emit a hardwareStartFailureEvent and precisely indicate the cause of failure.

This has required that we now save hardware state data, so there's a new field of the config called HardwareStateData. It has required that we add JSON marshalling tags to the other states.