### PR TITLE
Bench: Use constants for device types on broadcast page.

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -294,9 +294,9 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, dev := range devices {
-		if dev.Type == "Camera" {
+		if dev.Type == model.DevTypeCamera {
 			req.Cameras = append(req.Cameras, dev)
-		} else if dev.Type == "Controller" {
+		} else if dev.Type == model.DevTypeController {
 			req.Controllers = append(req.Controllers, dev)
 		}
 	}

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.21.0"
+	version     = "v0.21.1"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This change uses the constant device types from model to ensure that the device type comparison is matching correctly.