### PR TITLE
ausoceantv: initialise user.name to empty string

### DIFF
--- a/cmd/ausoceantv/src/types/user.ts
+++ b/cmd/ausoceantv/src/types/user.ts
@@ -1,3 +1,3 @@
 export class User {
-  name: string;
+  name: string = '';
 }


### PR DESCRIPTION
This was done because typescript wouldn't let us run npm run build without it.