### PR TITLE
Create broadcast variable if not exist on update

### DIFF
--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -162,7 +162,17 @@ func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, b
 	}
 
 	err := store.Update(ctx, key, updateConfig, &model.Variable{})
-	if err != nil {
+	if errors.Is(err, datastore.ErrNoSuchEntity) {
+		err = store.Create(ctx, key, &model.Variable{})
+		if err != nil {
+			return fmt.Errorf("could not create broadcast variable: %w", err)
+		}
+
+		err = store.Update(ctx, key, updateConfig, &model.Variable{})
+		if err != nil {
+			return fmt.Errorf("could not update broadcast variable after creation: %w", err)
+		}
+	} else if err != nil {
 		return fmt.Errorf("could not update variable: %w", err)
 	}
 


### PR DESCRIPTION
The Save method in the OceanBroadcastManager now wraps the updateConfigWithTransaction function.  This means that it will also have to handle saving of an entirely new broadcast configuration.

We now use store.Create to create a broadcast variable if we get an ErrNoSuchEntity error on update, and then try the update again.