### PR TITLE
Remove unused or inappropriate config fields

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -119,10 +119,8 @@ type BroadcastConfig struct {
 	Description       string        // The broadcast description shown below viewing window.
 	Privacy           string        // Privacy of the broadcast i.e. public, private or unlisted.
 	Resolution        string        // Resolution of the stream e.g. 1080p.
-	StartTime         string        // Start time of the broadcast in yy/mm/dd, hh:mm format.
 	StartTimestamp    string        // Start time of the broadcast in unix format.
 	Start             time.Time     // Start time in native go format for easy operations.
-	EndTime           string        // End time of the broadcast in yy/mm/dd, hh:mm format.
 	EndTimestamp      string        // End time of the broadcast in unix format.
 	End               time.Time     // End time in native go format for easy operations.
 	VidforwardHost    string        // Host address of vidforward service.
@@ -133,16 +131,11 @@ type BroadcastConfig struct {
 	RTMPVar           string        // The variable name that holds the RTMP URL and key.
 	Active            bool          // This is true if the broadcast is currently active i.e. waiting for data or currently streaming.
 	Slate             bool          // This is true if the broadcast is currently in slate mode i.e. no camera.
-	LastStatusCheck   time.Time     // Time of last status check i.e. if complete or not.
-	LastChatMsg       time.Time     // Time of last chat message posted.
-	LastHealthCheck   time.Time     // Time of last stream health check.
 	Issues            int           // The number of successive stream issues currently experienced. Reset when good health seen.
 	SendMsg           bool          // True if sensor data will be sent to the YouTube live chat.
 	SensorList        []SensorEntry // List of sensors which can be reported to the YouTube live chat.
 	RTMPKey           string        // The RTMP key corresponding to the newly created broadcast.
 	UsingVidforward   bool          // Indicates if we're using vidforward i.e. doing long term broadcast.
-	CamOn             string        // The time that the slate will be removed and the camera will turn on.
-	CamOff            string        // The time that the camera will be turned off and the slate will be encoded.
 	CheckingHealth    bool          // Are we performing health checks for the broadcast? Having this false is useful for dodgy testing streams.
 	AttemptingToStart bool          // Indicates if we're currently attempting to start the broadcast.
 	Enabled           bool          // Is the broadcast enabled? If not, it will not be started.
@@ -203,9 +196,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			Description:     r.FormValue("description"),
 			Privacy:         r.FormValue("privacy"),
 			Resolution:      r.FormValue("resolution"),
-			StartTime:       r.FormValue("start-time"),
 			StartTimestamp:  r.FormValue("start-timestamp"),
-			EndTime:         r.FormValue("end-time"),
 			EndTimestamp:    r.FormValue("end-timestamp"),
 			RTMPVar:         r.FormValue("rtmp-key-var"),
 			RTMPKey:         r.FormValue("rtmp-key"),
@@ -216,8 +207,6 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			OffActions:      r.FormValue("off-actions"),
 			SendMsg:         r.FormValue("report-sensor") == "Chat",
 			UsingVidforward: r.FormValue("use-vidforward") == "using-vidforward",
-			CamOn:           r.FormValue("cam-on"),
-			CamOff:          r.FormValue("cam-off"),
 			CheckingHealth:  r.FormValue("check-health") == "checking-health",
 			Enabled:         r.FormValue("enabled") == "enabled",
 			InFailure:       r.FormValue("in-failure") == "in-failure",

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -109,16 +109,11 @@ type BroadcastConfig struct {
 	RTMPVar           string        // The variable name that holds the RTMP URL and key.
 	Active            bool          // This is true if the broadcast is currently active i.e. waiting for data or currently streaming.
 	Slate             bool          // This is true if the broadcast is currently in slate mode i.e. no camera.
-	LastStatusCheck   time.Time     // Time of last status check i.e. if complete or not.
-	LastChatMsg       time.Time     // Time of last chat message posted.
-	LastHealthCheck   time.Time     // Time of last stream health check.
 	Issues            int           // The number of successive stream issues currently experienced. Reset when good health seen.
 	SendMsg           bool          // True if sensor data will be sent to the YouTube live chat.
 	SensorList        []SensorEntry // List of sensors which can be reported to the YouTube live chat.
 	RTMPKey           string        // The RTMP key corresponding to the newly created broadcast.
 	UsingVidforward   bool          // Indicates if we're using vidforward i.e. doing long term broadcast.
-	CamOn             string        // The time that the slate will be removed and the camera will turn on.
-	CamOff            string        // The time that the camera will be turned off and the slate will be encoded.
 	CheckingHealth    bool          // Are we performing health checks for the broadcast? Having this false is useful for dodgy testing streams.
 	AttemptingToStart bool          // Indicates if we're currently attempting to start the broadcast.
 	Enabled           bool          // Is the broadcast enabled? If not, it will not be started.

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -282,22 +282,22 @@ func (sm *broadcastStateMachine) publishHealthStatusOrChatEvents(event timeEvent
 	)
 	sm.publishHealthEvent(event)
 	now := event.Time
-	if now.Sub(sm.ctx.cfg.LastStatusCheck) > statusInterval {
+	if now.Sub(sm.currentState.(liveState).lastStatusCheck()) > statusInterval {
 		sm.ctx.bus.publish(statusCheckDueEvent{})
-		sm.ctx.cfg.LastStatusCheck = now
+		sm.currentState.(liveState).setLastStatusCheck(now)
 	}
-	if now.Sub(sm.ctx.cfg.LastChatMsg) > chatInterval {
+	if now.Sub(sm.currentState.(liveState).lastChatMsg()) > chatInterval {
 		sm.ctx.bus.publish(chatMessageDueEvent{})
-		sm.ctx.cfg.LastChatMsg = now
+		sm.currentState.(liveState).setLastChatMsg(now)
 	}
 }
 
 func (sm *broadcastStateMachine) publishHealthEvent(event timeEvent) {
 	const healthInterval = 1 * time.Minute
 	now := event.Time
-	if now.Sub(sm.ctx.cfg.LastHealthCheck) > healthInterval && sm.ctx.cfg.CheckingHealth {
+	if now.Sub(sm.currentState.(stateWithHealth).lastHealthCheck()) > healthInterval && sm.ctx.cfg.CheckingHealth {
 		sm.ctx.bus.publish(healthCheckDueEvent{})
-		sm.ctx.cfg.LastHealthCheck = event.Time
+		sm.currentState.(stateWithHealth).setLastHealthCheck(event.Time)
 	}
 }
 

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -491,49 +491,6 @@ func TestHandleTimeEvent(t *testing.T) {
 			},
 		},
 		{
-			desc:           "vidforwardPermanentLive with health check due",
-			initialState:   newVidforwardPermanentLive(),
-			event:          timeEvent{now.Add(70 * time.Minute)}, // 10 minutes after cfg.Start for health check
-			expectedEvents: []event{timeEvent{}, healthCheckDueEvent{}},
-			expectedState:  newVidforwardPermanentLive(), // state shouldn't change in this scenario
-			cfg: &BroadcastConfig{
-				Start:           now,
-				End:             now.Add(2 * time.Hour),
-				CheckingHealth:  true,
-				LastHealthCheck: now,
-				LastStatusCheck: now.Add(70 * time.Minute),
-				LastChatMsg:     now.Add(70 * time.Minute),
-			},
-		},
-		{
-			desc:           "vidforwardPermanentLive with status check due",
-			initialState:   newVidforwardPermanentLive(),
-			event:          timeEvent{now.Add(80 * time.Minute)}, // 10 minutes after cfg.Start for status check
-			expectedEvents: []event{timeEvent{}, statusCheckDueEvent{}},
-			expectedState:  newVidforwardPermanentLive(), // state shouldn't change in this scenario
-			cfg: &BroadcastConfig{
-				Start:           now,
-				End:             now.Add(2 * time.Hour),
-				LastHealthCheck: now.Add(70 * time.Minute),
-				LastStatusCheck: now,
-				LastChatMsg:     now.Add(70 * time.Minute),
-			},
-		},
-		{
-			desc:           "vidforwardPermanentLive with chat message due",
-			initialState:   newVidforwardPermanentLive(),
-			event:          timeEvent{now.Add(40 * time.Minute)}, // 10 minutes after cfg.Start for chat message
-			expectedEvents: []event{timeEvent{}, chatMessageDueEvent{}},
-			expectedState:  newVidforwardPermanentLive(), // state shouldn't change in this scenario
-			cfg: &BroadcastConfig{
-				Start:           now,
-				End:             now.Add(2 * time.Hour),
-				LastHealthCheck: now.Add(40 * time.Minute),
-				LastStatusCheck: now.Add(40 * time.Minute),
-				LastChatMsg:     now,
-			},
-		},
-		{
 			desc:           "vidforwardPermanentStarting timed out",
 			initialState:   &vidforwardPermanentStarting{broadcastContext: bCtx, LastEntered: now},
 			event:          timeEvent{now.Add(6 * time.Minute)},

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -380,7 +380,7 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 		},
 		{
 			desc: "vidforwardSecondaryLive",
-			s:    &vidforwardSecondaryLive{ctx},
+			s:    &vidforwardSecondaryLive{broadcastContext: ctx},
 			equal: func(a, b state) bool {
 				return true
 			},
@@ -408,7 +408,7 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 		},
 		{
 			desc: "directLive",
-			s:    &directLive{ctx},
+			s:    &directLive{broadcastContext: ctx},
 			equal: func(a, b state) bool {
 				return true
 			},

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.1.3"
+	version            = "v0.1.4"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This change performs some cleaning up of the BroadcastConfig struct. We remove some fields that are unused i.e. StartTime, EndTime, CamOn and CamOff, and also relocate LastStatusCheck, LastChatMsg and LastHealthCheck, given that these are state specific and can be part of the state data. Moving the lastBlah states was most easily done by embedding a couple of structs with common fields into states that require these, and have these implement an interface to allow access of these fields.