### PR TITLE
Bench: Add channel field to broadcast UI (#147)

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -210,6 +210,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			CamOff:          r.FormValue("cam-off"),
 			CheckingHealth:  r.FormValue("check-health") == "checking-health",
 			Enabled:         r.FormValue("enabled") == "enabled",
+			Account:         r.FormValue("account"),
 		},
 		Action:             r.FormValue("action"),
 		ListingSecondaries: r.FormValue("list-secondaries") == "listing-secondaries",

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -58,6 +58,9 @@
           <label>Enabled:</label>
           <input type="checkbox" name="enabled" value="enabled" {{if .CurrentBroadcast.Enabled}}checked{{end}}>
           <br>
+          <label>Channel:</label>
+          <input type="input" name="account" value="{{.CurrentBroadcast.Account}}" readonly>
+          <br>
           <label>Description:</label>
           <textarea id="description-box" type="input" name="description">{{.CurrentBroadcast.Description}}</textarea>
           <br>


### PR DESCRIPTION
The channel field will show the current account associated with the broadcast config. This will show the current channel that the stream will be sent to. This also ensures that the current account stays associated with the broadcast rather than being overwritten by a null value.

Addresses (#147)
Requires (#148)