### PR TITLE
Report start failure on starting state timeout

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -199,7 +199,10 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 	case *vidforwardSecondaryStarting:
 		sm.transitionIfTimedOut(sm.currentState, newVidforwardSecondaryIdle(sm.ctx), event)
 	case *directStarting:
-		sm.transitionIfTimedOut(sm.currentState, newDirectIdle(sm.ctx), event)
+		withTimeout := sm.currentState.(stateWithTimeout)
+		if withTimeout.timedOut(event.Time) {
+			onFailureClosure(sm.ctx, sm.ctx.cfg)(errors.New("direct starting timed out"))
+		}
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -567,8 +567,8 @@ func TestHandleTimeEvent(t *testing.T) {
 		{
 			desc:           "directStarting timed out",
 			initialState:   &directStarting{broadcastContext: bCtx, LastEntered: now},
-			event:          timeEvent{now.Add(6 * time.Minute)},
-			expectedEvents: []event{timeEvent{}, hardwareStopRequestEvent{}},
+			event:          timeEvent{now.Add(11 * time.Minute)},
+			expectedEvents: []event{timeEvent{}, startFailedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
 			cfg:            &BroadcastConfig{},
 		},

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -366,7 +366,7 @@ func (s *directStarting) enter() {
 }
 func (s *directStarting) exit() {}
 func (s *directStarting) timedOut(t time.Time) bool {
-	const timeout = 5 * time.Minute
+	const timeout = 10 * time.Minute
 	if t.Sub(s.LastEntered) > timeout {
 		s.log("timed out starting broadcast, last entered: %v, time now: %v", s.LastEntered, t)
 		return true


### PR DESCRIPTION
Depends on PR #97 

This should not happen under normal circumstances given that we now report start failure on both broadcast live transition issues and hardware camera startup failures, but it will cover us with any other unforseen conditions.

We're modifying the timeout to 10 minutes, which will give the hardware enough time to timeout (5 minutes).