### PR TITLE
Check success of state type assertions

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -367,22 +367,22 @@ func (sm *broadcastStateMachine) publishHealthStatusOrChatEvents(event timeEvent
 	)
 	sm.publishHealthEvent(event)
 	now := event.Time
-	if now.Sub(sm.currentState.(liveState).lastStatusCheck()) > statusInterval {
+	if liveState, ok := sm.currentState.(liveState); ok && now.Sub(liveState.lastStatusCheck()) > statusInterval {
+		liveState.setLastStatusCheck(now)
 		sm.ctx.bus.publish(statusCheckDueEvent{})
-		sm.currentState.(liveState).setLastStatusCheck(now)
 	}
-	if now.Sub(sm.currentState.(liveState).lastChatMsg()) > chatInterval {
+	if liveState, ok := sm.currentState.(liveState); ok && now.Sub(liveState.lastChatMsg()) > chatInterval {
+		liveState.setLastChatMsg(now)
 		sm.ctx.bus.publish(chatMessageDueEvent{})
-		sm.currentState.(liveState).setLastChatMsg(now)
 	}
 }
 
 func (sm *broadcastStateMachine) publishHealthEvent(event timeEvent) {
 	const healthInterval = 1 * time.Minute
 	now := event.Time
-	if now.Sub(sm.currentState.(stateWithHealth).lastHealthCheck()) > healthInterval && sm.ctx.cfg.CheckingHealth {
+	if stateWithHealth, ok := sm.currentState.(stateWithHealth); ok && sm.ctx.cfg.CheckingHealth && now.Sub(stateWithHealth.lastHealthCheck()) > healthInterval {
+		stateWithHealth.setLastHealthCheck(now)
 		sm.ctx.bus.publish(healthCheckDueEvent{})
-		sm.currentState.(stateWithHealth).setLastHealthCheck(event.Time)
 	}
 }
 

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.2.4"
+	version            = "v0.2.5"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
Closes #298 

It's possible through event emission that the current state transitions to something that does not implement particular interfaces we assert to, so now we're checking the success of these assertions in the methods that deal with checking if health, status or chat is due.