### PR TITLE
tv: ignore hardware start requests if stopping

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -230,7 +230,10 @@ func (sm *hardwareStateMachine) handleHardwareStartRequestEvent(event hardwareSt
 		sm.transition(newHardwareStarting(sm.ctx))
 	case *hardwareStarting:
 		sm.ctx.camera.publishEventIfStatus(hardwareStartedEvent{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.publish)
-	case *hardwareOn, *hardwareStopping:
+	case *hardwareStopping:
+		// Ignore and log.
+		sm.log("ignoring hardware start request event since hardware is still stopping")
+	case *hardwareOn:
 		// Ignore.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -226,11 +226,11 @@ func (sm *hardwareStateMachine) handleHardwareStartedEvent(event hardwareStarted
 func (sm *hardwareStateMachine) handleHardwareStartRequestEvent(event hardwareStartRequestEvent) {
 	sm.log("handling hardware start request event")
 	switch sm.currentState.(type) {
-	case *hardwareOff, *hardwareStopping, *hardwareRestarting:
+	case *hardwareOff, *hardwareRestarting:
 		sm.transition(newHardwareStarting(sm.ctx))
 	case *hardwareStarting:
 		sm.ctx.camera.publishEventIfStatus(hardwareStartedEvent{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.publish)
-	case *hardwareOn:
+	case *hardwareOn, *hardwareStopping:
 		// Ignore.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)


### PR DESCRIPTION
This is done to ensure that the hardware fully stops if requested to stop.

See issue #313.

