### PR TITLE
Extend hardwareManager interface

### DIFF
--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -1196,7 +1196,7 @@ func TestBroadcastStart(t *testing.T) {
 		cfg                      *BroadcastConfig
 		initialState             state
 		finalState               state
-		hardwareHealthy          bool
+		hardwareMan              hardwareManager
 		expectHardwareStartCall  bool
 		expectBroadcastStartCall bool
 		inputEvent               event
@@ -1210,7 +1210,7 @@ func TestBroadcastStart(t *testing.T) {
 			},
 			initialState:             &directIdle{},
 			finalState:               &directLive{},
-			hardwareHealthy:          true,
+			hardwareMan:              newDummyHardwareManager(),
 			expectHardwareStartCall:  true,
 			expectBroadcastStartCall: true,
 			inputEvent:               timeEvent{now.Add(1 * time.Minute)},
@@ -1233,7 +1233,7 @@ func TestBroadcastStart(t *testing.T) {
 			},
 			initialState:             &directIdle{},
 			finalState:               &directStarting{},
-			hardwareHealthy:          false,
+			hardwareMan:              newDummyHardwareManager(withHardwareFault()),
 			expectHardwareStartCall:  true,
 			expectBroadcastStartCall: false,
 			inputEvent:               timeEvent{now.Add(1 * time.Minute)},
@@ -1261,7 +1261,7 @@ func TestBroadcastStart(t *testing.T) {
 			)
 
 			bCtx.man = newDummyManager(t, tt.cfg)
-			bCtx.camera = newDummyHardwareManager(tt.hardwareHealthy)
+			bCtx.camera = tt.hardwareMan
 			bCtx.fwd = newDummyForwardingService()
 			bCtx.cfg = tt.cfg
 			bCtx.bus = bus
@@ -1431,7 +1431,7 @@ func TestHandleCameraConfiguration(t *testing.T) {
 				withBroadcastManager(newDummyManager(t, cfg)),
 				withBroadcastService(newDummyService()),
 				withForwardingService(newDummyForwardingService()),
-				withHardwareManager(newDummyHardwareManager(hardwareHealthy, withMACSanitisation())),
+				withHardwareManager(newDummyHardwareManager(withMACSanitisation())),
 				withNotifier(newMockNotifier()),
 			)
 			if err != nil {

--- a/cmd/oceantv/broadcast_manager_test.go
+++ b/cmd/oceantv/broadcast_manager_test.go
@@ -142,7 +142,7 @@ func TestCreateBroadcast(t *testing.T) {
 				withBroadcastManager(bm),
 				withBroadcastService(svc),
 				withForwardingService(newDummyForwardingService()),
-				withHardwareManager(newDummyHardwareManager(hardwareHealthy, withMACSanitisation())),
+				withHardwareManager(newDummyHardwareManager(withMACSanitisation())),
 				withNotifier(newMockNotifier()),
 			)
 			if err != nil {

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -479,7 +479,7 @@ func TestRateLimited(t *testing.T) {
 				newDummyService(),
 				newDummyForwardingService(),
 				bus,
-				newDummyHardwareManager(true),
+				newDummyHardwareManager(),
 				t.Log,
 				newMockNotifier(),
 			}

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -45,7 +45,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.2.8"
+	version            = "v0.2.9"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
Depends on PR #327

This change extends the hardwareManager interface by adding voltage, alarmVoltage and isUp methods. These additions have been motivated by voltage handling in the broadcast functionality.