### PR TITLE
Bench: Use api/get/sites/user to populate site menu

### DIFF
--- a/cmd/oceanbench/admin.go
+++ b/cmd/oceanbench/admin.go
@@ -100,12 +100,6 @@ func adminHandler(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 
-		data.Users, err = getUsersForSiteMenu(w, r, ctx, p, data)
-		if err != nil {
-			writeTemplate(w, r, "register.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-			return
-		}
-
 		switch r.Method {
 		case "GET":
 			writeTemplate(w, r, "register.html", &data, "")
@@ -392,11 +386,7 @@ func writeAdmin(w http.ResponseWriter, r *http.Request, p *gauth.Profile, err er
 	}
 
 	ctx := r.Context()
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, p, data)
-	if err != nil {
-		writeTemplate(w, r, "admin.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
+
 	data.Site, err = model.GetSite(ctx, settingsStore, skey)
 	if err != nil {
 		log.Printf("GetSite error: %v", err)
@@ -441,12 +431,6 @@ func utilsHandler(w http.ResponseWriter, r *http.Request, p *gauth.Profile) {
 			"Go version":  runtime.Version(),
 			"Experiments": os.Getenv("VIDGRIND_EXPERIMENTS"),
 		},
-	}
-
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, p, data)
-	if err != nil {
-		writeTemplate(w, r, "utils.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
 	}
 
 	if r.Method == "GET" {

--- a/cmd/oceanbench/api.go
+++ b/cmd/oceanbench/api.go
@@ -112,20 +112,18 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			case "user":
-				users, err := getUsersForSiteMenu(w, r, ctx, p, nil)
+				users, sites, err := model.GetUserSites(ctx, settingsStore, p.Email)
 				if err != nil {
-					writeHttpError(w, http.StatusInternalServerError, "unable to get users: %v", err)
+					writeHttpError(w, http.StatusInternalServerError, "unable to get sites for user: %v. err: %v", p.Email, err)
 					return
 				}
 				userMap := make(map[int64]int64)
-				for _, user := range users {
-					userMap[user.Skey] = user.Perm
+				for _, u := range users {
+					userMap[u.Skey] = u.Perm
 				}
 				var userSites []minimalSite
 				for _, site := range sites {
-					if _, ok := userMap[site.Skey]; ok {
-						userSites = append(userSites, minimalSite{site.Skey, userMap[site.Skey], site.Name, site.Public})
-					}
+					userSites = append(userSites, minimalSite{site.Skey, userMap[site.Skey], site.Name, site.Public})
 				}
 				b, err := json.Marshal(userSites)
 				if err != nil {

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -221,11 +221,6 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	req.Users, err = getUsersForSiteMenu(w, r, ctx, profile, req)
-	if err != nil {
-		writeTemplate(w, r, "broadcast.html", &req, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
 
 	cfg := &req.CurrentBroadcast
 

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.21.9"
+	version     = "v0.22.9"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -365,14 +365,6 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-	setup(ctx)
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, profile, data)
-	if err != nil {
-		writeTemplate(w, r, "index.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
-
 	writeTemplate(w, r, "index.html", &data, "")
 }
 

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -368,31 +368,6 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	writeTemplate(w, r, "index.html", &data, "")
 }
 
-func getUsersForSiteMenu(w http.ResponseWriter, r *http.Request, ctx context.Context, profile *gauth.Profile, data interface{}) ([]model.User, error) {
-	users, err := model.GetUsers(ctx, settingsStore, profile.Email)
-	if err != nil {
-		return nil, fmt.Errorf("could not get users: %w", err)
-	}
-
-	// Keep track of site keys added.
-	added := map[int64]bool{}
-	for _, u := range users {
-		added[u.Skey] = true
-	}
-
-	// Get all public sites, if a public site hasn't been added yet, add it.
-	publicSites, err := model.GetPublicSites(ctx, settingsStore)
-	if err != nil {
-		return nil, fmt.Errorf("could not get public sites: %w", err)
-	}
-	for _, s := range publicSites {
-		if !added[s.Skey] {
-			users = append(users, model.User{Skey: s.Skey, Perm: model.ReadPermission})
-		}
-	}
-	return users, nil
-}
-
 // warmupHandler handles warmup requests. It is a no-op that simply ensures that the intance is loaded.
 func warmupHandler(w http.ResponseWriter, r *http.Request) {
 	logRequest(r)

--- a/cmd/oceanbench/monitor.go
+++ b/cmd/oceanbench/monitor.go
@@ -99,12 +99,6 @@ func monitorHandler(w http.ResponseWriter, r *http.Request) {
 	data := monitorData{commonData: commonData{Pages: pages("monitor"), Profile: profile}}
 
 	ctx := r.Context()
-	setup(ctx)
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, profile, data)
-	if err != nil {
-		writeTemplate(w, r, "monitor.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
 
 	skey, _ := profileData(profile)
 

--- a/cmd/oceanbench/search.go
+++ b/cmd/oceanbench/search.go
@@ -155,12 +155,6 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	setup(ctx)
-	sd.Users, err = getUsersForSiteMenu(w, r, ctx, profile, sd)
-	if err != nil {
-		writeTemplate(w, r, "search.html", &sd, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
 
 	site, err := model.GetSite(ctx, settingsStore, skey)
 	if err != nil {

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -629,12 +629,6 @@ func writeCrons(w http.ResponseWriter, r *http.Request, msg string) {
 		Actions:  []string{"set", "del", "call", "rpc", "email"},
 	}
 
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, profile, data)
-	if err != nil {
-		writeTemplate(w, r, "set/cron.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
-
 	writeTemplate(w, r, "set/cron.html", &data, msg)
 }
 

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -159,12 +159,6 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 
 	data.Timezone = site.Timezone
 
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, profile, data)
-	if err != nil {
-		writeTemplate(w, r, "set/device.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
-
 	data.Devices, err = model.GetDevicesBySite(ctx, settingsStore, skey)
 	if err != nil {
 		reportDevicesError(w, r, data, "get devices by site error: %v", err)

--- a/cmd/oceanbench/t/index.html
+++ b/cmd/oceanbench/t/index.html
@@ -20,9 +20,7 @@
       {{- end}}
     </nav-menu>
     <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
+      <option value="{{index (split .Profile.Data ":") 0}}" selected slot="selected">test</option>
     </site-menu>
   </header-group>
   <section id="main" class="main">

--- a/cmd/oceanbench/video.go
+++ b/cmd/oceanbench/video.go
@@ -203,14 +203,6 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := r.Context()
-	setup(ctx)
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, profile, data)
-	if err != nil {
-		writeTemplate(w, r, "upload.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
-	}
-
 	n, err := upload(w, r)
 	switch err {
 	case nil:
@@ -345,14 +337,6 @@ func playHandler(w http.ResponseWriter, r *http.Request) {
 			Pages: pages("play"),
 		},
 		MID: mid,
-	}
-
-	ctx := r.Context()
-	setup(ctx)
-	data.Users, err = getUsersForSiteMenu(w, r, ctx, profile, data)
-	if err != nil {
-		writeTemplate(w, r, "play.html", &data, fmt.Sprintf("could not populate site menu: %v", err.Error()))
-		return
 	}
 
 	writeTemplate(w, r, "play.html", &data, msg)


### PR DESCRIPTION
This change removes the need to call get sites before every page load, allowing the loading to happen completely async.

This should limit the number of database calls before returning the page to the user. This should make cloudblue feel like it loads slightly faster