### PR TITLE
bench: change disabled form elements to readonly so they can be submitted

### DIFF
--- a/cmd/oceanbench/t/sandbox.html
+++ b/cmd/oceanbench/t/sandbox.html
@@ -62,7 +62,7 @@
           <div class="d-flex align-items-center gap-1 mb-1">
             <label class="col-4 text-end">MAC:</label>
             <div class="col-6">
-              <input class="form-control" value="{{.MAC}}" disabled></input>
+              <input class="form-control" value="{{.MAC}}" readonly></input>
             </div>
           </div>
           <div class="d-flex align-items-center gap-1 mb-1">

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -238,14 +238,14 @@
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">MAC:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="ma" value="{{.MAC}}" {{if .MAC}}disabled{{end}}>
+                  <input class="form-control" type="input" name="ma" value="{{.MAC}}" {{if .MAC}}readonly{{end}}>
                 </div>
               </div>
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Type:</label>
                 <div class="col-sm-10 col-md-6 col-12">
                   {{if .Name}}
-                  <input class="form-control" value="{{.Type}}" disabled>
+                  <input class="form-control" value="{{.Type}}" readonly>
                   {{else}}
                   <select name="ct" class="form-select h-auto">
                     <option value="">-- Select type --</option>{{range $.DevTypes}}
@@ -316,7 +316,7 @@
                 </div>
               </div>
               <div class="advanced row gx-1">
-                <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Local Addess:</label>
+                <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Local Address:</label>
                 <div class="col-sm-10 col-md-6 col-12">
                   <input class="form-control" type="input" name="la" value="{{if (.Other "localaddr")}}{{.Other "localaddr"}}{{end}}" disabled>
                 </div>
@@ -387,7 +387,7 @@
             <tr>
                 <form class="row gx-1 d-flex align-items-center" id="{{ .Basename }}" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" novalidate>
                 <td class="d-flex justify-content-end h-75"><img src="/s/delete.png" onclick="deleteVar('{{$.Device.MAC}}','{{ .Basename }}');"></td>
-                <td><input class="form-control form-control-sm w-100" type="text" name="vn" value="{{ .Basename }}" disabled></td>
+                <td><input class="form-control form-control-sm w-100" type="text" name="vn" value="{{ .Basename }}" readonly></td>
                 <td><input class="form-control form-control-sm w-100" type="text" name="vv" value="{{ .Value }}" onchange="submitVar(this)" oninput="validateVar(this)">
                     {{if .IsLink }}
                     <a href="{{ .Value }}" target="_blank"><img src="/s/link.png"></a>
@@ -434,7 +434,7 @@
               <form class="row gx-1 d-flex align-items-center" id="{{ .Name }}" enctype="multipart/form-data" action="/set/devices/edit/sensor" method="post" novalidate>
                 <td><img class="mt-2" src="/s/delete.png" onclick="deleteSensor('{{$dev.MAC}}','{{ $sensor.Pin }}');"></td>
                 <td><input class="form-control form-control-sm" type="text" name="name" value="{{ $sensor.Name }}" onchange="submitSensor(this)"></td>
-                <td class="col-1"><input class="form-control form-control-sm" type="text" name="pin" value="{{ $sensor.Pin }}" disabled></td>
+                <td class="col-1"><input class="form-control form-control-sm" type="text" name="pin" value="{{ $sensor.Pin }}" readonly></td>
                 <td>
                   <select class="form-select form-select-sm" name="sqty" onchange="submitSensor(this)">
                     {{range $qty := $data.Quantities}}
@@ -530,7 +530,7 @@
                     <td><img class="mt-2" src="/s/delete.png" onclick="deleteActuator('{{$dev.MAC}}','{{ $act.Pin }}');"></td>
                     <td><input class="form-control form-control-sm" type="text" name="name" value="{{ $act.Name }}" onchange="submitActuator(this)"></td>
                     <td><input class="form-control form-control-sm" type="text" name="var" value="{{ $act.Var}}" onchange="submitActuator(this)"></td>
-                    <td><input class="form-control form-control-sm" type="text" name="pin" value="{{ $act.Pin }}" disabled></td>
+                    <td><input class="form-control form-control-sm" type="text" name="pin" value="{{ $act.Pin }}" readonly></td>
                     <span class="td msg hidden"></span>
                     <input type="hidden" name="ma" value="{{$dev.MAC}}">
                 </form>


### PR DESCRIPTION
This was done so that necessary form values still submit values when greyed out. Closes #345 and closes #346 .

I tested on standalone to confirm fields are still greyed out and submit in the form.

![image](https://github.com/user-attachments/assets/9e133be6-7d0b-41e6-81f3-394ef76eadac)
