### PR TITLE
bench: use site timezone for broadcast, don't expect offset decimal

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -97,6 +97,7 @@ type broadcastRequest struct {
 	Settings           Settings         // A struct containing options for some settings that have limited options.
 	Action             string           // Holds value of any button pressed.
 	ListingSecondaries bool             // Are we listing secondary broadcasts?
+	Site               *model.Site
 	commonData
 }
 
@@ -275,6 +276,12 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not load existing settings for broadcast: %v", err)
 			return
 		}
+	}
+
+	// Get site to use the site's timezone.
+	req.Site, err = model.GetSite(ctx, settingsStore, sKey)
+	if err != nil {
+		log.Printf("GetSite error: %v", err)
 	}
 
 	// Get all Cameras and Controllers that could be used by the broadcast.

--- a/cmd/oceanbench/s/main.js
+++ b/cmd/oceanbench/s/main.js
@@ -189,7 +189,12 @@ function sync(dateID, tsID, tzID, dateChanged) {
     if (s.length == 16) {
       s += ":00"; // Append seconds to make RFC3339 compliant.
     }
-    s += tzFormat(tz);
+    // If the timezone is not in UTC offset format, try to convert it from an offset number.
+    if(!checkUTCOffset(tz)){
+      s += tzFormat(tz);
+    } else {
+      s += tz;
+    }
     const ts = new Date(s).getTime() / 1000;
     document.getElementById(tsID).value = ts.toString();
   } else {
@@ -203,4 +208,9 @@ function sync(dateID, tsID, tzID, dateChanged) {
     const dt = new Date(ts * 1000).toISOString().slice(0, -1);
     document.getElementById(dateID).value = dt;
   }
+}
+
+function checkUTCOffset(tz) {
+  const utcOffsetRegex = /^[+-](?:2[0-3]|[01][0-9]):[0-5][0-9]$/;
+  return utcOffsetRegex.test(tz);
 }

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -129,7 +129,7 @@
               <input class="advanced" name="end-timestamp" type="input" id="end-timestamp" onchange="sync('end-time', 'end-timestamp', 'time-zone', false);" value="{{if .CurrentBroadcast.EndTimestamp}}{{.CurrentBroadcast.EndTimestamp}}{{end}}" size="15">
             </div>
             <label>Timezone:</label>
-            <input id="time-zone" size="1" onchange="sync('start-time', 'start-timestamp', 'time-zone', true)">
+            <input id="time-zone" size="3" value="{{if .Site.Timezone}}{{.Site.Timezone}}{{end}}" readonly>
             <br>
           </div>
           <label>Live Chat:</label>


### PR DESCRIPTION
This was done because the javascript was being used that interpreted the UTC offset string as a decimal, which caused the time to be off by an 30 minutes. This change should fix that.
The site's timezone can be used to keep things consistent and avoid error from user input.