### PR TITLE
OceanTV: Check status of controller before starting broadcast (#114)

### DIFF
--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -77,6 +77,10 @@ type hardwareStoppedEvent struct{}
 
 func (e hardwareStoppedEvent) String() string { return "hardwareStoppedEvent" }
 
+type controllerFailureEvent struct{}
+
+func (e controllerFailureEvent) String() string { return "controllerFailureEvent" }
+
 type slateResetRequested struct{}
 
 func (e slateResetRequested) String() string { return "slateResetRequested" }
@@ -153,6 +157,7 @@ func stringToEvent(name string) (event, error) {
 		"hardwareStopFailedEvent":   hardwareStopFailedEvent{},
 		"hardwareStartedEvent":      hardwareStartedEvent{},
 		"hardwareStoppedEvent":      hardwareStoppedEvent{},
+		"controllerFailureEvent":    controllerFailureEvent{},
 		"slateResetRequested":       slateResetRequested{},
 		"fixFailureEvent":           fixFailureEvent{},
 	}


### PR DESCRIPTION
createBroadcastAndRequestHardware now makes a call to getDeviceStatus for the controller to ensure that the controller will even respond to hardware start events before trying to create a new broadcast. This will give a pretty good indicator that the controller is not powered, likely due to a low power event on the rig.