### PR TITLE
AOTV: Configure prettier (#372)

### DIFF
--- a/cmd/ausoceantv/.prettierrc
+++ b/cmd/ausoceantv/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "overrides": [
+    {
+      "files": "*.html",
+      "options": {
+        "printWidth": 2000
+      }
+    }
+  ]
+}

--- a/cmd/ausoceantv/README.md
+++ b/cmd/ausoceantv/README.md
@@ -76,3 +76,27 @@ Tailwind is class based styling framework, which makes styling elements easy
 without the worry of unexpected cascading issues.
 
 To Learn more about Tailwind see: [Tailwind](https://tailwindcss.com/).
+
+### Prettier
+To ensure that AusOcean TV files are easy to edit without worrying about formnatting, this directory includes
+a ```.prettierrc``` file which can be used to format according to the same guidelines. Prettier should be installed
+if all npm packages have been installed using ```npm install```.
+
+To format all files run:
+```bash
+$ npm run format
+```
+OR
+```bash
+$ npm run format:watch
+```
+to format when new changes are detected.
+
+To only format a specific file or set of files use:
+```bash
+$ npx prettier -w [Path]
+```
+This command will format all the files specified by that path.
+
+Many editors also support Prettier as a default formater, and will read the .prettierrc file from the directory and
+apply the relevant formatting when formatted. To set this up will change depending on your development environment.

--- a/cmd/ausoceantv/package-lock.json
+++ b/cmd/ausoceantv/package-lock.json
@@ -12,7 +12,10 @@
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
+        "onchange": "^7.1.0",
         "postcss": "^8.4.48",
+        "prettier": "^3.3.3",
+        "prettier-plugin-tailwindcss": "^0.6.9",
         "tailwindcss": "^3.4.14",
         "typescript": "~5.6.2",
         "vite": "^5.4.10"
@@ -29,6 +32,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@blakeembrey/deque": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@blakeembrey/deque/-/deque-1.0.5.tgz",
+      "integrity": "sha512-6xnwtvp9DY1EINIKdTfvfeAtCYw4OqBZJhtiqkT3ivjnEfa25VQ3TsKvaFfKm8MyGIEfE95qLe+bNEt3nB0Ylg==",
+      "dev": true
+    },
+    "node_modules/@blakeembrey/template": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@blakeembrey/template/-/template-1.2.0.tgz",
+      "integrity": "sha512-w/63nURdkRPpg3AXbNr7lPv6HgOuVDyefTumiXsbXxtIwcuk5EXayWR5OpSwDjsQPgaYsfUSedMduaNOjAYY8A==",
+      "dev": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1263,6 +1278,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1525,6 +1549,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/onchange": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/onchange/-/onchange-7.1.0.tgz",
+      "integrity": "sha512-ZJcqsPiWUAUpvmnJri5TPBooqJOPmC0ttN65juhN15Q8xA+Nbg3BaxBHXQ45EistKKlKElb0edmbPWnKSBkvMg==",
+      "dev": true,
+      "dependencies": {
+        "@blakeembrey/deque": "^1.0.5",
+        "@blakeembrey/template": "^1.0.0",
+        "arg": "^4.1.3",
+        "chokidar": "^3.3.1",
+        "cross-spawn": "^7.0.1",
+        "ignore": "^5.1.4",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "onchange": "dist/bin.js"
+      }
+    },
+    "node_modules/onchange/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1752,6 +1800,99 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.9.tgz",
+      "integrity": "sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -2121,6 +2262,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/cmd/ausoceantv/package.json
+++ b/cmd/ausoceantv/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "format": "prettier --write ./",
+    "format:watch": "onchange \"**/*\" -- prettier --write --ignore-unknown {{changed}}",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
@@ -13,7 +15,10 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",
+    "onchange": "^7.1.0",
     "postcss": "^8.4.48",
+    "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.9",
     "tailwindcss": "^3.4.14",
     "typescript": "~5.6.2",
     "vite": "^5.4.10"


### PR DESCRIPTION
This change adds prettier as a formatter to help keep formatting in sync.

This change adds a prettier setup to the project which will allow us to use consistent formatting guides.

The reason that I chose prettier is that it has a plugin for tailwind that will ensure that the classes will always be sorted the same, this benefits both the predictability of applying styles, but also makes it easier to make the classes consistent across commits.

See: https://tailwindcss.com/blog/automatic-class-sorting-with-prettier