### PR TITLE
Improve permanent start/transition error behaviour

### DIFF
--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -537,7 +537,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "vidforwardPermanentStarting timed out",
 			initialState:   &vidforwardPermanentStarting{broadcastContext: bCtx, LastEntered: now},
 			event:          timeEvent{now.Add(6 * time.Minute)},
-			expectedEvents: []event{timeEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, startFailedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardPermanentIdle(bCtx),
 			cfg:            &BroadcastConfig{},
 		},


### PR DESCRIPTION
Resolves #156

We're making the error handling behaviour a little smarter when it comes to error condition behaviour. For many of these cases, we were transitioning to the idle state, but this isn't great for a permanent broadcast.

Firstly, if we time out transitioning from live to slate, we're now notifying ops to check fordwarder software and staying in the live state.

Secondly, if we time out on permanent starting, we use the onFailure closure which gives us some more chances, but will notify and disable when a limit is reached.

Thirdly, if we time out transitioning from slate to live, we enter the permanent failure state which stays in slate mode and notifies ops that there may be a problem with the hardware.