### PR TITLE
Ensure that utils form is not resubmitted (#288)

### DIFF
--- a/cmd/datablue/handlers.go
+++ b/cmd/datablue/handlers.go
@@ -363,7 +363,7 @@ func processActuators(ctx context.Context, dev *model.Device, respMap map[string
 		// Actuator var names are relative to their device.
 		val, err := model.GetVariable(ctx, settingsStore, dev.Skey, dev.Hex()+"."+act.Var)
 		if err != nil {
-			return fmt.Errorf("failed to get actuator by %s.%s: %w", dev.Hex(), act.Pin, err)
+			return fmt.Errorf("failed to get actuator by %s.%s: %w", dev.Hex(), act.Var, err)
 		}
 
 		n, err := toInt(val.Value)

--- a/cmd/oceanbench/admin.go
+++ b/cmd/oceanbench/admin.go
@@ -516,6 +516,10 @@ func utilsTaskHandler(w http.ResponseWriter, r *http.Request, p *gauth.Profile, 
 		return nil
 	}
 
+	if targetSkey == skey {
+		return fmt.Errorf("target site cannot match source site")
+	}
+
 	// Move a device.
 	// Check the user is an admin for the target site.
 	if !isAdmin(ctx, targetSkey, p.Email) {

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.21.8"
+	version     = "v0.21.9"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/utils.html
+++ b/cmd/oceanbench/t/utils.html
@@ -16,7 +16,7 @@
   }
   </script>
 </head>
-<body>
+<body onload="history.pushState({}, '', '/admin/utils')">
   <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
     <nav-menu id="nav-menu" slot="nav-menu">
       {{range .Pages -}}


### PR DESCRIPTION
Previously, if the site was changed on the utils page, it would resubmit the form. Since moving a device puts a variable, then deletes it, if the user switches to the site the device was moved to, it will delete the variables associated with that device.

This change also update the error reporting in datablue which can hide the root issue.

closes #288 