### PR TITLE
Slate on hardware failure for permanent live states

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -116,6 +116,12 @@ func (sm *broadcastStateMachine) handleHardwareStartFailedEvent(event hardwareSt
 	switch sm.currentState.(type) {
 	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting, *directStarting:
 		onFailureClosure(sm.ctx, sm.ctx.cfg)(errors.New("hardware start failed"))
+	case *vidforwardPermanentLive, *vidforwardPermanentLiveUnhealthy:
+		sm.logAndNotify("hardware failure event in permanent live state, moving to failure slate state")
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
+	case *vidforwardPermanentTransitionSlateToLive:
+		sm.logAndNotify("hardware failure event in transition from slate to live, moving to failure slate state")
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}
@@ -399,4 +405,8 @@ func (sm *broadcastStateMachine) unexpectedEvent(event event, state state) {
 
 func (sm *broadcastStateMachine) log(msg string, args ...interface{}) {
 	sm.ctx.log(msg, args...)
+}
+
+func (sm *broadcastStateMachine) logAndNotify(msg string, args ...interface{}) {
+	sm.ctx.logAndNotify(msg, args...)
 }

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -22,6 +22,10 @@ type broadcastContext struct {
 func (ctx *broadcastContext) log(msg string, args ...interface{}) {
 	logForBroadcast(ctx.cfg, msg, args...)
 }
+func (ctx *broadcastContext) logAndNotify(msg string, args ...interface{}) {
+	logForBroadcast(ctx.cfg, msg, args...)
+	notifier.Send(context.Background(), ctx.cfg.SKey, "health", fmtForBroadcastLog(ctx.cfg, msg, args...))
+}
 
 type state interface {
 	enter()


### PR DESCRIPTION
closes #54 

We're now handling hardware failure events when we're in the permanent live/live unhealthy and slate to live states. Under these circumstances, we should stay in slate. We can do this by entering the vidforwardPermanentInFailure state in which case we wait until admin has taken the broadcast out of this state i.e. maybe fixed the problem.