### PR TITLE
Add gitignores for all modules/dirs that often contain generated files

### DIFF
--- a/cmd/ausoceantv/.gitignore
+++ b/cmd/ausoceantv/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+ausoceantv

--- a/cmd/datablue/.gitignore
+++ b/cmd/datablue/.gitignore
@@ -1,0 +1,1 @@
+datablue

--- a/cmd/oceanbench/.gitignore
+++ b/cmd/oceanbench/.gitignore
@@ -4,3 +4,4 @@ oceanbench
 store
 node_modules
 .vscode
+s/lit

--- a/cmd/oceancenter/.gitignore
+++ b/cmd/oceancenter/.gitignore
@@ -1,0 +1,1 @@
+oceancenter

--- a/cmd/oceancron/.gitignore
+++ b/cmd/oceancron/.gitignore
@@ -1,0 +1,2 @@
+store
+oceancron

--- a/cmd/oceantv/.gitignore
+++ b/cmd/oceantv/.gitignore
@@ -1,0 +1,1 @@
+oceantv

--- a/model/.gitignore
+++ b/model/.gitignore
@@ -1,0 +1,2 @@
+vidgrind
+netreceiver


### PR DESCRIPTION
This was done because my git status output was getting too big.