### PR TITLE
Improve testing facilities

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -241,7 +241,7 @@ func performChecksInternalThroughStateMachine(
 	// classic func(string, ...interface{}) signature.
 	// This can be used by a lot of the components here.
 	log := func(msg string, args ...interface{}) {
-		logForBroadcast(cfg, msg, args...)
+		logForBroadcast(cfg, log.Println, msg, args...)
 	}
 
 	// Create the youtube broadcast service. This will deal with the YouTube API bindings.
@@ -338,7 +338,7 @@ func performChecksInternalThroughStateMachine(
 	bus.subscribe(healthStatusChatHandler)
 
 	// This context will be used by the state machines for access to our bits and bobs.
-	broadcastContext := &broadcastContext{cfg, man, store, svc, NewVidforwardService(log), bus, &revidCameraClient{}}
+	broadcastContext := &broadcastContext{cfg, man, store, svc, NewVidforwardService(log), bus, &revidCameraClient{}, nil, nil}
 
 	// The hardware state machine will be responsible for the external camera hardware
 	// state.

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -13,15 +13,15 @@ func TestGetHardwareStateStorage(t *testing.T) {
 	}{
 		{"test hardware off", newHardwareOff()},
 		{"test hardware on", newHardwareOn()},
-		{"test hardware starting", newHardwareStarting(&broadcastContext{camera: &dummyHardwareManager{}})},
-		{"test hardware stopping", newHardwareStopping(&broadcastContext{})},
-		{"test hardware restarting", newHardwareRestarting(&broadcastContext{})},
+		{"test hardware starting", newHardwareStarting(&broadcastContext{camera: &dummyHardwareManager{}, logOutput: t.Log, notifier: newMockNotifier()})},
+		{"test hardware stopping", newHardwareStopping(minimalMockBroadcastContext(t))},
+		{"test hardware restarting", newHardwareRestarting(minimalMockBroadcastContext(t))},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stateStr := hardwareStateToString(tt.initialState)
-			gotState := getHardwareState(&broadcastContext{cfg: &BroadcastConfig{HardwareState: stateStr}})
+			gotState := getHardwareState(&broadcastContext{cfg: &BroadcastConfig{HardwareState: stateStr}, logOutput: t.Log, notifier: newMockNotifier()})
 			if reflect.TypeOf(gotState) != reflect.TypeOf(tt.initialState) {
 				t.Errorf("expected state %v, got %v", tt.initialState, gotState)
 			}
@@ -30,11 +30,7 @@ func TestGetHardwareStateStorage(t *testing.T) {
 }
 
 func TestHandleHardwareStoppedEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	tests := []struct {
 		desc          string
@@ -71,7 +67,7 @@ func TestHandleHardwareStoppedEvent(t *testing.T) {
 
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
-			bCtx.man = NewDummyManager(t, bCtx.cfg)
+			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -90,11 +86,7 @@ func TestHandleHardwareStoppedEvent(t *testing.T) {
 }
 
 func TestHandleHardwareStopFailedEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	tests := []struct {
 		desc          string
@@ -126,7 +118,7 @@ func TestHandleHardwareStopFailedEvent(t *testing.T) {
 
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
-			bCtx.man = NewDummyManager(t, bCtx.cfg)
+			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -145,11 +137,7 @@ func TestHandleHardwareStopFailedEvent(t *testing.T) {
 }
 
 func TestHandleHardwareStartFailedEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	tests := []struct {
 		desc          string
@@ -183,7 +171,7 @@ func TestHandleHardwareStartFailedEvent(t *testing.T) {
 
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
-			bCtx.man = NewDummyManager(t, bCtx.cfg)
+			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -202,11 +190,7 @@ func TestHandleHardwareStartFailedEvent(t *testing.T) {
 }
 
 func TestHandleHardwareStartedEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	tests := []struct {
 		desc          string
@@ -240,7 +224,7 @@ func TestHandleHardwareStartedEvent(t *testing.T) {
 
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
-			bCtx.man = NewDummyManager(t, bCtx.cfg)
+			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)
@@ -259,11 +243,7 @@ func TestHandleHardwareStartedEvent(t *testing.T) {
 }
 
 func TestHandleHardwareResetRequestEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{hardwareHealthy: true},
-	}
+	bCtx := standardMockBroadcastContext(t, true)
 
 	tests := []struct {
 		desc          string
@@ -305,7 +285,7 @@ func TestHandleHardwareResetRequestEvent(t *testing.T) {
 
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = &BroadcastConfig{}
-			bCtx.man = NewDummyManager(t, bCtx.cfg)
+			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
 			sm := newHardwareStateMachine(bCtx)

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -10,11 +10,7 @@ import (
 func TestHandleTimeEvent(t *testing.T) {
 	// Mock eventBus to capture published events
 
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 	tests := []struct {
@@ -551,7 +547,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 			bus.subscribe(handler)
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -608,11 +604,7 @@ func TestHandleTimeEvent(t *testing.T) {
 func TestHandleStartFailedEvent(t *testing.T) {
 	// Mock eventBus to capture published events
 
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 
@@ -656,7 +648,7 @@ func TestHandleStartFailedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -684,11 +676,7 @@ func TestHandleStartFailedEvent(t *testing.T) {
 func TestHandleBadHealthEvent(t *testing.T) {
 	// Mock eventBus to capture published events
 
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 
@@ -777,7 +765,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -805,11 +793,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 func TestHandleGoodHealthEvent(t *testing.T) {
 	// Mock eventBus to capture published events
 
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 
@@ -898,7 +882,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -924,11 +908,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 }
 
 func TestHandleFinishEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 	tests := []struct {
@@ -1001,7 +981,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1027,11 +1007,7 @@ func TestHandleFinishEvent(t *testing.T) {
 }
 
 func TestHandleStartEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 	tests := []struct {
@@ -1110,7 +1086,7 @@ func TestHandleStartEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1136,11 +1112,7 @@ func TestHandleStartEvent(t *testing.T) {
 }
 
 func TestHandleStartedEvent(t *testing.T) {
-	bCtx := &broadcastContext{
-		store:  &dummyStore{},
-		svc:    &dummyService{},
-		camera: &dummyHardwareManager{},
-	}
+	bCtx := standardMockBroadcastContext(t, false)
 
 	now := time.Now()
 	tests := []struct {
@@ -1183,7 +1155,7 @@ func TestHandleStartedEvent(t *testing.T) {
 			ctx, _ := context.WithCancel(context.Background())
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1210,8 +1182,10 @@ func TestHandleStartedEvent(t *testing.T) {
 
 func TestBroadcastStart(t *testing.T) {
 	bCtx := &broadcastContext{
-		store: &dummyStore{},
-		svc:   &dummyService{},
+		store:     &dummyStore{},
+		svc:       &dummyService{},
+		logOutput: t.Log,
+		notifier:  newMockNotifier(),
 	}
 
 	now := time.Now()
@@ -1282,7 +1256,7 @@ func TestBroadcastStart(t *testing.T) {
 				},
 			)
 
-			bCtx.man = NewDummyManager(t, tt.cfg)
+			bCtx.man = newDummyManager(t, tt.cfg)
 			bCtx.camera = newDummyHardwareManager(tt.hardwareHealthy)
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -204,7 +204,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 }
 
 func TestBroadcastCfgToState(t *testing.T) {
-	ctx := &broadcastContext{}
+	ctx := minimalMockBroadcastContext(t)
 	tests := []struct {
 		name string
 		cfg  BroadcastConfig
@@ -311,7 +311,7 @@ func TestBroadcastCfgToState(t *testing.T) {
 }
 
 func TestStateMarshalUnmarshal(t *testing.T) {
-	ctx := &broadcastContext{}
+	ctx := minimalMockBroadcastContext(t)
 	tests := []struct {
 		desc  string
 		s     state
@@ -440,7 +440,7 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			var cfg BroadcastConfig
 			updateBroadcastBasedOnState(tt.s, &cfg)
-			state := broadcastCfgToState(&broadcastContext{cfg: &cfg})
+			state := broadcastCfgToState(&broadcastContext{cfg: &cfg, logOutput: t.Log, notifier: newMockNotifier()})
 			if !tt.equal(tt.s, state) {
 				t.Errorf("expected state %v, got %v", tt.s, state)
 			}

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -26,12 +26,14 @@ LICENSE
 package main
 
 import (
+	"fmt"
 	"io"
-	"log"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/notify"
 	"github.com/ausocean/openfish/datastore"
 )
 
@@ -60,12 +62,11 @@ type dummyManager struct {
 	cfg                                                                *Cfg
 	startDone                                                          chan struct{}
 	saved, started, stopped, healthHandled, statusHandled, chatHandled bool
-	savedCfgs                                                          map[string]*Cfg
 	t                                                                  *testing.T
 }
 
-func NewDummyManager(t *testing.T, cfg *Cfg) *dummyManager {
-	log.Println("creating dummy manager")
+func newDummyManager(t *testing.T, cfg *Cfg) *dummyManager {
+	t.Log("creating dummy manager")
 	return &dummyManager{
 		t:         t,
 		startDone: make(chan struct{}),
@@ -110,11 +111,9 @@ func (d *dummyManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc Svc) er
 }
 func (d *dummyManager) Save(ctx Ctx, update func(*BroadcastConfig)) error {
 	d.saved = true
-	d.logf("saving broadcast: %s", d.cfg.Name)
-	if d.savedCfgs == nil {
-		d.savedCfgs = make(map[string]*Cfg)
+	if update != nil {
+		update(d.cfg)
 	}
-	d.savedCfgs[d.cfg.Name] = d.cfg
 	return nil
 }
 func (d *dummyManager) HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc Svc, call BroadcastCallback) error {
@@ -142,6 +141,8 @@ func (d *dummyManager) logf(format string, args ...interface{}) {
 // It basically does nothing and is used to test the broadcast functions.
 type dummyStore struct{}
 
+func newDummyStore() *dummyStore { return &dummyStore{} }
+
 func (d *dummyStore) IDKey(kind string, id int64) *Key       { return nil }
 func (d *dummyStore) NameKey(kind, name string) *Key         { return nil }
 func (d *dummyStore) IncompleteKey(kind string) *Key         { return nil }
@@ -161,6 +162,8 @@ func (d *dummyStore) Delete(ctx Ctx, key *Key) error                        { re
 // dummyService is a dummy implementation of the BroadcastService interface.
 // It does nothing and is used to test the broadcast functions.
 type dummyService struct{}
+
+func newDummyService() *dummyService { return &dummyService{} }
 
 func (d *dummyService) CreateBroadcast(
 	ctx Ctx,
@@ -197,10 +200,21 @@ type dummyHardwareManager struct {
 	hardwareHealthy bool
 	startCalled     bool
 	stopCalled      bool
+	checkMAC        bool
 }
 
-func newDummyHardwareManager(healthy bool) *dummyHardwareManager {
-	return &dummyHardwareManager{hardwareHealthy: healthy}
+func withMACSanitisation() func(*dummyHardwareManager) {
+	return func(h *dummyHardwareManager) {
+		h.checkMAC = true
+	}
+}
+
+func newDummyHardwareManager(healthy bool, options ...func(*dummyHardwareManager)) *dummyHardwareManager {
+	m := &dummyHardwareManager{hardwareHealthy: healthy}
+	for _, option := range options {
+		option(m)
+	}
+	return m
 }
 func (h *dummyHardwareManager) start(ctx *broadcastContext) {
 	h.startCalled = true
@@ -215,4 +229,157 @@ func (h *dummyHardwareManager) publishEventIfStatus(event event, status bool, ma
 	} else if status == false {
 		publish(event)
 	}
+}
+
+// mockNotifier to implement Notifier interface.
+type mockNotifier struct {
+	// Holds sent messages for a site and kind.
+	sent map[int64]map[notify.Kind][]string
+}
+
+func newMockNotifier() *mockNotifier {
+	return &mockNotifier{sent: make(map[int64]map[notify.Kind][]string)}
+}
+
+func (m *mockNotifier) Send(ctx Ctx, skey int64, kind notify.Kind, msg string) error {
+	if m.sent[skey] == nil {
+		m.sent[skey] = make(map[notify.Kind][]string)
+	}
+	m.sent[skey][kind] = append(m.sent[skey][kind], msg)
+	return nil
+}
+
+// checkNotifications checks that the messages contained in want were sent (contained in m.sent).
+// The order of want messages in sent messages is not checked.
+func (m *mockNotifier) checkNotifications(want map[int64]map[notify.Kind][]string) error {
+	for skey, kinds := range want {
+		for kind, msgs := range kinds {
+			if len(m.sent[skey][kind]) != len(msgs) {
+				return fmt.Errorf(
+					"expected %d messages for site %d and kind %s, got %d. \nGot messages: %v, \nwant messages: %v",
+					len(msgs),
+					skey,
+					kind,
+					len(m.sent[skey][kind]),
+					m.sent[skey][kind],
+					msgs,
+				)
+			}
+			for i, msg := range msgs {
+				if !strings.Contains(msg, m.sent[skey][kind][i]) {
+					return fmt.Errorf("expected message %s for site %d and kind %s, got %s", msg, skey, kind, m.sent[skey][kind][i])
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m *mockNotifier) Recipients(skey int64, k notify.Kind) ([]string, time.Duration, error) {
+	return []string{}, 0, nil
+}
+
+// factory to create a broadcastContext with mock facilities.
+func standardMockBroadcastContext(t *testing.T, hardwareHealthy bool) *broadcastContext {
+	return &broadcastContext{
+		store:     &dummyStore{},
+		svc:       &dummyService{},
+		camera:    &dummyHardwareManager{hardwareHealthy: hardwareHealthy},
+		notifier:  newMockNotifier(),
+		logOutput: t.Log,
+	}
+}
+
+// factory to create a broadcastContext with minimal mock facilities.
+func minimalMockBroadcastContext(t *testing.T) *broadcastContext {
+	return &broadcastContext{
+		logOutput: t.Log,
+		notifier:  newMockNotifier(),
+	}
+}
+
+type logRecorder struct {
+	t    *testing.T
+	logs []string
+}
+
+func newLogRecorder(t *testing.T) *logRecorder {
+	return &logRecorder{t: t}
+}
+
+func (r *logRecorder) log(v ...any) {
+	r.t.Log(v...)
+	r.logs = append(r.logs, fmt.Sprintln(v...))
+}
+
+// Note this only checks that want are in the logs, not that they are the only logs.
+// We also don't care about the order of the logs.
+func (r *logRecorder) checkLogs(want []string) error {
+	for _, w := range want {
+		found := false
+		for _, l := range r.logs {
+			if strings.Contains(l, w) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("expected log not found: %s", w)
+		}
+	}
+	return nil
+}
+
+// mockEventBus is a simple event bus that stores events when the context is
+// cancelled.
+type mockEventBus struct {
+	disabled     bool
+	handlers     []handler
+	log          func(string, ...interface{})
+	eventHistory []event
+}
+
+// newmockEventBus creates a new mockEventBus.
+func newMockEventBus(log func(string, ...interface{})) *mockEventBus {
+	return &mockEventBus{log: log}
+}
+
+func (bus *mockEventBus) subscribe(handler handler) { bus.handlers = append(bus.handlers, handler) }
+
+func (bus *mockEventBus) publish(event event) {
+	bus.eventHistory = append(bus.eventHistory, event)
+	bus.log("publishing event: %s", event.String())
+
+	for _, handler := range bus.handlers {
+		err := handler(event)
+		if err != nil {
+			bus.log("error handling event: %s: %v", event.String(), err)
+		}
+	}
+}
+
+func (bus *mockEventBus) checkEvents(want []event) error {
+	fmtError := func(want, got []event) error {
+		return fmt.Errorf(
+			"expected %d events, got %d, expected: %v, got: %v",
+			len(want),
+			len(got),
+			eventsToStringSlice(want),
+			eventsToStringSlice(got),
+		)
+	}
+
+	// Basic check on length of expected and actual events
+	if len(bus.eventHistory) != len(want) {
+		return fmtError(want, bus.eventHistory)
+	}
+
+	// Check each published event matches the events we expected to see.
+	for i, e := range bus.eventHistory {
+		// Assuming you have an eventToString function
+		if e.String() != want[i].String() {
+			return fmtError(want, bus.eventHistory)
+		}
+	}
+	return nil
 }

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.1.5"
+	version            = "v0.1.6"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.
@@ -210,7 +210,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log := func(msg string, args ...interface{}) {
-		logForBroadcast(&cfg, msg, args...)
+		logForBroadcast(&cfg, log.Println, msg, args...)
 	}
 
 	// Use the broadcast manager to save the broadcast.

--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -31,7 +31,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -43,8 +42,8 @@ import (
 
 // logForBroadcast logs a message with the broadcast name and ID.
 // This is useful to keep track of logs for different broadcasts.
-func logForBroadcast(cfg *BroadcastConfig, msg string, args ...interface{}) {
-	log.Println(fmtForBroadcastLog(cfg, msg, args...))
+func logForBroadcast(cfg *BroadcastConfig, output func(v ...any), msg string, args ...interface{}) {
+	output(fmtForBroadcastLog(cfg, msg, args...))
 }
 
 func fmtForBroadcastLog(cfg *BroadcastConfig, msg string, args ...interface{}) string {


### PR DESCRIPTION
Depends on PR #242 

This change aims to improve aspects of the broadcast testing facilities.

To start, we're adding logOutput and notifier fields to the broadcastContext. This will allow us to specify different log and notification implementations for the context. For example t.Log and a mock notifier implementation when testing.

We're also now providing some factories for common broadcast context arrangements.

We've added mock eventBus and notifier implementations, and a log output implementation, logRecorder, which will allow us to validate logging.

Some other smaller changes:
* unexporting the dummyManager
* modifying dummyManager.Save method to better reflect our real implementation.
* providing constructors for the dummyService and dummyStore implementations