### PR TITLE
bench: set broadcast check cron in scheduler after putting it in the datastore

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -345,7 +345,13 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		c := &model.Cron{Skey: cfg.SKey, ID: "Broadcast Check", TOD: "* * * * *", Action: "rpc", Var: tvURL + "/checkbroadcasts", Enabled: true}
 		err = model.PutCron(context.Background(), settingsStore, c)
 		if err != nil {
-			reportError(w, r, req, "Warning: failed to verify checkbroadcasts cron: %v", err)
+			reportError(w, r, req, "warning: failed to verify checkbroadcasts cron: %v", err)
+			return
+		}
+
+		err = cronScheduler.Set(c)
+		if err != nil {
+			reportError(w, r, req, "could not automatically set broadcast check cron in the scheduler: %v", err)
 			return
 		}
 


### PR DESCRIPTION
This was done because the scheduler wont check the datastore often, only when the oceancron service starts.

Addresses issue #406 