### PR TITLE
tv: check for youtube credentials env var in standalone

### DIFF
--- a/cmd/oceantv/broadcast/storage.go
+++ b/cmd/oceantv/broadcast/storage.go
@@ -130,14 +130,9 @@ func objTok(ctx context.Context, url string) (*oauth2.Token, error) {
 // fileTok extracts an oauth2.Token from a file with name specified by the given
 // URL.
 func fileTok(uri string) (*oauth2.Token, error) {
-	var name string
+	name := os.Getenv("YOUTUBE_API_CREDENTIALS")
 	var err error
-	if standalone {
-		name = os.Getenv("YOUTUBE_API_CREDENTIALS")
-		if name == "" {
-			return nil, fmt.Errorf("YOUTUBE_API_CREDENTIALS environment variable is not set for standalone: %w", err)
-		}
-	} else {
+	if name == "" {
 		_, name, err = googleStorageAddr(uri)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse uri: %w", err)

--- a/cmd/oceantv/broadcast/storage.go
+++ b/cmd/oceantv/broadcast/storage.go
@@ -130,9 +130,18 @@ func objTok(ctx context.Context, url string) (*oauth2.Token, error) {
 // fileTok extracts an oauth2.Token from a file with name specified by the given
 // URL.
 func fileTok(uri string) (*oauth2.Token, error) {
-	_, name, err := googleStorageAddr(uri)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse uri: %w", err)
+	var name string
+	var err error
+	if standalone {
+		name = os.Getenv("YOUTUBE_API_CREDENTIALS")
+		if name == "" {
+			return nil, fmt.Errorf("YOUTUBE_API_CREDENTIALS environment variable is not set for standalone: %w", err)
+		}
+	} else {
+		_, name, err = googleStorageAddr(uri)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse uri: %w", err)
+		}
 	}
 
 	f, err := os.Open(name)


### PR DESCRIPTION
This was done so we can stream to our youtube channel from our local machines.