### PR TITLE
Add RecoveryCallbackServeMux

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"net/http"
+)
+
 // TokenURIFromAccount forms a Google Cloud Storage URI for a YouTube token
 // based on the provided account. If the account is empty, it's assumed that
 // the legacy token is being used. Otherwise, the account is used to form the
@@ -20,4 +24,37 @@ func TokenURIFromAccount(account string) string {
 	const tokenPostfix = ".youtube.token.json"
 
 	return bucket + account + tokenPostfix
+}
+
+// RecoveryCallbackServeMux extends the default http.ServeMux and accepts
+// a callback function to be called in case of handler panic recovery.
+type RecoveryCallbackServeMux struct {
+	*http.ServeMux
+	recover func(w http.ResponseWriter, err any)
+}
+
+// NewRecoveryCallbackServeMux creates a new RecoveryCallbackServeMux.
+// recover is the callback function to be called in case of handler panic recovery.
+func NewRecoveryCallbackServeMux(recover func(w http.ResponseWriter, err any)) *RecoveryCallbackServeMux {
+	return &RecoveryCallbackServeMux{http.NewServeMux(), recover}
+}
+
+// ServeHTTP applies the recovery middleware and serves the HTTP request.
+func (m *RecoveryCallbackServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			m.recover(w, err)
+		}
+	}()
+	m.ServeMux.ServeHTTP(w, r)
+}
+
+// Handle registers the handler for the given pattern.
+func (m *RecoveryCallbackServeMux) Handle(pattern string, handler http.Handler) {
+	m.ServeMux.Handle(pattern, handler)
+}
+
+// HandleFunc registers the handler function for the given pattern.
+func (m *RecoveryCallbackServeMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	m.ServeMux.HandleFunc(pattern, handler)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRecoveryCallbackServeMux(t *testing.T) {
+	var recoveredErr any
+
+	recoveryCallback := func(w http.ResponseWriter, err any) {
+		recoveredErr = err
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
+
+	mux := NewRecoveryCallbackServeMux(recoveryCallback)
+
+	// Add a handler that will panic
+	mux.HandleFunc("/panic", func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	// Create a test server
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Send a request to the /panic endpoint
+	resp, err := http.Get(fmt.Sprintf("%s/panic", server.URL))
+	if err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check we got internal server error, recover was called, and the error was as expected.
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status code 500, got %d", resp.StatusCode)
+	}
+	if recoveredErr == nil {
+		t.Fatal("expected panic to be recovered, but it was not")
+	}
+	if recoveredErr != "test panic" {
+		t.Fatalf("expected recovered error to be 'test panic', got %v", recoveredErr)
+	}
+}


### PR DESCRIPTION
closes #257 

This is a ServeMux that extends the http.ServeMux to allow the provision of custom handler panic recovery. This was motivated by the desire to have notification on recovery of handler panics so that things don't fail so silently.