### PR TITLE
Bench: Broadcast UI radio buttons

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -97,7 +97,7 @@ type broadcastRequest struct {
 	commonData
 }
 
-// Settings contains constant values to be used to populat the form with limited options.
+// Settings contains constant values to be used to populate the form with limited options.
 type Settings struct {
 	Resolution []string
 	Privacy    []string

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -91,9 +91,16 @@ type broadcastRequest struct {
 	CurrentBroadcast   BroadcastConfig  // Holds configuration data for broadcast config in form.
 	Cameras            []model.Device   // Slice of all the cameras on the site.
 	Controllers        []model.Device   // Slice of all the controllers on the site.
+	Settings           Settings         // A struct containing options for some settings that have limited options.
 	Action             string           // Holds value of any button pressed.
 	ListingSecondaries bool             // Are we listing secondary broadcasts?
 	commonData
+}
+
+// Settings contains constant values to be used to populat the form with limited options.
+type Settings struct {
+	Resolution []string
+	Privacy    []string
 }
 
 // BroadcastConfig holds configuration data for a YouTube broadcast.
@@ -209,6 +216,10 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		},
 		Action:             r.FormValue("action"),
 		ListingSecondaries: r.FormValue("list-secondaries") == "listing-secondaries",
+		Settings: Settings{
+			Resolution: []string{"1080p"},
+			Privacy:    []string{"unlisted", "private", "public"},
+		},
 	}
 
 	ctx := r.Context()

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -65,7 +65,14 @@
           <input type="input" name="stream-name" value="{{.CurrentBroadcast.StreamName}}">
           <br>
           <label>Privacy:</label>
-          <input type="input" name="privacy" value="{{.CurrentBroadcast.Privacy}}">
+          <div class="d-flex gap-3 flex-row">
+          {{range .Settings.Privacy}}
+            <div>
+              <input type="radio" name="privacy" id="{{.}}">
+              {{.}}
+            </div>
+          {{end}}
+          </div>
           <br>
           <label>Resolution:</label>
           <input type="input" name="resolution" value="{{.CurrentBroadcast.Resolution}}">

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -68,12 +68,11 @@
           <div class="d-flex gap-3 flex-row">
           {{range .Settings.Privacy}}
             <div>
-              <input type="radio" name="privacy" id="{{.}}">
+              <input type="radio" name="privacy" value="{{.}}" {{if eq . $.CurrentBroadcast.Privacy}}checked{{end}}>
               {{.}}
             </div>
           {{end}}
           </div>
-          <br>
           <label>Resolution:</label>
           <input type="input" name="resolution" value="{{.CurrentBroadcast.Resolution}}">
           <br>

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -74,8 +74,14 @@
           {{end}}
           </div>
           <label>Resolution:</label>
-          <input type="input" name="resolution" value="{{.CurrentBroadcast.Resolution}}">
-          <br>
+          <div class="d-flex gap-3 flex-row">
+          {{range .Settings.Resolution}}
+            <div>
+              <input type="radio" name="resolution" value="{{.}}" {{if eq . $.CurrentBroadcast.Resolution}}checked{{end}}>
+              {{.}}
+            </div>
+          {{end}}
+          </div>
           <label>Camera:</label>
           <select name="camera-mac">
             {{if not .CurrentBroadcast.CameraMac}}


### PR DESCRIPTION
The broadcast UI now makes use of radio buttons for common settings with limited options (resolution and privacy). These settings can also be easily updated within broadcast.go by updating the request struct with new options.