### PR TITLE
bench: send user a message for saves and deletes on broadcast page.

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -304,6 +304,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var msg string
 	switch action {
 	case broadcastToken:
 		tokenURI := utils.TokenURIFromAccount(profile.Email)
@@ -320,6 +321,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not save broadcast: %v", err)
 			return
 		}
+		msg = "channel authenticated successfully"
 	case broadcastSave:
 		// If we haven't just generated a token we should keep the same account
 		// that the config previously had.
@@ -333,7 +335,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not save broadcast: %v", err)
 			return
 		}
-		req.commonData.Msg = "broadcast saved successfully"
+		msg = "broadcast saved successfully"
 
 		// Ensure that the CheckBroadcast cron exists.
 		c := &model.Cron{Skey: cfg.SKey, ID: "Broadcast Check", TOD: "* * * * *", Action: "rpc", Var: tvURL + "/checkbroadcasts", Enabled: true}
@@ -349,7 +351,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not delete broadcast: %v", err)
 			return
 		}
-		req.commonData.Msg = "broadcast deleted successfully"
+		msg = "broadcast deleted successfully"
 
 	case vidforwardSlateUpdate:
 		const fieldName = "slate-file"
@@ -365,9 +367,10 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			return
 
 		}
+		msg = "slate uploaded successfully"
 	}
 
-	writeTemplate(w, r, "broadcast.html", &req, "")
+	writeTemplate(w, r, "broadcast.html", &req, msg)
 }
 
 func stringToAction(s string, req broadcastRequest) Action {

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -333,6 +333,8 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not save broadcast: %v", err)
 			return
 		}
+		req.commonData.Msg = "broadcast saved successfully"
+
 		// Ensure that the CheckBroadcast cron exists.
 		c := &model.Cron{Skey: cfg.SKey, ID: "Broadcast Check", TOD: "* * * * *", Action: "rpc", Var: tvURL + "/checkbroadcasts", Enabled: true}
 		err = model.PutCron(context.Background(), settingsStore, c)
@@ -347,6 +349,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not delete broadcast: %v", err)
 			return
 		}
+		req.commonData.Msg = "broadcast deleted successfully"
 
 	case vidforwardSlateUpdate:
 		const fieldName = "slate-file"

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.21.5"
+	version     = "v0.21.8"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This was done because it is hard to tell is an operation has been performed successfully.

Closes issue #253 

messages have also been added for slate upload and authentication of a new channel too.