### PR TITLE
OceanTV: Add controller MAC to broadcast config

### DIFF
--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -76,7 +76,17 @@
             <option>Select</option>
             {{end}}
             {{range .Cameras}}
-              <option value="{{.MAC}}" {{if eq .MAC (macdecode $.CurrentBroadcast.CameraMac) }}selected{{end}}>{{.Name}}</option>
+              <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.CameraMac }}selected{{end}}>{{.Name}}</option>
+          {{ end }}
+          </select>
+          <br>
+          <label>Controller:</label>
+          <select name="controller-mac">
+            {{if not .CurrentBroadcast.ControllerMAC}}
+              <option>Select</option>
+            {{end}}
+            {{range .Controllers}}
+              <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.ControllerMAC }}selected{{end}}>{{.Name}}</option>
             {{ end }}
           </select>
           <br>

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -103,6 +103,7 @@ type BroadcastConfig struct {
 	End               time.Time     // End time in native go format for easy operations.
 	VidforwardHost    string        // Host address of vidforward service.
 	CameraMac         int64         // Camera hardware's MAC address.
+	ControllerMAC     int64         // Controller hardware's MAC adress (controller used to power camera).
 	OnActions         string        // A series of actions to be used for power up of camera hardware.
 	OffActions        string        // A series of actions to be used for power down of camera hardware.
 	RTMPVar           string        // The variable name that holds the RTMP URL and key.


### PR DESCRIPTION
The broadcast config now contains the controller MAC allowing the state machine to make queries about the status of the controller.

This value is also read from the broadcast page.