### PR TITLE
Bench: Update Header for quality of life

### DIFF
--- a/cmd/oceanbench/ts/header-group.ts
+++ b/cmd/oceanbench/ts/header-group.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { NavMenu } from './nav-menu.js';
 import '../s/lit/nav-menu.js';
@@ -89,13 +89,23 @@ class HeaderGroup extends LitElement {
             `
     }
 
+    override firstUpdated() {
+        this._applyPermission(this.selectedPerm);
+    }
+
     private _onPermissionChange(event: Event){
         const customEvent = event as CustomEvent;
         this.selectedPerm = customEvent.detail.selectedPerm;
-        const slot = this.shadowRoot?.querySelector('slot') as HTMLSlotElement;
+        this._applyPermission(this.selectedPerm);
+    }
+
+    private _applyPermission(permission: number) {
+        const slot = this.shadowRoot?.querySelector('slot[name="nav-menu"]') as HTMLSlotElement;
         const elements = slot.assignedElements();
         const nav = elements.find(element => element.id === "nav-menu") as NavMenu;
-        nav.setPerm(this.selectedPerm);
+        if (nav) {
+            nav.setPerm(permission);  // Apply permission to nav menu
+        }
     }
 }
 

--- a/cmd/oceanbench/ts/header-group.ts
+++ b/cmd/oceanbench/ts/header-group.ts
@@ -76,15 +76,15 @@ class HeaderGroup extends LitElement {
             ? html`
                 <slot name="nav-menu"></slot>
                 <div id="top-bar">
-                    <h1 id="title">CloudBlue</h1>
+                    <a href="/"><h1 id="title">CloudBlue</h1></a>
                     <slot @permission-change=${this._onPermissionChange} id="site-menu" name="site-menu"></slot>
                 </div>
                 <a id="logout" href="${this.logoutURL}">Log out</a>
-                
+
             `
             : html`
                 <div id="top-bar">
-                    <h1 id="title">CloudBlue</h1>
+                    <a href="/"><h1 id="title">CloudBlue</h1></a>
                 </div>
             `
     }

--- a/cmd/oceanbench/ts/site-menu.ts
+++ b/cmd/oceanbench/ts/site-menu.ts
@@ -36,7 +36,12 @@ class SiteMenu extends LitElement {
     override render() {
         return html`
             <select id="select" @change=${this.handleSiteChange}>
-                <option id="loading">Select Site</option>
+                <option id="loading">
+                  ${this.selectedData
+                    ?this.selectedData.split(":")[1]
+                    :"Select Site"
+                  }
+                </option>
                 <optgroup style="display: none" id="read" label="Read"></optgroup>
                 <optgroup style="display: none" id="write" label="Write"></optgroup>
                 <optgroup style="display: none" id="admin" label="Admin"></optgroup>
@@ -68,16 +73,17 @@ class SiteMenu extends LitElement {
                     opt.label = site.Name
                     opt.setAttribute("perm", site.Perm)
                     if (site.Public) {
+                        opt.setAttribute("perm", "1")
                         opt.label += " (Public)"
                     }
-                    switch (site.Perm){
-                        case 1:
+                    switch (opt.getAttribute("perm")){
+                        case "1":
                             opts[0].push(opt);
                             break;
-                        case 3:
+                        case "3":
                             opts[1].push(opt);
                             break;
-                        case 7:
+                        case "7":
                             opts[2].push(opt);
                             break;
                     }


### PR DESCRIPTION
This change restores some features of the header group which were lost in a recent update. This includes:
- Defaulting to permission 1 for the nav menu for navigation before the site-menu has fully loaded
- Showing the current site name whilst the sites are loading
- Adding public sites to the site-selection
- Linking logotype to index