### PR TITLE
TV: Add back incrementing of failures (#231)

### DIFF
--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -717,6 +717,7 @@ func onFailureClosure(ctx *broadcastContext, cfg *BroadcastConfig, disableOnFirs
 		ctx.bus.publish(startFailedEvent{})
 		try(ctx.man.Save(nil, func(_cfg *BroadcastConfig) {
 			const maxStartFailures = 3
+			_cfg.StartFailures++
 			if disableOnFirstFail || _cfg.StartFailures >= maxStartFailures {
 				_cfg.StartFailures = 0
 				_cfg.Enabled = false

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.2.1"
+	version            = "v0.2.2"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
The number of start failures was not being incremented correctly, meaning that broadcasts were not disabling after failing 3 times.

closes #231 