### PR TITLE
ignore .git and .github folders

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,3 +1,5 @@
+.git/
+.github/
 # datablue
 cmd/datablue/.git
 cmd/datablue/.gitignore


### PR DESCRIPTION
This was done because they were increasing the size of gcloud deployments.