### PR TITLE
Bench: Remove unchecked reference to .Profile (#310)

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.22.9"
+	version     = "v0.22.10"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/s/index.js
+++ b/cmd/oceanbench/s/index.js
@@ -1,0 +1,6 @@
+document.addEventListener("sites-loaded", updateNumSites);
+
+function updateNumSites(e) {
+  let num = document.getElementById("num-sites");
+  num.outerHTML = e.detail.len;
+}

--- a/cmd/oceanbench/t/index.html
+++ b/cmd/oceanbench/t/index.html
@@ -9,6 +9,7 @@
   <title>CloudBlue</title>
   <script type="module" src="/s/lit/header-group.js"></script>
   <script type="text/javascript" src="/s/main.js" ></script>
+  <script type="text/javascript" src="/s/index.js"></script>
 </head>
 <body>
   <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
@@ -20,7 +21,6 @@
       {{- end}}
     </nav-menu>
     <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      <option value="{{index (split .Profile.Data ":") 0}}" selected slot="selected">test</option>
     </site-menu>
   </header-group>
   <section id="main" class="main">
@@ -31,7 +31,7 @@
       </p>
       {{if .Profile}}
         <p>
-          You are logged in as {{ .Profile.Email}} and have {{len .Users}} sites.
+          You are logged in as {{ .Profile.Email}} and have <span id="num-sites" class="spinner-border spinner-border-sm" role="status"></span> sites.
         </p>
         <p>
           <a href="/admin/site/add">Register a new site</a>

--- a/cmd/oceanbench/ts/site-menu.ts
+++ b/cmd/oceanbench/ts/site-menu.ts
@@ -60,6 +60,7 @@ class SiteMenu extends LitElement {
         r.onreadystatechange = () => {
             if (r.readyState == XMLHttpRequest.DONE) {
                 let sites = JSON.parse(r.response)
+                this.dispatchEvent(new CustomEvent('sites-loaded', {bubbles: true, composed: true, detail: {'len': sites.length}}))
                 var opts:HTMLOptionElement[][] = [[],[],[]]
                 for (let site of sites) {
                     var opt = document.createElement("option");


### PR DESCRIPTION
This change removes the unchecked reference to .Profile that was accidentally added in a previous change which was preventing logged out users from viewing the page.

This change also adds a spinner which gets replace by the number of sites, since the .User value was also removed.

![image](https://github.com/user-attachments/assets/6a8b2a26-bfee-4fac-8c9d-feb2e770cbb8)
