### PR TITLE
Merge broadcast man save and config update transaction

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -309,20 +309,10 @@ func (c *revidCameraClient) publishEventIfStatus(event event, status bool, mac i
 }
 
 func (sm *hardwareStateMachine) saveHardwareStateToConfig() error {
-	return updateConfigWithTransaction(
-		context.Background(),
-		sm.ctx.store,
-		sm.ctx.cfg.SKey,
-		sm.ctx.cfg.Name,
-		func(_cfg *BroadcastConfig) error {
-			_cfg.HardwareState = hardwareStateToString(sm.currentState)
-			hardwareStateData, err := json.Marshal(sm.currentState)
-			if err != nil {
-				return fmt.Errorf("could not marshal hardware state data: %v", err)
-			}
-			_cfg.HardwareStateData = hardwareStateData
-			*sm.ctx.cfg = *_cfg
-			return nil
-		},
-	)
+	hardwareState := hardwareStateToString(sm.currentState)
+	hardwareStateData, err := json.Marshal(sm.currentState)
+	if err != nil {
+		return fmt.Errorf("could not marshal hardware state data: %v", err)
+	}
+	return sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.HardwareState = hardwareState; _cfg.HardwareStateData = hardwareStateData })
 }

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -69,9 +69,9 @@ func TestHandleHardwareStoppedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
+			bCtx.man = NewDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -124,9 +124,9 @@ func TestHandleHardwareStopFailedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
+			bCtx.man = NewDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -181,9 +181,9 @@ func TestHandleHardwareStartFailedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
+			bCtx.man = NewDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -238,9 +238,9 @@ func TestHandleHardwareStartedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
+			bCtx.man = NewDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -303,9 +303,9 @@ func TestHandleHardwareResetRequestEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
+			bCtx.man = NewDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -594,7 +594,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 			bus.subscribe(handler)
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -699,7 +699,7 @@ func TestHandleStartFailedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -820,7 +820,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -941,7 +941,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1044,7 +1044,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1153,7 +1153,7 @@ func TestHandleStartEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1226,7 +1226,7 @@ func TestHandleStartedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1325,7 +1325,7 @@ func TestBroadcastStart(t *testing.T) {
 				},
 			)
 
-			bCtx.man = NewDummyManager(t)
+			bCtx.man = NewDummyManager(t, tt.cfg)
 			bCtx.camera = newDummyHardwareManager(tt.hardwareHealthy)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -57,17 +57,19 @@ func TestRemoveDate(t *testing.T) {
 
 // dummyManager is a dummy implementation of the broadcastManager interface.
 type dummyManager struct {
+	cfg                                                                *Cfg
 	startDone                                                          chan struct{}
 	saved, started, stopped, healthHandled, statusHandled, chatHandled bool
 	savedCfgs                                                          map[string]*Cfg
 	t                                                                  *testing.T
 }
 
-func NewDummyManager(t *testing.T) *dummyManager {
+func NewDummyManager(t *testing.T, cfg *Cfg) *dummyManager {
 	log.Println("creating dummy manager")
 	return &dummyManager{
 		t:         t,
 		startDone: make(chan struct{}),
+		cfg:       cfg,
 	}
 }
 
@@ -106,13 +108,13 @@ func (d *dummyManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc Svc) er
 	d.stopped = true
 	return nil
 }
-func (d *dummyManager) SaveBroadcast(ctx Ctx, cfg *Cfg, store Store) error {
+func (d *dummyManager) Save(ctx Ctx, update func(*BroadcastConfig)) error {
 	d.saved = true
-	d.logf("saving broadcast: %s", cfg.Name)
+	d.logf("saving broadcast: %s", d.cfg.Name)
 	if d.savedCfgs == nil {
 		d.savedCfgs = make(map[string]*Cfg)
 	}
-	d.savedCfgs[cfg.Name] = cfg
+	d.savedCfgs[d.cfg.Name] = d.cfg
 	return nil
 }
 func (d *dummyManager) HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc Svc, call BroadcastCallback) error {

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -191,9 +191,9 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use the broadcast manager to save the broadcast.
-	// We can provide a nil BroadcastService given that SaveBroadcast
+	// We can provide a nil BroadcastService given that Save
 	// won't need this.
-	err = newOceanBroadcastManager(nil, log).SaveBroadcast(ctx, &cfg, settingsStore)
+	err = newOceanBroadcastManager(nil, &cfg, settingsStore, log).Save(ctx, nil)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return

--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -125,7 +125,7 @@ func broadcastByName(sKey int64, name string) (*BroadcastConfig, error) {
 }
 
 // TODO: document this.
-func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, broadcast string, update func(cfg *BroadcastConfig) error) error {
+func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, broadcast string, update func(cfg *BroadcastConfig)) error {
 	name := broadcastScope + "." + broadcast
 	sep := strings.Index(name, ".")
 	if sep >= 0 {
@@ -149,11 +149,7 @@ func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, b
 			return
 		}
 
-		err = update(&cfg)
-		if err != nil {
-			callBackErr = fmt.Errorf("error from broadcast update callback: %w", err)
-			return
-		}
+		update(&cfg)
 
 		d, err := json.Marshal(cfg)
 		if err != nil {


### PR DESCRIPTION
closes #177 

We're having OceanBroadcastManager.Save wrap
updateConfigWithTransaction, which achieves several things.

Firstly, if everything uses OceanBroadcastManager.Save for updating broadcast config fields, then we'll have everything inherently synchronised propertly.

Secondly, this should greatly reduce boilerplate associated with using updateConfigWithTransaction for every modifification of the broadcast config.