### PR TITLE
Bench: Fix Navmenu on configure page (#344)

### DIFF
--- a/cmd/oceanbench/s/configure.js
+++ b/cmd/oceanbench/s/configure.js
@@ -1,0 +1,19 @@
+function init() {
+    'use strict'
+
+    // Fetch all the forms we want to apply custom Bootstrap validation styles to
+    var forms = document.querySelectorAll('.needs-validation')
+
+    // Loop over them and prevent submission
+    Array.prototype.slice.call(forms)
+        .forEach(function (form) {
+            form.addEventListener('submit', function (event) {
+                if (!form.checkValidity()) {
+                    event.preventDefault()
+                    event.stopPropagation()
+                }
+
+                form.classList.add('was-validated')
+            }, false)
+        })
+}

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -528,7 +528,10 @@ type configureData struct {
 }
 
 func writeConfigure(w http.ResponseWriter, r *http.Request, profile *gauth.Profile) {
-	data := configureData{}
+	data := configureData{
+		commonData: commonData{
+			Pages: pages("devices"),
+		}}
 	ctx := r.Context()
 	var err error
 


### PR DESCRIPTION
This change fixes the nav menu by ensuring the common data Page field is initialised correctly. This change also adds field validation for the configure page.

closes #344