### PR TITLE
Parameterise auth token URI for broadcast

### DIFF
--- a/cmd/oceantv/broadcast/auth.go
+++ b/cmd/oceantv/broadcast/auth.go
@@ -43,10 +43,7 @@ import (
 )
 
 // Authorisation related constants.
-const (
-	youtubeCredsRedirect = "/ytCredsCallback"
-	youtubeCredentials   = "gs://ausocean/youtube-api-credentials.json"
-)
+const youtubeCredsRedirect = "/ytCredsCallback"
 
 // Exported error values.
 var ErrGeneratedToken = errors.New("needed to generate token")
@@ -141,6 +138,9 @@ func genToken(w http.ResponseWriter, r *http.Request, config *oauth2.Config, url
 			if err != nil {
 				log.Printf("could not save new token: %v", err)
 			}
+
+			completionRedirect := "https://" + r.Host + "/admin/broadcast"
+			http.Redirect(w, r, completionRedirect, http.StatusSeeOther)
 		},
 	)
 

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -179,8 +179,10 @@ func (d *dummyService) StartBroadcast(
 	return nil
 }
 func (d *dummyService) BroadcastStatus(ctx Ctx, id string) (string, error) { return "", nil }
+func (d *dummyService) BroadcastHealth(ctx Ctx, id string) (string, error) { return "", nil }
 func (d *dummyService) RTMPKey(ctx Ctx, streamName string) (string, error) { return "", nil }
 func (d *dummyService) CompleteBroadcast(ctx Ctx, id string) error         { return nil }
+func (d *dummyService) PostChatMessage(id, msg string) error               { return nil }
 
 type dummyForwardingService struct{}
 

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -44,7 +44,7 @@ const (
 	projectID          = "oceantv"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
-	locationID         = "Australia/Adelaide"        // TODO: Use site location.
+	locationID         = "Australia/Adelaide" // TODO: Use site location.
 )
 
 var (
@@ -190,7 +190,10 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		logForBroadcast(&cfg, msg, args...)
 	}
 
-	err = newOceanBroadcastManager(log).SaveBroadcast(ctx, &cfg, settingsStore)
+	// Use the broadcast manager to save the broadcast.
+	// We can provide a nil BroadcastService given that SaveBroadcast
+	// won't need this.
+	err = newOceanBroadcastManager(nil, log).SaveBroadcast(ctx, &cfg, settingsStore)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,23 @@
+package utils
+
+// TokenURIFromAccount forms a Google Cloud Storage URI for a YouTube token
+// based on the provided account. If the account is empty, it's assumed that
+// the legacy token is being used. Otherwise, the account is used to form the
+// URI. This means we can have tokens stored for different YouTube accounts.
+// The URI is of the form: gs://ausocean/<account>.youtube.token.json
+// e.g. gs://ausocean/social@ausocean.org.youtube.token.json
+func TokenURIFromAccount(account string) string {
+	const (
+		bucket          = "gs://ausocean/"
+		legacyTokenName = "youtube-api-credentials.json"
+		defaultTokenURI = bucket + legacyTokenName
+	)
+
+	if account == "" {
+		return defaultTokenURI
+	}
+
+	const tokenPostfix = ".youtube.token.json"
+
+	return bucket + account + tokenPostfix
+}


### PR DESCRIPTION
The bucket object containing the required auth tokens for YouTube Live API usage was hardcoded to that belonging to AusOcean's account, however, we now require the ability to change this depending on the YouTube account for which we want to broadcast to.

We're now storing the Account email in the broadcast config, and using this according to a schema for the object name, which a common function, TokenURIFromAccount enforces. We provide this to the YoutTubeBroadcast service which will use it to get the auth token where required.

These changes also affect health checking and chat message posting
so to make things better, we're incorporating this functionality
into the broadcast manager/broadcast services.