### PR TITLE
Bench: Group Data in graph (#263)

### DIFF
--- a/cmd/oceanbench/s/graph.js
+++ b/cmd/oceanbench/s/graph.js
@@ -164,6 +164,7 @@ function graph() {
     // Create axes
     var dateAxis = chart.xAxes.push(new am4charts.DateAxis());
     dateAxis.renderer.minGridDistance = 60;
+    dateAxis.groupData = true;
 
     var valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
 


### PR DESCRIPTION
Use the groupData field in the graph element, which limits the number of points that get rendered. This improves the render time.

**NOTE:** I tried the updated v5 of amcharts, but this actually performs worse and crashes on larger requests.

closes #263 

PS: There is possibly room to edit the group size to maximise performance vs usability