### PR TITLE
AusOceanTV:Use tailwind with lit

### DIFF
--- a/cmd/ausoceantv/src/shared/global.d.ts
+++ b/cmd/ausoceantv/src/shared/global.d.ts
@@ -1,0 +1,5 @@
+declare module '*.scss';
+declare module '*.scss?inline';
+declare module '*.css';
+declare module '*.css?inline';
+declare module '*.html';

--- a/cmd/ausoceantv/src/shared/tailwind.element.ts
+++ b/cmd/ausoceantv/src/shared/tailwind.element.ts
@@ -6,9 +6,9 @@ import style from "./tailwind.global.css?inline";
 
 const tailwindElement = unsafeCSS(style);
 
-export const TailwindElement = (style) =>
+export const TailwindElement = (style? : string) =>
     class extends LitElement {
 
-        static styles = [tailwindElement, unsafeCSS(style)];
+      static styles = [tailwindElement, style ? unsafeCSS(style) : []];
 
     };

--- a/cmd/ausoceantv/src/shared/tailwind.element.ts
+++ b/cmd/ausoceantv/src/shared/tailwind.element.ts
@@ -1,0 +1,14 @@
+// See Also: https://github.com/butopen/web-components-tailwind-starter-kit
+
+import {LitElement, unsafeCSS} from "lit";
+
+import style from "./tailwind.global.css?inline";
+
+const tailwindElement = unsafeCSS(style);
+
+export const TailwindElement = (style) =>
+    class extends LitElement {
+
+        static styles = [tailwindElement, unsafeCSS(style)];
+
+    };

--- a/cmd/ausoceantv/src/shared/tailwind.global.css
+++ b/cmd/ausoceantv/src/shared/tailwind.global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
This change adds support for tailwind styling in lit elements using the Vite Dev tools and PostCSS.

See #351 for a developer readme to explain how this works.