### PR TITLE
Bench: Check for existing token before generating new token (#158)

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -318,9 +318,9 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	switch action {
 	case broadcastToken:
 		tokenURI := utils.TokenURIFromAccount(profile.Email)
-		err = broadcast.GenerateToken(ctx, w, r, youtube.YoutubeScope, tokenURI)
+		err = broadcast.AuthChannel(ctx, w, r, youtube.YoutubeScope, tokenURI)
 		if err != nil {
-			reportError(w, r, req, "could not generate token: %v", err)
+			reportError(w, r, req, "could not authenticate channel: %v", err)
 			return
 		}
 


### PR DESCRIPTION
Broadcast.go now calls AuthToken which first checks if a token for the given user already exists.
- If the token exists, the call returns
- If the token does not exist, the call generates a new token and saves it using GenerateToken.

This will prevent subsequent token generations of tokens which will not have refresh tokens (as only the first token will come with a refresh token).