### PR TITLE
Model: Add variable factories (#206)

### DIFF
--- a/model/factories.go
+++ b/model/factories.go
@@ -26,6 +26,9 @@ LICENSE
 package model
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/ausocean/utils/nmea"
 )
 
@@ -96,4 +99,112 @@ func WaterTemperatureSensor() SensorV2 {
 		formRound1,
 		tempLinearArgs...,
 	)
+}
+
+// NewAlarmNetworkVar returns a new AlarmNetwork var with the
+// passed number of failures as its value.
+func NewAlarmNetworkVar(numberOfFailures int) *Variable {
+	return &Variable{
+		Name:  "AlarmNetwork",
+		Value: string(numberOfFailures),
+	}
+}
+
+// NewAlarmPeriodVar returns a new AlarmPeriod var with the
+// passed duration as its value.
+func NewAlarmPeriodVar(duration time.Duration) *Variable {
+	return &Variable{
+		Name:  "AlarmPeriod",
+		Value: strconv.FormatFloat(duration.Seconds(), 'f', 0, 64),
+	}
+}
+
+// NewAlarmRecoveryVoltageVar returns a new AlarmRecoveryVoltage var with the
+// passed threshold as its value.
+func NewAlarmRecoveryVoltageVar(threshold int) *Variable {
+	return &Variable{
+		Name:  "AlarmRecoveryVoltage",
+		Value: string(threshold),
+	}
+}
+
+// NewAlarmVoltageVar returns a new AlarmVoltage var with the
+// passed threshold as its value.
+func NewAlarmVoltageVar(threshold int) *Variable {
+	return &Variable{
+		Name:  "AlarmVoltage",
+		Value: string(threshold),
+	}
+}
+
+// NewAutoRestartVar returns a new AutoRestart var with the
+// passed duration as its value.
+func NewAutoRestartVar(duration time.Duration) *Variable {
+	return &Variable{
+		Name:  "AutoRestart",
+		Value: strconv.FormatFloat(duration.Seconds(), 'f', 0, 64),
+	}
+}
+
+// NewPower1Var returns a new Power1 var with the
+// power initialised to the passed power.
+func NewPower1Var(power bool) *Variable {
+	return &Variable{
+		Name:  "Power1",
+		Value: strconv.FormatBool(power),
+	}
+}
+
+// NewPower2Var returns a new Power2 var with the
+// power initialised to the passed power.
+func NewPower2Var(power bool) *Variable {
+	return &Variable{
+		Name:  "Power2",
+		Value: strconv.FormatBool(power),
+	}
+}
+
+// NewPower3Var returns a new Power3 var with the
+// power initialised to the passed power.
+func NewPower3Var(power bool) *Variable {
+	return &Variable{
+		Name:  "Power3",
+		Value: strconv.FormatBool(power),
+	}
+}
+
+// NewPulsesVar returns a new Pulses var with the
+// passed number of pulses as its value.
+func NewPulsesVar(pulses int) *Variable {
+	return &Variable{
+		Name:  "Pulses",
+		Value: string(pulses),
+	}
+}
+
+// NewPulseWidthVar returns a new PulseWidth var with the
+// passed width duration as its value.
+func NewPulseWidthVar(width time.Duration) *Variable {
+	return &Variable{
+		Name:  "PulseWidth",
+		Value: strconv.FormatFloat(width.Seconds(), 'f', 0, 64),
+	}
+}
+
+// NewPulseCycleVar returns a new PulseCycle var with the
+// passed cycle duration as its value.
+func NewPulseCycleVar(cycle time.Duration) *Variable {
+	return &Variable{
+		Name:  "PulseCycle",
+		Value: strconv.FormatFloat(cycle.Seconds(), 'f', 0, 64),
+	}
+}
+
+// NewPulseSuppressVar returns a new PulseSuppress var with the
+// passed value as its value.
+func NewPulseSuppressVar(suppress bool) *Variable {
+	return &Variable{
+		Name:  "PulseSuppress",
+		Value: strconv.FormatBool(suppress),
+	}
 }


### PR DESCRIPTION
This change adds factories to create the following variables (with passed values)
- AlarmNetwork
- AlarmPeriod
- AlarmRecoveryVoltage
- AlarmVoltage
- AutoRestart
- Power1
- Power2
- Power3
- Pulses
- PulseWidth
- PulseCycleVar
- PulseSuppress

## NOTE
It is up to the caller to define the value of the variable for most of these factories. I think this makes more sense, as the system layer will be making the decision about what the default values look like.

depends on #207 