### PR TITLE
Model: Move device types to model

### DIFF
--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -58,7 +58,14 @@ func setDevicesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // devTypes are valid device types.
-var devTypes = []string{"Controller", "Camera", "Hydrophone", "Speaker", "Aligner", "Test"}
+var devTypes = []string{
+	model.DevTypeController,
+	model.DevTypeCamera,
+	model.DevTypeHydrophone,
+	model.DevTypeSpeaker,
+	model.DevTypeAligner,
+	model.DevTypeTest,
+}
 
 // devicesData contains data required by the device.html template, and is populated
 // by the writeDevices function.

--- a/model/device.go
+++ b/model/device.go
@@ -83,6 +83,16 @@ type Device struct {
 	other         map[string]string // Other, non-persistent data.
 }
 
+// Device types.
+const (
+	DevTypeController = "Controller"
+	DevTypeCamera     = "Camera"
+	DevTypeHydrophone = "Hydrophone"
+	DevTypeSpeaker    = "Speaker"
+	DevTypeAligner    = "Aligner"
+	DevTypeTest       = "Test"
+)
+
 // Encode serializes a Device into tab-separated values.
 func (dev *Device) Encode() []byte {
 	return []byte(fmt.Sprintf("%d\t%d\t%d\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\t%f\t%f\t%t\t%d",


### PR DESCRIPTION
Device type constants are now stored in model/device.go and exported.