### PR TITLE
AOTV: Add authenticator wrapper around contents.

### DIFF
--- a/cmd/ausoceantv/auth.go
+++ b/cmd/ausoceantv/auth.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/gofiber/fiber/v2"
@@ -49,7 +50,9 @@ func (svc *service) callbackHandler(c *fiber.Ctx) error {
 // profileHandler handles requests to get the profile of the logged in user.
 func (svc *service) profileHandler(c *fiber.Ctx) error {
 	p, err := svc.GetProfile(c)
-	if err != nil {
+	if errors.Is(err, SessionNotFound) || errors.Is(err, TokenNotFound) {
+		return fiber.ErrUnauthorized
+	} else if err != nil {
 		return fmt.Errorf("unable to get profile: %w", err)
 	}
 	bytes, err := json.Marshal(p)

--- a/cmd/ausoceantv/index.html
+++ b/cmd/ausoceantv/index.html
@@ -6,16 +6,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AusOcean TV | Welcome</title>
     <link rel="stylesheet" href="./src/index.css" />
+    <script type="module" src="src/web-components/authenticator.ts"></script>
   </head>
   <body class="h-screen">
-    <div class="align-center container m-auto flex h-full flex-col justify-center">
-      <a href="https://ausocean.org" target="_blank">
-        <img src="src/assets/ausocean_logo.png" class="logo m-12 mx-auto w-64" alt="AusOcean logo" />
-      </a>
-      <h1 class="m-12 whitespace-nowrap text-center text-2xl font-bold sm:text-4xl md:text-6xl">Welcome to AusOcean TV</h1>
-      <button class="mx-auto w-auto whitespace-nowrap rounded bg-gray-300 px-5 py-3 text-center">
-        <a href="/api/v1/auth/login">Sign Up</a>
-      </button>
-    </div>
+    <auth-wrapper>
+      <div class="align-center container m-auto flex h-full flex-col justify-center">
+        <a href="https://ausocean.org" target="_blank">
+          <img src="src/assets/ausocean_logo.png" class="logo m-12 mx-auto w-64" alt="AusOcean logo" />
+        </a>
+        <h1 class="m-12 whitespace-nowrap text-center text-2xl font-bold sm:text-4xl md:text-6xl">Welcome to AusOcean TV</h1>
+        <button class="mx-auto w-auto whitespace-nowrap rounded bg-gray-300 px-5 py-3 text-center">
+          <a href="/api/v1/auth/login">Sign Up</a>
+        </button>
+      </div>
+    </auth-wrapper>
   </body>
 </html>

--- a/cmd/ausoceantv/src/types/user.ts
+++ b/cmd/ausoceantv/src/types/user.ts
@@ -1,0 +1,3 @@
+export class User {
+  name: string;
+}

--- a/cmd/ausoceantv/src/utils/context.ts
+++ b/cmd/ausoceantv/src/utils/context.ts
@@ -1,0 +1,4 @@
+import type { User } from "../types/user";
+import { createContext } from "@lit/context";
+
+export const userContext = createContext<User | null>(Symbol("current-user"));

--- a/cmd/ausoceantv/src/web-components/authenticator.ts
+++ b/cmd/ausoceantv/src/web-components/authenticator.ts
@@ -1,0 +1,47 @@
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { TailwindElement } from "../shared/tailwind.element.ts";
+import { provide } from "@lit/context";
+import { userContext } from "../utils/context.ts";
+import { User } from "../types/user.ts";
+
+@customElement("auth-wrapper")
+export class Authenticator extends TailwindElement() {
+  @provide({ context: userContext })
+  @property({ type: Object })
+  user: User | null = null;
+
+  async connectedCallback() {
+    super.connectedCallback();
+
+    await fetch("/api/v1/auth/profile")
+      .then((resp) => {
+        if (resp.status != 200) {
+          throw resp.status;
+        }
+        return resp.json();
+      })
+      .then((resp) => {
+        this.user = new User();
+        this.user.name = resp.GivenName;
+        console.log(this.user.name);
+      })
+      .catch((err) => {
+        if (err == 401) {
+          console.log("No session found");
+        } else {
+          console.log("Error fetching profile:", err);
+        }
+      });
+  }
+
+  render() {
+    return html` <slot></slot> `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "auth-wrapper": Authenticator;
+  }
+}

--- a/cmd/ausoceantv/userauth.go
+++ b/cmd/ausoceantv/userauth.go
@@ -338,7 +338,16 @@ func (svc *service) GetProfile(c *fiber.Ctx) (*Profile, error) {
 	if err != nil {
 		return nil, SessionNotFound
 	}
-	tok := sess.Get(oauthTokenSessionKey).(*oauth2.Token)
+
+	tokenValue := sess.Get(oauthTokenSessionKey)
+	if tokenValue == nil {
+		return nil, TokenNotFound
+	}
+
+	tok, ok := tokenValue.(*oauth2.Token)
+	if !ok {
+		return nil, fmt.Errorf("could not assert session token as type *oauth2.Token")
+	}
 
 	profile := sess.Get(profileKey).(*Profile)
 


### PR DESCRIPTION
This change adds a custom element which wraps the page markup to get an authenticated user.

When the wrapper is loaded, it fetches the profile from the ```/api/v1/auth/profile``` endpoint. This then provides a user-context to other elements in the tree.

Inspired by user-provider from openfish.