### PR TITLE
bench: add warmup requests and min_instances to bench for latency.

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -200,6 +200,11 @@ func main() {
 		log.Printf("could not get cronSecret: %v", err)
 	}
 
+	// Warmup handler.
+	http.HandleFunc("/_ah/warmup", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("warmup request received, version: " + version)
+	})
+
 	// User requests.
 	http.HandleFunc("/search", searchHandler)
 	http.HandleFunc("/play", playHandler)

--- a/oceanbench.yaml
+++ b/oceanbench.yaml
@@ -25,3 +25,9 @@ handlers:
   - url: /.*
     secure: always
     script: auto
+
+automatic_scaling:
+  min_instances: 1
+
+inbound_services:
+- warmup


### PR DESCRIPTION
This was done because we frequently experience latency and this could help speed things up.