### PR TITLE
tv: handle stop and start requests to prevent getting stuck in restarting

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -226,11 +226,11 @@ func (sm *hardwareStateMachine) handleHardwareStartedEvent(event hardwareStarted
 func (sm *hardwareStateMachine) handleHardwareStartRequestEvent(event hardwareStartRequestEvent) {
 	sm.log("handling hardware start request event")
 	switch sm.currentState.(type) {
-	case *hardwareOff, *hardwareStopping:
+	case *hardwareOff, *hardwareStopping, *hardwareRestarting:
 		sm.transition(newHardwareStarting(sm.ctx))
 	case *hardwareStarting:
 		sm.ctx.camera.publishEventIfStatus(hardwareStartedEvent{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.publish)
-	case *hardwareOn, *hardwareRestarting:
+	case *hardwareOn:
 		// Ignore.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
@@ -240,9 +240,9 @@ func (sm *hardwareStateMachine) handleHardwareStartRequestEvent(event hardwareSt
 func (sm *hardwareStateMachine) handleHardwareStopRequestEvent(event hardwareStopRequestEvent) {
 	sm.log("handling hardware stop request event")
 	switch sm.currentState.(type) {
-	case *hardwareOn, *hardwareStarting:
+	case *hardwareOn, *hardwareStarting, *hardwareRestarting:
 		sm.transition(newHardwareStopping(sm.ctx))
-	case *hardwareOff, *hardwareStopping, *hardwareRestarting:
+	case *hardwareOff, *hardwareStopping:
 		// Ignore.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.2.2"
+	version            = "v0.2.4"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
I noticed the hardware machine could get into a state of restarting but ignoring stop and start requests. Since it was ignoring start requests it never transitioned out of that state. Now it will transition, same for a stop request while restarting.