### PR TITLE
Add token generation button to broadcast page

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -38,9 +38,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
 	"github.com/ausocean/cloud/gauth"
 	"github.com/ausocean/cloud/model"
+	"github.com/ausocean/cloud/utils"
 	"github.com/ausocean/openfish/datastore"
+	"google.golang.org/api/youtube/v3"
 )
 
 type Action int
@@ -138,6 +141,7 @@ type BroadcastConfig struct {
 	StartFailures     int           // The number of times the broadcast has failed to start.
 	Transitioning     bool          // If the broadcast is transition from live to slate, or vice versa.
 	StateData         []byte        // States will be marshalled and their data stored here.
+	Account           string        // The YouTube account email that this broadcast is associated with.
 }
 
 // SensorEntry contains the information for each sensor.
@@ -293,6 +297,19 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch action {
+	case broadcastToken:
+		tokenURI := utils.TokenURIFromAccount(profile.Email)
+		err = broadcast.GenerateToken(ctx, w, r, youtube.YoutubeScope, tokenURI)
+		if err != nil {
+			reportError(w, r, req, "could not generate token: %v", err)
+			return
+		}
+
+		// Store the account email in the broadcast config.
+		cfg.Account = profile.Email
+
+		// Fallthrough to save broadcast configuration.
+		fallthrough
 	case broadcastSave:
 		err := saveBroadcast(ctx, &req.CurrentBroadcast)
 		if err != nil {

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -138,6 +138,7 @@
       <input type="hidden" name="active" value="{{.CurrentBroadcast.Active}}">
       <button onclick="buttonClick(this)" value="broadcast-save">Save</button>
       <button onclick="buttonClick(this)" value="broadcast-delete">Delete</button>
+      <button onclick="buttonClick(this)" value="broadcast-token">Generate Token</button>
       <br>
 
       <!--This hidden field stores the value of button presses.-->

--- a/oceanbench.yaml
+++ b/oceanbench.yaml
@@ -6,6 +6,7 @@ env_variables:
   VIDGRIND_CREDENTIALS: gs://ausocean/VideoGrinder-b0ad82abac05.json
   OCEANBENCH_SECRETS: gs://ausocean/OceanBench-secrets.txt
   OCEANCRON_SECRETS: gs://ausocean/OceanCron-secrets.txt
+  YOUTUBE_SECRETS: gs://ausocean/YouTube-secrets.json
   OAUTH2_CALLBACK: https://bench.cloudblue.org/oauth2callback
   OPS_EMAIL: ops@ausocean.org
   OPS_PERIOD: 60


### PR DESCRIPTION
Depends on PR #134

Resolves issue #131 

To associate and authenticate a broadcast with a particular YouTube account, we need to generate a token for the account.

We're providing a button on the broadcast page that performs the generation and stores the account email in the broadcast config, which can be used to later retreive the token for refresh and/or use.