### PR TITLE
TV: Use onFailureClosure for request limits (#222)

### DIFF
--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -121,7 +121,7 @@ func (m *OceanBroadcastManager) CreateBroadcast(
 		WithRateLimiter(limiter),
 	)
 	if err != nil {
-		return fmt.Errorf("could not create broadcast: %v, resp: %v", err, resp)
+		return fmt.Errorf("could not create broadcast: %w, resp: %v", err, resp)
 	}
 	err = m.Save(nil, func(_cfg *Cfg) { _cfg.ID = ids.BID; _cfg.SID = ids.SID; _cfg.CID = ids.CID; _cfg.RTMPKey = rtmpKey })
 	if err != nil {

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -670,8 +671,12 @@ func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *BroadcastConf
 		ctx.store,
 		ctx.svc,
 	)
+	if errors.Is(err, ErrRequestLimitExceeded) {
+		onFailureClosure(ctx, cfg, true)(fmt.Errorf("could not create broadcast: %w", err))
+		return
+	}
 	if err != nil {
-		onFailureClosure(ctx, cfg, false)(fmt.Errorf("could not create broadcast: %v", err))
+		onFailureClosure(ctx, cfg, false)(fmt.Errorf("could not create broadcast: %w", err))
 		return
 	}
 	if onCreation != nil {


### PR DESCRIPTION
When a ErrRequestLimitExceeded error is received from svc.CreateBroadcast we will use the disable on first failure bool in the failure closure to ensure the broadcast is disabled before making any additional calls to youtube (which will also be rate limited). This will prevent us from extending our broadcast down time by needlessly making blocked calls, adding to our rate limit.

closes #222 