### PR TITLE
Include response code in config request

### DIFF
--- a/cmd/datablue/handlers.go
+++ b/cmd/datablue/handlers.go
@@ -71,6 +71,7 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 	la := q.Get("la")
 	vt := q.Get("vt")
 	md := q.Get("md")
+	er := q.Get("er")
 
 	// Is this request for a valid device?
 	setup(ctx)
@@ -130,7 +131,7 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 	case model.DeviceStatusUpgrade:
-		if md == "Upgraded" {
+		if md == "Completed" {
 			log.Printf("device %s upgrade completed", ma)
 			dev.Status = model.DeviceStatusOK
 		} // Else upgrade in progress.
@@ -169,6 +170,7 @@ func configHandler(w http.ResponseWriter, r *http.Request) {
 	// Update the variables corresponding to the client's uptime, local address and var types.
 	if md != "" {
 		model.PutVariable(ctx, settingsStore, dev.Skey, dev.Hex()+".mode", md)
+		model.PutVariable(ctx, settingsStore, dev.Skey, dev.Hex()+".error", er)
 	}
 	if ut != "" {
 		model.PutVariable(ctx, settingsStore, dev.Skey, "_"+dev.Hex()+".uptime", ut)

--- a/cmd/datablue/main.go
+++ b/cmd/datablue/main.go
@@ -35,6 +35,11 @@ import (
 	"github.com/ausocean/openfish/datastore"
 )
 
+const (
+	version   = "v0.2.0"
+	projectID = "datablue"
+)
+
 var (
 	setupMutex    sync.Mutex
 	mediaStore    datastore.Store
@@ -91,7 +96,7 @@ func warmupHandler(w http.ResponseWriter, r *http.Request) {
 // test that the service is running. Devices do not use this endpoint.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	logRequest(r)
-	w.Write([]byte("OK"))
+	w.Write([]byte(projectID + " " + version))
 }
 
 // setup executes per-instance one-time warmup and is used to


### PR DESCRIPTION
- The response code (rc) and client type (ct) are now included in config responses.
- Config requests now clear the device status only when an upgrade completes.
