### PR TITLE
ausoceantv: add store to fiber's context.Locals

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -107,7 +107,7 @@ func main() {
 	} else if svc.standalone {
 		log.SetLevel(log.LevelInfo)
 	} else {
-		// Appengine logs requests for us.
+		// App engine logs requests for us.
 		log.SetLevel(log.LevelError)
 	}
 
@@ -129,9 +129,10 @@ func main() {
 // serviceMiddleware attaches the global service pointer to
 // each of the requests.
 func serviceMiddleware(svc *service) func(*fiber.Ctx) error {
-	log.Info("Attaching service to context locals")
+	log.Info("attaching service and settingsStore to context locals")
 	return func(ctx *fiber.Ctx) error {
 		ctx.Locals("service", svc)
+		ctx.Locals("store", svc.settingsStore)
 		return ctx.Next()
 	}
 }
@@ -154,10 +155,10 @@ func (svc *service) setup(ctx context.Context) {
 
 	var err error
 	if svc.standalone {
-		log.Info("Running in standalone mode")
+		log.Info("running in standalone mode")
 		svc.settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", svc.storePath)
 	} else {
-		log.Info("Running in App Engine mode")
+		log.Info("running in App Engine mode")
 		svc.settingsStore, err = datastore.NewStore(ctx, "cloud", "netreceiver", "")
 	}
 	if err != nil {


### PR DESCRIPTION
This was done so the api package can use the store to create, get etc. from the store.