### PR TITLE
model: add ausoceantv entities

### DIFF
--- a/model/ausoceantv/feed.go
+++ b/model/ausoceantv/feed.go
@@ -1,0 +1,36 @@
+/*
+AUTHORS
+  Trek Hopton <trek@ausocean.org>
+
+LICENSE
+  Copyright (C) 2024 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import "time"
+
+// Feed is an entity in the datastore that represents information about a particular feed.
+type Feed struct {
+	ID      string    // AusOcean assigned Feed ID.
+	Name    string    // Display name, e.g., “Rapid Bay Live Stream”.
+	Area    string    // Location, e.g., “SA” or “FNQ”.
+	Class   string    // Feed class, e.g., “Video” or “Data”.
+	Source  string    // Feed source URL, e.g., a YouTube URL, or a URL to an AusOcean data stream (such as weather data).
+	Params  string    // Optional params to be applied to the source.
+	Bundle  []string  // Feed IDs of other feeds bundled with this feed, or nil.
+	Created time.Time // Time the feed entity was created.
+}

--- a/model/ausoceantv/subscriber.go
+++ b/model/ausoceantv/subscriber.go
@@ -1,0 +1,37 @@
+/*
+AUTHORS
+  Trek Hopton <trek@ausocean.org>
+
+LICENSE
+  Copyright (C) 2024 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import "time"
+
+// Subscriber is an entity in the datastore representing a user who subscribes to AusOcean.TV.
+type Subscriber struct {
+	ID              string    // AusOcean assigned Subscriber ID.
+	AccountID       string    // Google Account ID. NB: May not be necessary.
+	Email           string    // Subscriber's email address.
+	GivenName       string    // Subscriber's given name.
+	FamilyName      string    // Subscriber's family name.
+	Area            []string  // Subscriber’s area(s) of interest.
+	DemographicInfo string    // Optional demographic info about the subscriber, e.g., their postcode.
+	PaymentInfo     string    // Info required to use a payments platform.
+	Created         time.Time // Time the subscriber entity was created.
+}

--- a/model/ausoceantv/subscription.go
+++ b/model/ausoceantv/subscription.go
@@ -1,0 +1,35 @@
+/*
+AUTHORS
+  Trek Hopton <trek@ausocean.org>
+
+LICENSE
+  Copyright (C) 2024 the Australian Ocean Lab (AusOcean).
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+  License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package model
+
+import "time"
+
+// Subscription is an entity in the datastore that represents the relationship between a subscriber and a feed.
+type Subscription struct {
+	SubscriberID string    // Subscriber’s ID.
+	FeedID       string    // Feed’s ID.
+	Class        string    // Subscription class, e.g., “Day”, “Month”, or “Year”.
+	Prefs        string    // User’s preferences for the presentation of this stream, e.g., “Top, Favorite”.
+	Start        time.Time // Start time of the subscription.
+	Finish       time.Time // Finish time of the subscription.
+	Renew        bool      // True if the subscription should auto-renew.
+}


### PR DESCRIPTION
This was done to get the basic entities in place for ausoceantv. They may change over time but that's okay.