### PR TITLE
tv: correct alarm voltage variable name

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -468,11 +468,12 @@ func (c *revidCameraClient) voltage(ctx *broadcastContext) (float64, error) {
 func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error) {
 	// Get AlarmVoltage variable; if the voltage is above this we expect the controller to be on.
 	// If the voltage is below this, we expect the controller to be off.
-	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, fmt.Sprintf("%012x", ctx.cfg.ControllerMAC)+".AlarmVoltage")
+	controllerMACHex := (&model.Device{Mac: ctx.cfg.ControllerMAC}).Hex()
+	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, controllerMACHex+".AlarmVoltage")
 	if err != nil {
 		return 0, fmt.Errorf("could not get alarm voltage variable: %v", err)
 	}
-	ctx.log("got AlarmVoltage for %s: %s", fmt.Sprintf("%012x", ctx.cfg.ControllerMAC), alarmVoltageVar.Value)
+	ctx.log("got AlarmVoltage for %s: %s", controllerMACHex, alarmVoltageVar.Value)
 
 	uncalibratedAlarmVoltage, err := strconv.Atoi(alarmVoltageVar.Value)
 	if err != nil {

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -468,10 +468,11 @@ func (c *revidCameraClient) voltage(ctx *broadcastContext) (float64, error) {
 func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error) {
 	// Get AlarmVoltage variable; if the voltage is above this we expect the controller to be on.
 	// If the voltage is below this, we expect the controller to be off.
-	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, "AlarmVoltage")
+	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, fmt.Sprintf("%012x", ctx.cfg.ControllerMAC)+".AlarmVoltage")
 	if err != nil {
 		return 0, fmt.Errorf("could not get alarm voltage variable: %v", err)
 	}
+	fmt.Printf("got AlarmVoltage for %s: %s", fmt.Sprintf("%012x", ctx.cfg.ControllerMAC), alarmVoltageVar.Value)
 
 	uncalibratedAlarmVoltage, err := strconv.Atoi(alarmVoltageVar.Value)
 	if err != nil {
@@ -540,6 +541,7 @@ func (c *revidCameraClient) publishEventIfStatus(event event, status bool, mac i
 }
 
 func (sm *hardwareStateMachine) saveHardwareStateToConfig() error {
+	fmt.Println("saving hardware state to config", hardwareStateToString(sm.currentState))
 	hardwareState := hardwareStateToString(sm.currentState)
 	hardwareStateData, err := json.Marshal(sm.currentState)
 	if err != nil {

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -472,7 +472,7 @@ func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error)
 	if err != nil {
 		return 0, fmt.Errorf("could not get alarm voltage variable: %v", err)
 	}
-	fmt.Printf("got AlarmVoltage for %s: %s", fmt.Sprintf("%012x", ctx.cfg.ControllerMAC), alarmVoltageVar.Value)
+	ctx.log("got AlarmVoltage for %s: %s", fmt.Sprintf("%012x", ctx.cfg.ControllerMAC), alarmVoltageVar.Value)
 
 	uncalibratedAlarmVoltage, err := strconv.Atoi(alarmVoltageVar.Value)
 	if err != nil {
@@ -541,7 +541,7 @@ func (c *revidCameraClient) publishEventIfStatus(event event, status bool, mac i
 }
 
 func (sm *hardwareStateMachine) saveHardwareStateToConfig() error {
-	fmt.Println("saving hardware state to config", hardwareStateToString(sm.currentState))
+	sm.log("saving hardware state to config: %v", hardwareStateToString(sm.currentState))
 	hardwareState := hardwareStateToString(sm.currentState)
 	hardwareStateData, err := json.Marshal(sm.currentState)
 	if err != nil {


### PR DESCRIPTION
This was done because I don't think the AlarmVoltage was being retrieved properly. There was no reference to the device.

I also added a print for save hardware state because we see an error about this all the time and it would be good to have more logging.