### PR TITLE
Bench: add name to type input field

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.24.4"
+	version     = "v0.24.5"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -245,7 +245,7 @@
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Type:</label>
                 <div class="col-sm-10 col-md-6 col-12">
                   {{if .Name}}
-                  <input class="form-control" value="{{.Type}}" readonly>
+                  <input class="form-control" value="{{.Type}}" name="ct" readonly>
                   {{else}}
                   <select name="ct" class="form-select h-auto">
                     <option value="">-- Select type --</option>{{range $.DevTypes}}


### PR DESCRIPTION
This change restores the name="ct" attribute to the client type field on the devices page. This was otherwise meaning that the type was getting overwritten as an empty string.