### PR TITLE
Bench: Add last reported time to monitor page (#281)

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.23.1"
+	version     = "v0.24.0"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/monitor.html
+++ b/cmd/oceanbench/t/monitor.html
@@ -35,7 +35,9 @@
               Protocol: {{ .Device.Protocol }}<br>
               Configured: <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}"><br>
               Status: <img src="/s/{{ .Sending }}.png" alt="{{ .Sending }}"><br>
-              Uptime: {{ .Uptime }}<br>
+              {{if eq .Sending "green"}}Uptime: {{ .Uptime }}<br>
+              {{else}} Last Reported: {{localdatetime .LastReportedTimestamp $.Timezone}}
+              {{end}}
               {{ if eq .Count 0 }}{{ else }}Throughput: {{ .Throughput }}% {{ .Count }}/{{ .MaxCount }}{{ end }}
             </span>
             {{ range .Sensors }}


### PR DESCRIPTION
This change adds the last reported time to the monitor page for any devices that are not currently reporting (ie. red).

This change also sorts the monitor page so that the most recently reported devices are first in the list.

![image](https://github.com/user-attachments/assets/39f66b1d-378f-4d1c-b428-067d928059af)

closes #281 
