### PR TITLE
Device status var

### DIFF
--- a/model/device.go
+++ b/model/device.go
@@ -40,6 +40,7 @@ import (
 const typeDevice = "Device"
 
 // Device state statuses.
+// Keep StatusText and IsValidStatus is sync with this list.
 const (
 	DeviceStatusOK = iota
 	DeviceStatusUpdate
@@ -430,4 +431,14 @@ func DeviceIsUp(ctx context.Context, store datastore.Store, mac string) (bool, e
 		return true, nil
 	}
 	return false, nil
+}
+
+// IsValidStatus returns true if the supplied number is a valid status, or false otherwise.
+func IsValidStatus(n int64) bool {
+	switch n {
+	case DeviceStatusOK, DeviceStatusUpdate, DeviceStatusReboot, DeviceStatusDebug, DeviceStatusUpgrade, DeviceStatusAlarm, DeviceStatusTest, DeviceStatusShutdown:
+		return true
+	default:
+		return false
+	}
 }

--- a/model/device.go
+++ b/model/device.go
@@ -50,6 +50,7 @@ const (
 	DeviceStatusAlarm
 	DeviceStatusTest
 	DeviceStatusShutdown
+	DeviceStatusEnd
 )
 
 var (
@@ -435,10 +436,8 @@ func DeviceIsUp(ctx context.Context, store datastore.Store, mac string) (bool, e
 
 // IsValidStatus returns true if the supplied number is a valid status, or false otherwise.
 func IsValidStatus(n int64) bool {
-	switch n {
-	case DeviceStatusOK, DeviceStatusUpdate, DeviceStatusReboot, DeviceStatusDebug, DeviceStatusUpgrade, DeviceStatusAlarm, DeviceStatusTest, DeviceStatusShutdown:
-		return true
-	default:
-		return false
-	}
+	if 0 <= n && n < DeviceStatusEnd {
+        return true
+    }
+    return false
 }


### PR DESCRIPTION
With this change, it is possible to programmatically set the device status by setting a variable called `status` to a value between 0 and 7 (as defined in `device.go`).

This will be most useful in conjunction with cron jobs. For example, to force a device to reboot, set the variable `<device.mac-address>.status` to the value `2`.



