### PR TITLE
tv: move auto add checkbroadcast cron to CreateBroadcast

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -332,6 +332,12 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not save broadcast: %v", err)
 			return
 		}
+		// Ensure that the CheckBroadcast cron exists.
+		c := &model.Cron{Skey: cfg.SKey, ID: "Broadcast Check", TOD: "* * * * *", Action: "rpc", Var: tvURL + "/checkbroadcasts", Enabled: true}
+		err = model.PutCron(context.Background(), settingsStore, c)
+		if err != nil {
+			return reportError(w, r, req, "Warning: failed to verify checkbroadcasts cron: %v", err)
+		}
 
 	case broadcastDelete:
 		err = deleteBroadcast(ctx, &req, settingsStore)

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.21.3"
+	version     = "v0.21.4"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -455,13 +455,6 @@ func saveBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.St
 		return fmt.Errorf("could not put broadcast data in store: %w", err)
 	}
 
-	// Ensure that the CheckBroadcast cron exists.
-	c := &model.Cron{Skey: cfg.SKey, ID: "Broadcast Check", TOD: "* * * * *", Action: "rpc", Var: projectURL + "/checkbroadcasts", Enabled: true}
-	err = model.PutCron(ctx, store, c)
-	if err != nil {
-		return fmt.Errorf("failure verifying check broadcast cron: %w", err)
-	}
-
 	return nil
 }
 

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.1.4"
+	version            = "v0.1.5"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This was done because CreateBroadcast no longer uses the saveBroadcast function that checks the cron. But we still want the cron to be checked whena broadcast is created.

Addresses issue #232.