### PR TITLE
Bench: Use dropdowns for cron variables (#113)

### DIFF
--- a/cmd/oceanbench/s/cron.js
+++ b/cmd/oceanbench/s/cron.js
@@ -1,0 +1,49 @@
+window.addEventListener("load", init());
+
+async function init() {
+  // Get all variables for the site.
+  let devicesPromise = fetch("/api/get/devices/site");
+  let varsPromise = await fetch("/api/get/vars/site");
+
+  // Get select elements.
+  let varSelects = document.getElementsByName("cv");
+
+  let [devicesRaw, varsRaw] = await Promise.all([devicesPromise, varsPromise]);
+
+  const vars = await varsRaw.json();
+  const devs = await devicesRaw.json();
+
+  vars.forEach((v) => {
+    let mac = v.Name.split(".")[0];
+    let device = devs.find((d) => {
+      return d.Mac === parseInt(mac, 16);
+    });
+
+    // Add the variables to each dropdown.
+    varSelects.forEach((element) => {
+      if (v.Name == element.value) {
+        // If the values match, this means this is the currently selected var.
+        // Edit the inner text rather creating a new option with the same value.
+        element.firstElementChild.innerText =
+          device.Name + "." + v.Name.split(".")[1];
+        return;
+      }
+      let opt = document.createElement("option");
+      opt.value = v.Name;
+      opt.innerText = device.Name + "." + v.Name.split(".")[1];
+      element.appendChild(opt);
+    });
+  });
+}
+
+function updateCron(elem) {
+  elem.form.submit();
+}
+
+function addCron() {
+  document.getElementById("_newcron").submit();
+}
+
+function deleteCron(id) {
+  window.location = "/set/crons/edit?ci=" + id + "&task=Delete";
+}

--- a/cmd/oceanbench/t/set/cron.html
+++ b/cmd/oceanbench/t/set/cron.html
@@ -8,17 +8,7 @@
   <title>Crons</title>
   <script type="module" src="/s/lit/header-group.js"></script>
   <script type="text/javascript" src="/s/main.js"></script>
-  <script type="text/javascript">
-    function updateCron(elem) {
-      elem.form.submit();
-    }
-    function addCron() {
-      document.getElementById("_newcron").submit();
-    }
-    function deleteCron(id) {
-      window.location = '/set/crons/edit?ci=' + id + '&task=Delete';
-    }
-  </script>
+  <script type="text/javascript" src="/s/cron.js"></script>
 </head>
 <body>
   <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
@@ -57,7 +47,9 @@
         <span class="td half"><input type="text" name="ct" value="{{ .FormatTime $.Timezone }}" class="half" onchange="updateCron(this);"></span>
         <span class="td half"><select name="ca" class="half" onchange="updateCron(this);">{{range $.Actions }}
           <option value="{{.}}"{{if eq . $c.Action }} selected{{end}}>{{.}}</option>{{end}}</select></span>
-        <span class="td std"><input type="text" name="cv" value="{{ .Var }}" class="std" onchange="updateCron(this);"></span>
+        <span class="td std"><select type="text" name="cv" class="std" onchange="updateCron(this);">
+          <option selected value="{{.Var}}"></option>
+        </select></span>
         <span class="td std"><input type="text" name="cd" value="{{ .Data }}" class="std" onchange="updateCron(this);"></span>
         <span class="td half"><input type="checkbox" name="ce"{{if .Enabled}} checked{{end}} onchange="updateCron(this);"></span>
       </form>{{end}}
@@ -67,7 +59,9 @@
         <span class="td half"><input type="text" name="ct" class="half"></span>
         <span class="td half"><select name="ca" class="half">{{range $.Actions }}
           <option value="{{.}}">{{.}}</option>{{end}}</select></span>
-        <span class="td std"><input type="text" name="cv" class="std"></span>
+        <span class="td std"><select id="var-select" type="text" name="cv" class="std">
+          <option>-- Select Var --</option>
+        </select></span>
         <span class="td std"><input type="text" name="cd" class="std"></span>
         <span class="td half"><input type="checkbox" name="ce"></span>
         <input type="hidden" name="task" value="Add">


### PR DESCRIPTION
This changes allows the user to select from all of the variables on the site when setting a cron.

This also shows a human readable variable name, using the name of the device rather than the mac address. (the value is unchanged, and so all functionality is the same)

![image](https://github.com/user-attachments/assets/192cde56-76f2-442f-92cc-527f6f10e9a5)

requires #321 
closes #113 
