### PR TITLE
TV: Fix error matching for ErrNoSuchEntity

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	projectID          = "oceantv"
+	version            = "v0.1.0"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.
@@ -96,7 +97,7 @@ func warmupHandler(w http.ResponseWriter, r *http.Request) {
 // test that the service is running. Devices do not use this endpoint.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	logRequest(r)
-	w.Write([]byte("OK"))
+	w.Write([]byte(projectID + " " + version))
 }
 
 // setup executes per-instance one-time initialization. Any errors are

--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -37,7 +37,6 @@ import (
 	"strings"
 	"time"
 
-	googledatastore "cloud.google.com/go/datastore"
 	"github.com/ausocean/cloud/model"
 	"github.com/ausocean/openfish/datastore"
 )
@@ -163,8 +162,7 @@ func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, b
 	}
 
 	err := store.Update(ctx, key, updateConfig, &model.Variable{})
-	// We need to check for both filestore and cloudstore error types here.
-	if errors.Is(err, datastore.ErrNoSuchEntity) || errors.Is(err, googledatastore.ErrNoSuchEntity) {
+	if errors.Is(err, datastore.ErrNoSuchEntity) {
 		err = store.Create(ctx, key, &model.Variable{})
 		if err != nil {
 			return fmt.Errorf("could not create broadcast variable: %w", err)


### PR DESCRIPTION
When saving a new broadcast, errors coming from cloudstore are now properly matched with the correct types from cloud.google.com/go/datastore.

This change also changes the updateConfig function since there will be no config to unmarshal

NOTE:
This is currently deployed to fix a P0 level bug

closes #213 