### PR TITLE
Bench: Hide autoconfig

### DIFF
--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -109,7 +109,7 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 	skey, _ := profileData(profile)
 	sandbox := false
 	file := "set/device.html"
-	if skey == model.SandboxSkey {
+	if skey == model.SandboxSkey && r.FormValue("new-configuration") == "true" {
 		sandbox = true
 		file = "sandbox.html"
 	}

--- a/cmd/oceanbench/t/configure.html
+++ b/cmd/oceanbench/t/configure.html
@@ -31,6 +31,7 @@
       {{if .Msg}}{{.Msg}}{{end}}
     </div>
     <div class="border rounded p-4 container-md bg-white">
+      <a href="/set/devices?ma={{.MAC}}">Manual Configuration</a>
       <form action="/set/devices/configure" enctype="multipart/form-data" method="post" class="needs-validation" novalidate>
         <input name="ma" value="{{.MAC}}" hidden>
         <div class="row d-flex gx-1 pb-1">

--- a/cmd/oceanbench/t/sandbox.html
+++ b/cmd/oceanbench/t/sandbox.html
@@ -33,6 +33,7 @@
     {{end}}
     <h1 class="container-md">Devices</h1>
     <div class="border rounded p-4 container-md bg-white">
+      <a href="/set/devices">Manual Configuration</a>
       {{ if eq (len .Devices) 0 }}
       No Devices waiting to be configured
       {{else}}

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -226,7 +226,10 @@
       {{with .Device}}
         <form action="/set/devices/edit" enctype="multipart/form-data" method="post">
           <fieldset>
-            <h2 class="pt-5">Configuration</h2>
+            <div class="d-flex justify-content-between h-auto pt-5">
+              <h2>Configuration</h2>
+              <a href="?new-configuration=true">Try Auto Configuration (Controllers Only)</a>
+            </div>
             <hr>
             <div class="d-flex flex-column gap-1">
               <div class="row d-flex gx-1">
@@ -244,7 +247,7 @@
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Type:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  {{if .Name}}
+                  {{if .Type}}
                   <input class="form-control" value="{{.Type}}" name="ct" readonly>
                   {{else}}
                   <select name="ct" class="form-select h-auto">


### PR DESCRIPTION
This change adds links back to the /set/devices page from the auto configuration pages.
This allows other devices to still be setup on the sandbox page whilst they aren't yet implemented.