### PR TITLE
Added --filestore command line flag to specify file store path

### DIFF
--- a/cmd/datablue/main.go
+++ b/cmd/datablue/main.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	version   = "v0.2.0"
+	version   = "v0.2.1"
 	projectID = "datablue"
 )
 
@@ -46,10 +46,11 @@ var (
 	settingsStore datastore.Store
 	debug         bool
 	standalone    bool
+	storePath     string
 )
 
 func main() {
-	defaultPort := 8080
+	defaultPort := 8083
 	v := os.Getenv("PORT")
 	if v != "" {
 		i, err := strconv.Atoi(v)
@@ -64,6 +65,7 @@ func main() {
 	flag.BoolVar(&standalone, "standalone", false, "Run in standalone mode.")
 	flag.StringVar(&host, "host", "localhost", "Host we run on in standalone mode")
 	flag.IntVar(&port, "port", defaultPort, "Port we listen on in standalone mode")
+	flag.StringVar(&storePath, "filestore", "store", "File store path")
 	flag.Parse()
 
 	// Perform one-time setup.
@@ -117,7 +119,7 @@ func setup(ctx context.Context) {
 	var err error
 	if standalone {
 		log.Printf("Running in standalone mode")
-		mediaStore, err = datastore.NewStore(ctx, "file", "datablue", "store")
+		mediaStore, err = datastore.NewStore(ctx, "file", "vidgrind", storePath)
 		if err == nil {
 			settingsStore = mediaStore
 			err = setupLocal(ctx, settingsStore)

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.21.2"
+	version     = "v0.21.3"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"
@@ -123,6 +123,7 @@ var (
 	standalone    bool
 	auth          *gauth.UserAuth
 	tvURL         = tvServiceURL
+	storePath     string
 )
 
 var (
@@ -180,6 +181,7 @@ func main() {
 	flag.IntVar(&port, "port", defaultPort, "Port we listen on in standalone mode")
 	flag.StringVar(&cronURL, "cronurl", cronServiceURL, "Cron service URL")
 	flag.StringVar(&tvURL, "tvurl", tvServiceURL, "TV service URL")
+	flag.StringVar(&storePath, "filestore", "store", "File store path")
 	flag.Parse()
 
 	// Perform one-time setup or bail.
@@ -286,7 +288,7 @@ func setup(ctx context.Context) {
 	var err error
 	if standalone {
 		log.Printf("Running in standalone mode")
-		mediaStore, err = datastore.NewStore(ctx, "file", "vidgrind", "store")
+		mediaStore, err = datastore.NewStore(ctx, "file", "vidgrind", storePath)
 		if err == nil {
 			settingsStore = mediaStore
 			err = setupLocal(ctx, settingsStore)

--- a/cmd/oceancenter/main.go
+++ b/cmd/oceancenter/main.go
@@ -51,7 +51,7 @@ import (
 // Project constants.
 const (
 	projectID = "oceancenter"
-	version   = "v0.2.0"
+	version   = "v0.2.1"
 )
 
 // Site/device defaults.
@@ -88,13 +88,14 @@ type service struct {
 	standalone    bool
 	notifier      notify.Notifier
 	totpSecret    []byte
+	storePath     string
 }
 
 // app is an instance of our service.
 var app *service = &service{}
 
 func main() {
-	defaultPort := 8083
+	defaultPort := 8084
 	v := os.Getenv("PORT")
 	if v != "" {
 		i, err := strconv.Atoi(v)
@@ -109,6 +110,7 @@ func main() {
 	flag.BoolVar(&app.standalone, "standalone", false, "Run in standalone mode.")
 	flag.StringVar(&host, "host", "localhost", "Host we run on in standalone mode")
 	flag.IntVar(&port, "port", defaultPort, "Port we listen on in standalone mode")
+	flag.StringVar(&app.storePath, "filestore", "store", "File store path")
 	flag.Parse()
 
 	// Perform one-time setup or bail.
@@ -146,7 +148,7 @@ func (svc *service) setup(ctx context.Context) {
 	var err error
 	if svc.standalone {
 		log.Printf("Running in standalone mode")
-		svc.settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", "store")
+		svc.settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", svc.storePath)
 	} else {
 		log.Printf("Running in App Engine mode")
 		svc.settingsStore, err = datastore.NewStore(ctx, "cloud", "netreceiver", "")

--- a/cmd/oceancron/main.go
+++ b/cmd/oceancron/main.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	projectID          = "oceancron"
-	version            = "v0.1.1"
+	version            = "v0.1.2"
 	cronServiceURL     = "https://oceancron.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 )
@@ -54,6 +54,7 @@ var (
 	cronScheduler *scheduler
 	cronSecret    []byte
 	notifier      notify.Notifier
+	storePath     string
 )
 
 func main() {
@@ -72,6 +73,7 @@ func main() {
 	flag.BoolVar(&standalone, "standalone", false, "Run in standalone mode.")
 	flag.StringVar(&host, "host", "localhost", "Host we run on in standalone mode")
 	flag.IntVar(&port, "port", defaultPort, "Port we listen on in standalone mode")
+	flag.StringVar(&storePath, "filestore", "store", "File store path")
 	flag.Parse()
 
 	// Perform one-time setup or bail.
@@ -112,7 +114,7 @@ func setup(ctx context.Context) {
 	var err error
 	if standalone {
 		log.Printf("Running in standalone mode")
-		settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", "store")
+		settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", storePath)
 	} else {
 		log.Printf("Running in App Engine mode")
 		settingsStore, err = datastore.NewStore(ctx, "cloud", "netreceiver", "")

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.1.1"
+	version            = "v0.1.2"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.
@@ -57,6 +57,7 @@ var (
 	standalone    bool
 	notifier      notify.Notifier
 	cronSecret    []byte
+	storePath     string
 )
 
 func main() {
@@ -75,6 +76,7 @@ func main() {
 	flag.BoolVar(&standalone, "standalone", false, "Run in standalone mode.")
 	flag.StringVar(&host, "host", "localhost", "Host we run on in standalone mode")
 	flag.IntVar(&port, "port", defaultPort, "Port we listen on in standalone mode")
+	flag.StringVar(&storePath, "filestore", "store", "File store path")
 	flag.Parse()
 
 	// Perform one-time setup or bail.
@@ -114,7 +116,7 @@ func setup(ctx context.Context) {
 	var err error
 	if standalone {
 		log.Printf("Running in standalone mode")
-		settingsStore, err = datastore.NewStore(ctx, "file", projectID, "store")
+		settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", storePath)
 		if err != nil {
 			mediaStore = settingsStore
 		}


### PR DESCRIPTION
Also ensured that all of the default ports  in standalone mode are different:

- oceanbench 8080
- oceancron 8081
- oceantv 8082
- datablue 8083
- oceancenter 8084

Implements Issue #115 
