### PR TITLE
Add token generation button to broadcast page

### DIFF
--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -145,7 +145,8 @@
         <input type="hidden" name="active" value="{{.CurrentBroadcast.Active}}">
         <button onclick="buttonClick(this)" value="broadcast-save">Save</button>
         <button onclick="buttonClick(this)" value="broadcast-delete">Delete</button>
-        <br>
+        <button onclick="buttonClick(this)" value="broadcast-token">Generate Token</button>
+      <br>
 
         <!--This hidden field stores the value of button presses.-->
         <input type="hidden" name="action" value="">

--- a/oceanbench.yaml
+++ b/oceanbench.yaml
@@ -6,6 +6,7 @@ env_variables:
   VIDGRIND_CREDENTIALS: gs://ausocean/VideoGrinder-b0ad82abac05.json
   OCEANBENCH_SECRETS: gs://ausocean/OceanBench-secrets.txt
   OCEANCRON_SECRETS: gs://ausocean/OceanCron-secrets.txt
+  YOUTUBE_SECRETS: gs://ausocean/YouTube-secrets.json
   OAUTH2_CALLBACK: https://bench.cloudblue.org/oauth2callback
   OPS_EMAIL: ops@ausocean.org
   OPS_PERIOD: 60


### PR DESCRIPTION
To associate and authenticate a broadcast with a particular YouTube account, we need to generate a token for the account.

We're providing a button on the broadcast page that performs the generation and stores the account email in the broadcast config, which can be used to later retreive the token for refresh and/or use.

# NOTE
This has already been approved, but it was merged to a non-master branch
