### PR TITLE
Added type Kind

### DIFF
--- a/notify/notify_test.go
+++ b/notify/notify_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	projectID = "test"
-	kind      = "test"
-	message   = "This is a test."
+	projectID      = "test"
+	kind      Kind = "test"
+	message        = "This is a test."
 )
 
 // testStore implements a dummy time store for testing purposes.


### PR DESCRIPTION
This is a simple change to improve typesafe usage of the `notify` package, which is backwards compatible with clients, providing the kind is supplied as literal.

I considered making `Kind` an interface (modeled on `Error`), but that would not be backwards compatible. Further, it is not clear that `Kind` needs to be more than a string.