### PR TITLE
Start adding configuration sanitisation

### DIFF
--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -89,6 +89,11 @@ type fixFailureEvent struct{}
 
 func (e fixFailureEvent) String() string { return "fixFailureEvent" }
 
+type invalidConfigurationEvent struct{ desc string }
+
+func (e invalidConfigurationEvent) String() string { return "invalidConfigurationEvent" }
+func (e invalidConfigurationEvent) Error() string  { return e.desc }
+
 type handler func(event) error
 
 type eventBus interface {

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -320,6 +320,11 @@ func (c *revidCameraClient) stop(ctx *broadcastContext) {
 }
 
 func (c *revidCameraClient) publishEventIfStatus(event event, status bool, mac int64, store Store, log func(string, ...interface{}), publish func(event event)) {
+	if mac == 0 {
+		log("camera is not set in configuration")
+		publish(invalidConfigurationEvent{"camera mac is empty"})
+		return
+	}
 	log("checking status of device with mac: %d", mac)
 	alive, err := model.DeviceIsUp(context.Background(), store, model.MacDecode(mac))
 	if err != nil {

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -150,20 +150,22 @@ func (m *OceanBroadcastManager) StartBroadcast(
 		}
 	}
 
-	err := svc.StartBroadcast(
-		cfg.Name,
-		cfg.ID,
-		cfg.SID,
-		saveLinkFunc(),
-		func() error { return nil }, // This is now handled by the hardware state machine.
-		func() error { return nil }, // This is now handled by the hardware state machine.
-		opsHealthNotifyFunc(ctx, cfg),
-		func() error { return nil }) // This is now handled by the hardware state machine.
-	if err != nil {
-		onFailure(fmt.Errorf("could not start broadcast: %w", err))
-		return
-	}
-	onSuccess()
+	go func() {
+		err := svc.StartBroadcast(
+			cfg.Name,
+			cfg.ID,
+			cfg.SID,
+			saveLinkFunc(),
+			func() error { return nil }, // This is now handled by the hardware state machine.
+			func() error { return nil }, // This is now handled by the hardware state machine.
+			opsHealthNotifyFunc(ctx, cfg),
+			func() error { return nil }) // This is now handled by the hardware state machine.
+		if err != nil {
+			onFailure(fmt.Errorf("could not start broadcast: %w", err))
+			return
+		}
+		onSuccess()
+	}()
 }
 
 // StopBroadcast stops a broadcast using the youtube live streaming API.

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -37,11 +37,12 @@ func (ctx *broadcastContext) log(msg string, args ...interface{}) {
 }
 
 const (
-	broadcastGeneric   notify.Kind = "broadcast-generic"   // Problems where cause is unknown.
-	broadcastForwarder notify.Kind = "broadcast-forwarder" // Problems related to out forwarding service i.e. can't stream slate.
-	broadcastHardware  notify.Kind = "broadcast-hardware"  // Problems related to streaming hardware i.e. controllers and cameras.
-	broadcastNetwork   notify.Kind = "broadcast-network"   // Problems related to bad bandwidth, generally indicated by bad health events.
-	broadcastSoftware  notify.Kind = "broadcast-software"  // Problems related to the functioning of our broadcast software.
+	broadcastGeneric       notify.Kind = "broadcast-generic"       // Problems where cause is unknown.
+	broadcastForwarder     notify.Kind = "broadcast-forwarder"     // Problems related to our forwarding service i.e. can't stream slate.
+	broadcastHardware      notify.Kind = "broadcast-hardware"      // Problems related to streaming hardware i.e. controllers and cameras.
+	broadcastNetwork       notify.Kind = "broadcast-network"       // Problems related to bad bandwidth, generally indicated by bad health events.
+	broadcastSoftware      notify.Kind = "broadcast-software"      // Problems related to the functioning of our broadcast software.
+	broadcastConfiguration notify.Kind = "broadcast-configuration" // Problems related to the configuration of the broadcast.
 )
 
 func (ctx *broadcastContext) logAndNotify(kind notify.Kind, msg string, args ...interface{}) {
@@ -692,7 +693,7 @@ func startBroadcast(ctx *broadcastContext, cfg *BroadcastConfig) {
 		}
 	}
 
-	go ctx.man.StartBroadcast(
+	ctx.man.StartBroadcast(
 		context.Background(),
 		cfg,
 		ctx.store,

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -223,6 +223,11 @@ func (h *dummyHardwareManager) stop(ctx *broadcastContext) {
 	h.stopCalled = true
 }
 func (h *dummyHardwareManager) publishEventIfStatus(event event, status bool, mac int64, store Store, log func(format string, args ...interface{}), publish func(event event)) {
+	if h.checkMAC && mac == 0 {
+		log("camera is not set in configuration")
+		publish(invalidConfigurationEvent{"camera mac is empty"})
+		return
+	}
 	log("status is %v, hardware is healthy %v", status, h.hardwareHealthy)
 	if status == true && h.hardwareHealthy {
 		publish(event)

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.1.7"
+	version            = "v0.1.8"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
Depends on PR #244 

We're starting with checking the hardware is defined for a given broadcast, otherwise we disable. We're doing this with an invalidConfigurationEvent. This can be used for various configuration issues, and for convenience also impelements the error interface.

We're adding a basic test case that highlights the ease of integration type testing using the new broadcastSystem abstraction added in the prior change.