### PR TITLE
Bench: Redirect all cron pages to base path (#214)

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.24.0"
+	version     = "v0.24.1"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -762,6 +762,11 @@ func writeCrons(w http.ResponseWriter, r *http.Request, msg string) {
 		http.Redirect(w, r, "/", http.StatusUnauthorized)
 		return
 	}
+	if r.URL.Path != "/set/crons/" {
+		// Redirect all requests to the cron base path to clear any actions.
+		http.Redirect(w, r, "/set/crons/", http.StatusFound)
+		return
+	}
 
 	ctx := r.Context()
 	setup(ctx)


### PR DESCRIPTION
This change redirects any requests to /set/crons/* back to /set/crons/ on a call to writeCrons. This prevents resubmission of forms when changing sites.

closes #214 