### PR TITLE
Check Controller Status before starting hardware

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -32,6 +32,16 @@ func newHardwareStarting(ctx *broadcastContext) *hardwareStarting {
 }
 func (s *hardwareStarting) enter() {
 	s.LastEntered = time.Now()
+	if s.cfg.ControllerMAC != 0 {
+		controllerIsOn, err := getDeviceStatus(context.Background(), s.cfg.ControllerMAC, settingsStore)
+		if err != nil {
+			disableBroadcast(s.cfg, 1, fmt.Errorf("failed to get controller status: %v", err))
+			return
+		} else if !controllerIsOn {
+			disableBroadcast(s.cfg, 1, fmt.Errorf("controller not reporting, likely due to low voltage"))
+			return
+		}
+	}
 	s.camera.start(s.broadcastContext)
 }
 func (s *hardwareStarting) exit() {}

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -571,14 +571,13 @@ func broadcastCfgToState(ctx *broadcastContext) state {
 }
 
 func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *BroadcastConfig, onCreation func() error) {
-	background := context.Background()
-	controllerIsOn, err := getDeviceStatus(background, cfg.ControllerMac, settingsStore)
+	controllerIsOn, err := getDeviceStatus(context.Background(), cfg.ControllerMac, settingsStore)
 	if err != nil {
-		onFailureClosure(ctx, cfg)(fmt.Errorf("could not get controller status: %v", err))
+		disableBroadcast(cfg, 1, fmt.Errorf("failed to get controller status: %v", err))
 		return
 	} else if !controllerIsOn {
-		notifier.Send(background, cfg.SKey, "health", "The controller is not reporting, likely due to low rig voltage.")
-		onFailureClosure(ctx, cfg)(fmt.Errorf("could not get controller status: %v", err))
+		disableBroadcast(cfg, 1, fmt.Errorf("controller not reporting, likely due to low voltage"))
+		return
 	}
 	err = ctx.man.CreateBroadcast(
 		cfg,

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -571,15 +571,17 @@ func broadcastCfgToState(ctx *broadcastContext) state {
 }
 
 func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *BroadcastConfig, onCreation func() error) {
-	controllerIsOn, err := getDeviceStatus(context.Background(), cfg.ControllerMac, settingsStore)
-	if err != nil {
-		disableBroadcast(cfg, 1, fmt.Errorf("failed to get controller status: %v", err))
-		return
-	} else if !controllerIsOn {
-		disableBroadcast(cfg, 1, fmt.Errorf("controller not reporting, likely due to low voltage"))
-		return
+	if cfg.ControllerMac != 0 {
+		controllerIsOn, err := getDeviceStatus(context.Background(), cfg.ControllerMac, settingsStore)
+		if err != nil {
+			disableBroadcast(cfg, 1, fmt.Errorf("failed to get controller status: %v", err))
+			return
+		} else if !controllerIsOn {
+			disableBroadcast(cfg, 1, fmt.Errorf("controller not reporting, likely due to low voltage"))
+			return
+		}
 	}
-	err = ctx.man.CreateBroadcast(
+	err := ctx.man.CreateBroadcast(
 		cfg,
 		ctx.store,
 		ctx.svc,

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -643,14 +643,7 @@ func onFailureClosure(ctx *broadcastContext, cfg *BroadcastConfig) func(err erro
 				// TODO: make this configurable in config.
 				const maxStartFailures = 3
 				if _cfg.StartFailures >= maxStartFailures {
-					_cfg.StartFailures = 0
-					_cfg.Enabled = false
-					notifier.Send(
-						context.Background(),
-						_cfg.SKey,
-						"health",
-						fmt.Sprintf("Broadcast %s has failed to start %d times so it has been disabled.", _cfg.Name, maxStartFailures),
-					)
+					disableBroadcast(_cfg, maxStartFailures, err)
 				}
 				*cfg = *_cfg
 				return nil
@@ -660,6 +653,17 @@ func onFailureClosure(ctx *broadcastContext, cfg *BroadcastConfig) func(err erro
 			ctx.log("could not update config after failed start: %v", err)
 		}
 	}
+}
+
+func disableBroadcast(cfg *BroadcastConfig, maxStartFailures int, reason error) {
+	cfg.StartFailures = 0
+	cfg.Enabled = false
+	notifier.Send(
+		context.Background(),
+		cfg.SKey,
+		"health",
+		fmt.Sprintf("Broadcast %s has failed to start %d times so it has been disabled. Error: %v", cfg.Name, maxStartFailures, reason),
+	)
 }
 
 func stateToString(state state) string {

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -571,16 +571,6 @@ func broadcastCfgToState(ctx *broadcastContext) state {
 }
 
 func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *BroadcastConfig, onCreation func() error) {
-	if cfg.ControllerMac != 0 {
-		controllerIsOn, err := getDeviceStatus(context.Background(), cfg.ControllerMac, settingsStore)
-		if err != nil {
-			disableBroadcast(cfg, 1, fmt.Errorf("failed to get controller status: %v", err))
-			return
-		} else if !controllerIsOn {
-			disableBroadcast(cfg, 1, fmt.Errorf("controller not reporting, likely due to low voltage"))
-			return
-		}
-	}
 	err := ctx.man.CreateBroadcast(
 		cfg,
 		ctx.store,


### PR DESCRIPTION
Checking the controller status will prevent the hardware from trying to be started when the controller isn't connected. This will prevent a powered off rig from trying to start and will give a more informative error message.

We should still be adding testing for these functions.