### PR TITLE
Bench: Fix site-menu public permissions (#364)

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.24.3"
+	version     = "v0.24.4"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/ts/site-menu.ts
+++ b/cmd/oceanbench/ts/site-menu.ts
@@ -73,8 +73,8 @@ class SiteMenu extends LitElement {
                     opt.label = site.Name
                     opt.setAttribute("perm", site.Perm)
                     if (site.Public) {
-                        opt.setAttribute("perm", "1")
                         opt.label += " (Public)"
+                        opt.getAttribute("perm") == "0" ? opt.setAttribute("perm", "1") : null;
                     }
                     switch (opt.getAttribute("perm")){
                         case "1":


### PR DESCRIPTION
This change now only alters the permission if none currently exists.

closes #364