### PR TITLE
model: Add methods for subscription and subscriber (#391)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stripe/stripe-go/v81 v81.0.0
 	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+	golang.org/x/exp v0.0.0-20190121172915-509febef88a4
 	golang.org/x/oauth2 v0.7.0
 	google.golang.org/api v0.118.0
 )

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/model/feed.go
+++ b/model/feed.go
@@ -33,7 +33,7 @@ const (
 
 // Feed is an entity in the datastore that represents information about a particular feed.
 type Feed struct {
-	ID      string    // AusOcean assigned Feed ID.
+	ID      int64     // AusOcean assigned Feed ID.
 	Name    string    // Display name, e.g., “Rapid Bay Live Stream”.
 	Area    string    // Location, e.g., “SA” or “FNQ”.
 	Class   string    // Feed class, e.g., “Video” or “Data”.

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -27,6 +27,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -43,49 +44,51 @@ import (
 )
 
 const (
-	testSiteKey    = 1
-	testSiteKey2   = 2
-	testSiteName   = "OfficialTestSite"
-	testSiteOrg    = "AusOcean"
-	testSiteOps    = "ops@ausocean.org"
-	testSiteLat    = -34.91805
-	testSiteLng    = 138.60475
-	testSiteTZ     = 9.5
-	testSiteEnc    = `{"Skey":1,"Name":"OfficialTestSite","Description":"","OrgID":"AusOcean","OwnerEmail":"","OpsEmail":"ops@ausocean.org","YouTubeEmail":"","Latitude":-34.91805,"Longitude":138.60475,"Timezone":9.5,"NotifyPeriod":0,"Enabled":true,"Confirmed":false,"Premium":false,"Public":false,"Subscribed":"1970-01-01T00:00:00Z","Created":"1970-01-01T00:00:00Z"}`
-	testDevMac     = "00:00:00:00:00:01"
-	testDevMa      = 1
-	testMID        = testDevMa << 4
-	testDevDkey    = 10000001
-	testDevID      = "TestDevice"
-	testDevInputs  = "A0,V0"
-	testDevEnc     = "1\t10000001\t1\tTestDevice\tX0,V0\t\t"
-	testDevEnc2    = "1\t10000001\t1\tTestDevice\t\t\t"
-	testDevEnc3    = "1\t10000001\t1\tTestDevice\tX0,V0\t\t\t0\t0\t0\ttag\tprotocol\t-34.918050\t138.604750\ttrue\t"
-	testUserEmail  = "test@ausocean.org"
-	testUserEmail2 = "test@testdomain.org"
-	testUserPerm   = ReadPermission
-	testUserPerm2  = ReadPermission | WritePermission
-	testUserTime   = 1572157457
-	testUserTime2  = 1572157475
-	testUserEnc    = "1\ttest@ausocean.org\t\t1\t1572157457"
-	testUserEnc2   = "2\ttest@ausocean.org\t\t3\t1572157475"
-	testDevMac2    = "00:00:00:00:00:0F"
-	testDevMac3    = "1A:2B:3C:4F:50:61"
-	testDevMa2     = 15
-	testMID2       = testDevMa2 << 4
-	testMIDAll     = 0
-	testDevPin     = "V0"
-	testDevPin2    = "S1"
-	testMetadata   = "loc:-34.91805,138.60475"
-	testTimestamp  = datastore.EpochStart
-	testGeohash    = "r1f9652gs"
-	testTextMID    = (testDevMa << 4) | 0x08
-	testDomain     = "@ausocean.org"
-	testDomain2    = "@testdomain.org"
-	testOtherUser  = "other@ausocean.org"
-	testJunkUser   = "someone@junk.com"
-	anyDomain      = "@"
-	testCronEnc    = "1\tTest\t0\tSunrise\tfalse\t0\tset\tPower\toff\tfalse"
+	testSiteKey      = 1
+	testSiteKey2     = 2
+	testSiteName     = "OfficialTestSite"
+	testSiteOrg      = "AusOcean"
+	testSiteOps      = "ops@ausocean.org"
+	testSiteLat      = -34.91805
+	testSiteLng      = 138.60475
+	testSiteTZ       = 9.5
+	testSiteEnc      = `{"Skey":1,"Name":"OfficialTestSite","Description":"","OrgID":"AusOcean","OwnerEmail":"","OpsEmail":"ops@ausocean.org","YouTubeEmail":"","Latitude":-34.91805,"Longitude":138.60475,"Timezone":9.5,"NotifyPeriod":0,"Enabled":true,"Confirmed":false,"Premium":false,"Public":false,"Subscribed":"1970-01-01T00:00:00Z","Created":"1970-01-01T00:00:00Z"}`
+	testDevMac       = "00:00:00:00:00:01"
+	testDevMa        = 1
+	testMID          = testDevMa << 4
+	testDevDkey      = 10000001
+	testDevID        = "TestDevice"
+	testDevInputs    = "A0,V0"
+	testDevEnc       = "1\t10000001\t1\tTestDevice\tX0,V0\t\t"
+	testDevEnc2      = "1\t10000001\t1\tTestDevice\t\t\t"
+	testDevEnc3      = "1\t10000001\t1\tTestDevice\tX0,V0\t\t\t0\t0\t0\ttag\tprotocol\t-34.918050\t138.604750\ttrue\t"
+	testUserEmail    = "test@ausocean.org"
+	testUserEmail2   = "test@testdomain.org"
+	testUserPerm     = ReadPermission
+	testUserPerm2    = ReadPermission | WritePermission
+	testUserTime     = 1572157457
+	testUserTime2    = 1572157475
+	testUserEnc      = "1\ttest@ausocean.org\t\t1\t1572157457"
+	testUserEnc2     = "2\ttest@ausocean.org\t\t3\t1572157475"
+	testDevMac2      = "00:00:00:00:00:0F"
+	testDevMac3      = "1A:2B:3C:4F:50:61"
+	testDevMa2       = 15
+	testMID2         = testDevMa2 << 4
+	testMIDAll       = 0
+	testDevPin       = "V0"
+	testDevPin2      = "S1"
+	testMetadata     = "loc:-34.91805,138.60475"
+	testTimestamp    = datastore.EpochStart
+	testGeohash      = "r1f9652gs"
+	testTextMID      = (testDevMa << 4) | 0x08
+	testDomain       = "@ausocean.org"
+	testDomain2      = "@testdomain.org"
+	testOtherUser    = "other@ausocean.org"
+	testJunkUser     = "someone@junk.com"
+	anyDomain        = "@"
+	testCronEnc      = "1\tTest\t0\tSunrise\tfalse\t0\tset\tPower\toff\tfalse"
+	testSubscriberID = 1234567890
+	testFeedID       = 9876543210
 )
 
 var testTime = time.Unix(0, 0).UTC()
@@ -414,6 +417,8 @@ func TestNetreceiverFileAccess(t *testing.T) {
 	testDevice(t, "file")
 	testVariable(t, "file")
 	testCron(t, "file")
+	testSubscriber(t, "file")
+	testSubscription(t, "file")
 }
 
 func TestNetreceiverCloudAccess(t *testing.T) {
@@ -424,6 +429,8 @@ func TestNetreceiverCloudAccess(t *testing.T) {
 	testDevice(t, "cloud")
 	testVariable(t, "cloud")
 	testCron(t, "cloud")
+	testSubscriber(t, "cloud")
+	testSubscription(t, "cloud")
 }
 
 // testEntities tests access to various entities in NetReceiver's datastore.
@@ -1322,6 +1329,144 @@ func testCron(t *testing.T, kind string) {
 	if err != nil {
 		t.Errorf("DeleteCron failed with error %v", err)
 	}
+}
+
+// testSubscriber tests Subscriber methods.
+func testSubscriber(t *testing.T, kind string) {
+	ctx := context.Background()
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Fatalf("could not create new store: %v", err)
+	}
+
+	// Since we will create a new subscriber, we need to make sure to delete the existing one if it exists
+	store.Delete(ctx, store.IDKey(typeSubscriber, testSubscriberID))
+
+	// Remove the monotonic time element from the Created field.
+	s1 := &Subscriber{testSubscriberID, "", testUserEmail, "first", "last", nil, "", "", time.Now().Round(time.Second).UTC()}
+
+	err = CreateSubscriber(ctx, store, s1)
+	if err != nil {
+		t.Errorf("CreateSubscriber failed with error: %v", err)
+	}
+
+	s2, err := GetSubscriber(ctx, store, s1.ID)
+	if err != nil {
+		t.Errorf("GetSubscriber failed with error: %v", err)
+	}
+
+	if !reflect.DeepEqual(s1, s2) {
+		t.Errorf("Got different subscriber than created (by ID), got: \n%+v, wanted \n%+v", s2, s1)
+	}
+
+	s2, err = GetSubscriberByEmail(ctx, store, testUserEmail)
+	if err != nil {
+		t.Errorf("GetSubscriberByEmail failed with error: %v", err)
+	}
+
+	if !reflect.DeepEqual(s1, s2) {
+		t.Errorf("Got different subscriber than created (by Email), got: \n%+v, wanted \n%+v", s2, s1)
+	}
+
+	s1.FamilyName = "New-Name"
+	err = UpdateSubscriber(ctx, store, s1)
+	if err != nil {
+		t.Errorf("UpdateSubscriber failed with error: %v", err)
+	}
+
+	s2, err = GetSubscriber(ctx, store, testSubscriberID)
+	if err != nil {
+		t.Errorf("GetSubscriberByEmail failed with error: %v", err)
+	}
+
+	if !reflect.DeepEqual(s1, s2) {
+		t.Errorf("Got different subscriber than updated (by ID), got: \n%+v, wanted \n%+v", s2, s1)
+	}
+
+	// Test Key generation.
+	newID := NewSubscriberID(ctx, store)
+
+	// Check the length of the key.
+	s := fmt.Sprintf("%d", newID)
+	if len(s) != 10 {
+		t.Errorf("new SubscriberID has incorrect length, wanted: 10, got: %d", len(s))
+	}
+
+	_, err = GetSubscriber(ctx, store, newID)
+	if err != datastore.ErrNoSuchEntity {
+		t.Errorf("got entity for newly generated ID key")
+	}
+
+}
+
+// testSubscriber tests Subscription methods.
+func testSubscription(t *testing.T, kind string) {
+	ctx := context.Background()
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Fatalf("could not create new store: %v", err)
+	}
+
+	// Since we will create a new subscription, we need to make sure to delete the existing one if it exists
+	store.Delete(ctx, store.NameKey(typeSubscription, fmt.Sprintf("%d.%d", testSubscriberID, testFeedID)))
+
+	start := time.Now().Truncate(24 * time.Hour).UTC()
+	finish := start.AddDate(0, 0, 1)
+	s1 := &Subscription{testSubscriberID, testFeedID, SubscriptionDay, "", start, finish, true}
+
+	err = CreateSubscription(ctx, store, testSubscriberID, testFeedID, SubscriptionDay, "", true)
+	if err != nil {
+		t.Errorf("CreateSubscription failed with error: %v", err)
+	}
+
+	s2, err := GetSubscription(ctx, store, testSubscriberID, testFeedID)
+	if err != nil {
+		t.Errorf("GetSubscription failed with error: %v", err)
+	}
+
+	if !reflect.DeepEqual(s1, s2) {
+		t.Errorf("Got different subscription than created (by IDs), got: \n%+v, wanted \n%+v", s2, s1)
+	}
+
+	subs, err := GetSubscriptions(ctx, store, testSubscriberID)
+	if err != nil {
+		t.Errorf("GetSubscriptions failed with error: %v", err)
+	}
+
+	if len(subs) != 1 {
+		t.Errorf("got incorrect number of subscriptions, got %d, wanted 1", len(subs))
+	}
+
+	if !reflect.DeepEqual(s1, &subs[0]) {
+		t.Errorf("Got different subscription than created, got: \n%+v, wanted \n%+v", s1, subs[0])
+	}
+
+	s1.Renew = false
+	err = UpdateSubscription(ctx, store, s1)
+	if err != nil {
+		t.Errorf("UpdateSubscriber failed with error: %v", err)
+	}
+
+	s2, err = GetSubscription(ctx, store, testSubscriberID, testFeedID)
+	if err != nil {
+		t.Errorf("GetSubscription failed with error: %v", err)
+	}
+
+	if !reflect.DeepEqual(s1, s2) {
+		t.Errorf("Got different subscription than updated (by IDs), got: \n%+v, wanted \n%+v", s2, s1)
+	}
+
+}
+
+func testFeed(t *testing.T, kind string) {
+	ctx := context.Background()
+	store, err := datastore.NewStore(ctx, kind, "vidgrind", "")
+	if err != nil {
+		t.Fatalf("could not create new store: %v", err)
+	}
+
+	// Since we will create a new Feed, we need to make sure to delete the existing one if it exists
+	store.Delete(ctx, store.IDKey(typeFeed, testFeedID))
 }
 
 // Benchmarks follow.

--- a/model/subscriber.go
+++ b/model/subscriber.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ausocean/cloud/utils"
 	"github.com/ausocean/openfish/datastore"
+	"golang.org/x/exp/rand"
 )
 
 const (

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -22,19 +22,30 @@ LICENSE
 package model
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/ausocean/openfish/datastore"
 )
 
 const (
+	SubscriptionDay   = "Day"
+	SubscriptionMonth = "Month"
+	SubscriptionYear  = "Year"
+)
+
+const (
 	typeSubscription = "Subscription" // Subscription datastore type.
 )
+
+var errDuplicateSubscriptions = errors.New("multiple subscriptions exist for given SubscriberID and FeedID")
 
 // Subscription is an entity in the datastore that represents the relationship between a subscriber and a feed.
 type Subscription struct {
 	SubscriberID int64     // Subscriber’s ID.
-	FeedID       string    // Feed’s ID.
+	FeedID       int64     // Feed’s ID.
 	Class        string    // Subscription class, e.g., “Day”, “Month”, or “Year”.
 	Prefs        string    // User’s preferences for the presentation of this stream, e.g., “Top, Favorite”.
 	Start        time.Time // Start time of the subscription.
@@ -61,4 +72,64 @@ func (s *Subscription) Copy(dst datastore.Entity) (datastore.Entity, error) {
 // GetCache returns nil, indicating no caching.
 func (s *Subscription) GetCache() datastore.Cache {
 	return nil
+}
+
+// GetSubscription gets a subscription for a given subscriberID (sid) and feedID (fid).
+func GetSubscription(ctx context.Context, store datastore.Store, sid, fid int64) (*Subscription, error) {
+	q := store.NewQuery(typeSubscription, false, "SubscriptionID", "FeedID")
+	q.FilterField("SubscriberID", "=", sid)
+	q.FilterField("FeedID", "=", fid)
+
+	var subscriptions []Subscription
+	_, err := store.GetAll(ctx, q, &subscriptions)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to get subscription with subscriberID: %d, feedID: %d: %w", sid, fid, err)
+	}
+
+	if len(subscriptions) > 1 {
+		return nil, fmt.Errorf("for SubscriberID: %d, and FeedID: %d, failed with error: %w", sid, fid, errDuplicateSubscriptions)
+	}
+
+	return &subscriptions[0], nil
+}
+
+// CreateSubscription creates a subscription for a given subscriber ID and feed ID.
+//
+// NOTE: For a month subscription, the date of renewal will not always be the same each month, and the month gets normalised.
+// see time.Time.AddDate() for further details.
+func CreateSubscription(ctx context.Context, store datastore.Store, sid, fid int64, class, prefs string, renew bool) error {
+	// Calculate characteristics of the subscription.
+	start := time.Now().Truncate(time.Hour * 24) // Start the subscription at the start of the current day.
+	var end time.Time
+	switch class {
+	case SubscriptionDay:
+		end = start.AddDate(0, 0, 1)
+	case SubscriptionMonth:
+		end = start.AddDate(0, 1, 0)
+	case SubscriptionYear:
+		end = start.AddDate(1, 0, 0)
+	}
+
+	s := &Subscription{sid, fid, class, prefs, start, end, renew}
+
+	key := store.NameKey(typeSubscription, fmt.Sprintf("%d.%d", sid, fid))
+	return store.Create(ctx, key, s)
+}
+
+// UpdateSubscription updates a subscription.
+func UpdateSubscription(ctx context.Context, store datastore.Store, s *Subscription) error {
+	key := store.NameKey(typeSubscription, fmt.Sprintf("%d.%d", s.SubscriberID, s.FeedID))
+	_, err := store.Put(ctx, key, s)
+	return err
+}
+
+// GetSubscriptions returns all the subscriptions for a given subscriber ID (sid).
+func GetSubscriptions(ctx context.Context, store datastore.Store, sid int64) ([]Subscription, error) {
+	q := store.NewQuery(typeSubscription, false, "SubscriberID", "FeedID")
+	q.FilterField("SubscriberID", "=", sid)
+
+	var subs = []Subscription{}
+	_, err := store.GetAll(ctx, q, &subs)
+	return subs, err
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	runtime "runtime/debug"
+
+	"golang.org/x/exp/rand"
 )
 
 // TokenURIFromAccount forms a Google Cloud Storage URI for a YouTube token
@@ -254,4 +256,17 @@ func (m *RecoverableServeMux) Handle(pattern string, handler http.Handler) {
 // HandleFunc registers the handler function for the given pattern.
 func (m *RecoverableServeMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
 	m.ServeMux.HandleFunc(pattern, handler)
+}
+
+// GenerateInt64ID generates a 10 digit int64 value which can be used as
+// an ID in many datastore types.
+//
+// NOTE: the generated ID can be cast to an int32 if required.
+func GenerateInt64ID() int64 {
+	// This function generates a random number between 0, and
+	// the largest number which can be expressed as a signed int32.
+	// Subtracting 1000000000 from the range allows 1000000000 to be
+	// added back to the number after generation to ensure that the
+	// value is at least 10 digits long.
+	return rand.Int63n((1<<31)-1000000000) + 1000000000
 }


### PR DESCRIPTION
This change implements the methods required for getting, creating and updating subscribers and subscriptions.

Also adds tests for the methods.

See the schema doc for details on these methods and types: https://docs.google.com/document/d/12TYm5Al0G3T-R0wiWtX7-vrB0Yn5dH8VYRo8yWTujjY/edit?tab=t.0#heading=h.mj06vfrpcpf5

requires #387 