### PR TITLE
Bench: Provide embed redirect link (#400)

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -577,7 +577,7 @@ func liveHandler(w http.ResponseWriter, r *http.Request) {
 	redirectURL := v.Value
 
 	// Provide embed link if requested.
-	if r.FormValue("embed") == "true" {
+	if _, ok := r.URL.Query()["embed"]; ok {
 		redirectURL = strings.ReplaceAll(redirectURL, "watch?v=", "embed/")
 	}
 

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -574,8 +574,15 @@ func liveHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("redirecting to livestream link, link: %s", v.Value)
-	http.Redirect(w, r, v.Value, http.StatusFound)
+	redirectURL := v.Value
+
+	// Provide embed link if requested.
+	if r.FormValue("embed") == "true" {
+		redirectURL = strings.ReplaceAll(redirectURL, "watch?v=", "embed/")
+	}
+
+	log.Printf("redirecting to livestream link, link: %s", redirectURL)
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // writeHttpErrorAndLog is a wrapper for writeHttpError that adds logging.

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -72,7 +72,7 @@ import (
 )
 
 const (
-	version     = "v0.24.5"
+	version     = "v0.24.6"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This change adds a form value ?embed to the /live endpoint which allows the user to specify if they want an embedable link for a youtube iFrame.

closes #400