### PR TITLE
Improve permanent live unhealthy state behaviour

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -151,6 +151,7 @@ type BroadcastConfig struct {
 	Transitioning     bool          // If the broadcast is transition from live to slate, or vice versa.
 	StateData         []byte        // States will be marshalled and their data stored here.
 	Account           string        // The YouTube account email that this broadcast is associated with.
+	InFailure         bool          // True if the broadcast is in a failure state.
 }
 
 // SensorEntry contains the information for each sensor.
@@ -218,6 +219,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			CheckingHealth:  r.FormValue("check-health") == "checking-health",
 			Enabled:         r.FormValue("enabled") == "enabled",
 			Account:         r.FormValue("account"),
+			InFailure:       r.FormValue("in-failure") == "in-failure",
 		},
 		Action:             r.FormValue("action"),
 		ListingSecondaries: r.FormValue("list-secondaries") == "listing-secondaries",

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -69,6 +69,13 @@
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
+              <div class="w-25"></div>
+              <div class="form-check form-switch d-flex align-items-center gap-1 p-0">
+                <input type="checkbox" name="in-failure" class="form-check-input m-0" role="switch" value="in-failure" {{if .CurrentBroadcast.InFailure}}checked{{end}}>
+                <small>Failure Mode</small>
+              </div>
+            </div>
+            <div class="d-flex align-items-center gap-1 mb-1">
               <label for="account" class="w-25 text-end">Channel:</label>
               <div class="d-flex align-items-center gap-2 w-50">
                 <input type="input" name="account" class="form-control align-items-center" value="{{.CurrentBroadcast.Account}}" readonly>

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -130,6 +130,7 @@ type BroadcastConfig struct {
 	StateData         []byte        // States will be marshalled and their data stored here.
 	HardwareStateData []byte        // Hardware states will be marshalled and their data stored here.
 	Account           string        // The YouTube account email that this broadcast is associated with.
+	InFailure         bool          // True if the broadcast is in a failure state.
 }
 
 // SensorEntry contains the information for each sensor.

--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -81,6 +81,10 @@ type slateResetRequested struct{}
 
 func (e slateResetRequested) String() string { return "slateResetRequested" }
 
+type fixFailureEvent struct{}
+
+func (e fixFailureEvent) String() string { return "fixFailureEvent" }
+
 type handler func(event) error
 
 type eventBus interface {
@@ -150,6 +154,7 @@ func stringToEvent(name string) (event, error) {
 		"hardwareStartedEvent":      hardwareStartedEvent{},
 		"hardwareStoppedEvent":      hardwareStoppedEvent{},
 		"slateResetRequested":       slateResetRequested{},
+		"fixFailureEvent":           fixFailureEvent{},
 	}
 
 	event, ok := eventMap[name]

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -248,6 +248,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 				statusCheckDueEvent{},
 				chatMessageDueEvent{},
+				hardwareResetRequestEvent{},
 			},
 			expectedState: newVidforwardPermanentLiveUnhealthy(bCtx),
 			cfg: &BroadcastConfig{

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -226,6 +226,11 @@ func TestBroadcastCfgToState(t *testing.T) {
 			want: newVidforwardPermanentLiveUnhealthy(ctx),
 		},
 		{
+			name: "Vidforward Permanent Failure",
+			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: false, InFailure: true},
+			want: newVidforwardPermanentFailure(ctx),
+		},
+		{
 			name: "Vidforward Permanent Slate",
 			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardPermanentSlate(),
@@ -345,6 +350,13 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 			s:    &vidforwardPermanentLiveUnhealthy{broadcastContext: ctx, LastResetAttempt: time.Now()},
 			equal: func(a, b state) bool {
 				return a.(*vidforwardPermanentLiveUnhealthy).LastResetAttempt.Equal(b.(*vidforwardPermanentLiveUnhealthy).LastResetAttempt)
+			},
+		},
+		{
+			desc: "vidforwardPermanentFailure",
+			s:    &vidforwardPermanentFailure{broadcastContext: ctx},
+			equal: func(a, b state) bool {
+				return true
 			},
 		},
 		{

--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -44,9 +44,13 @@ import (
 // logForBroadcast logs a message with the broadcast name and ID.
 // This is useful to keep track of logs for different broadcasts.
 func logForBroadcast(cfg *BroadcastConfig, msg string, args ...interface{}) {
+	log.Println(fmtForBroadcastLog(cfg, msg, args...))
+}
+
+func fmtForBroadcastLog(cfg *BroadcastConfig, msg string, args ...interface{}) string {
 	idArgs := []interface{}{cfg.Name, cfg.ID}
 	idArgs = append(idArgs, args...)
-	log.Printf("(name: %s, id: %s) "+msg, idArgs...)
+	return fmt.Sprintf("(name: %s, id: %s) "+msg, idArgs...)
 }
 
 // removeDate removes a date from within a string that matches dd/mm/yyyy or mm/dd/yyyy.


### PR DESCRIPTION
Resolves issue #157 

We're now allowing only limited health fixes when in the permanent live unhealthy state. Fixes include hardware reset and requesting the forwarding service for stream (in case problems are on this front).

In the case that we max out our fixes allowance, we transition to a new permanent failure state. In this state we request that the forwarder goes to slate mode. We've also introduced a state to the broadcast object "InFailure" which is true if the broadcast is in a failure state. This is accessible from the broadcast UI. We'll need to uncheck this once we've resolved any issues and would like to resume normal behaviour.