### PR TITLE
oceantv: register events and states using registry

### DIFF
--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -5,104 +5,165 @@ import (
 	"time"
 
 	"context"
+
+	"github.com/ausocean/cloud/cmd/oceantv/registry"
 )
 
 type event interface{ fmt.Stringer }
 
+// registerEvent registers an event in the registry.
+// It returns a struct{} to allow us to register the event in a var declaration in
+// the global scope.
+func registerEvent(e event) struct{} {
+	err := registry.Register(e)
+	if err != nil {
+		panic(err)
+	}
+	return struct{}{}
+}
+
 type timeEvent struct{ time.Time }
+
+var _ = registerEvent(timeEvent{})
 
 func (e timeEvent) String() string { return "timeEvent" }
 
 type finishEvent struct{}
 
+var _ = registerEvent(finishEvent{})
+
 func (e finishEvent) String() string { return "finishEvent" }
 
 type startEvent struct{}
+
+var _ = registerEvent(startEvent{})
 
 func (e startEvent) String() string { return "startEvent" }
 
 type startedEvent struct{}
 
+var _ = registerEvent(startedEvent{})
+
 func (e startedEvent) String() string { return "startedEvent" }
 
 type startFailedEvent struct{}
+
+var _ = registerEvent(startFailedEvent{})
 
 func (e startFailedEvent) String() string { return "startFailedEvent" }
 
 type criticalFailureEvent struct{}
 
+var _ = registerEvent(criticalFailureEvent{})
+
 func (e criticalFailureEvent) String() string { return "criticalFailureEvent" }
 
 type healthCheckDueEvent struct{}
+
+var _ = registerEvent(healthCheckDueEvent{})
 
 func (e healthCheckDueEvent) String() string { return "healthCheckDueEvent" }
 
 type statusCheckDueEvent struct{}
 
+var _ = registerEvent(statusCheckDueEvent{})
+
 func (e statusCheckDueEvent) String() string { return "statusCheckDueEvent" }
 
 type chatMessageDueEvent struct{}
+
+var _ = registerEvent(chatMessageDueEvent{})
 
 func (e chatMessageDueEvent) String() string { return "chatMessageDueEvent" }
 
 type badHealthEvent struct{}
 
+var _ = registerEvent(badHealthEvent{})
+
 func (e badHealthEvent) String() string { return "badHealthEvent" }
 
 type goodHealthEvent struct{}
+
+var _ = registerEvent(goodHealthEvent{})
 
 func (e goodHealthEvent) String() string { return "goodHealthEvent" }
 
 type hardwareStartRequestEvent struct{}
 
+var _ = registerEvent(hardwareStartRequestEvent{})
+
 func (e hardwareStartRequestEvent) String() string { return "hardwareStartRequestEvent" }
 
 type hardwareStopRequestEvent struct{}
+
+var _ = registerEvent(hardwareStopRequestEvent{})
 
 func (e hardwareStopRequestEvent) String() string { return "hardwareStopRequestEvent" }
 
 type hardwareResetRequestEvent struct{}
 
+var _ = registerEvent(hardwareResetRequestEvent{})
+
 func (e hardwareResetRequestEvent) String() string { return "hardwareResetRequestEvent" }
 
 type hardwareStartFailedEvent struct{}
+
+var _ = registerEvent(hardwareStartFailedEvent{})
 
 func (e hardwareStartFailedEvent) String() string { return "hardwareStartFailedEvent" }
 
 type hardwareStopFailedEvent struct{}
 
+var _ = registerEvent(hardwareStopFailedEvent{})
+
 func (e hardwareStopFailedEvent) String() string { return "hardwareStopFailedEvent" }
 
 type hardwareStartedEvent struct{}
+
+var _ = registerEvent(hardwareStartedEvent{})
 
 func (e hardwareStartedEvent) String() string { return "hardwareStartedEvent" }
 
 type hardwareStoppedEvent struct{}
 
+var _ = registerEvent(hardwareStoppedEvent{})
+
 func (e hardwareStoppedEvent) String() string { return "hardwareStoppedEvent" }
 
 type controllerFailureEvent struct{}
+
+var _ = registerEvent(controllerFailureEvent{})
 
 func (e controllerFailureEvent) String() string { return "controllerFailureEvent" }
 
 type slateResetRequested struct{}
 
+var _ = registerEvent(slateResetRequested{})
+
 func (e slateResetRequested) String() string { return "slateResetRequested" }
 
 type fixFailureEvent struct{}
 
+var _ = registerEvent(fixFailureEvent{})
+
 func (e fixFailureEvent) String() string { return "fixFailureEvent" }
 
 type invalidConfigurationEvent struct{ desc string }
+
+var _ = registerEvent(invalidConfigurationEvent{})
 
 func (e invalidConfigurationEvent) String() string { return "invalidConfigurationEvent" }
 func (e invalidConfigurationEvent) Error() string  { return e.desc }
 
 type lowVoltageEvent struct{}
 
+var _ = registerEvent(lowVoltageEvent{})
+
 func (e lowVoltageEvent) String() string { return "lowVoltageEvent" }
 
 type voltageRecoveredEvent struct{}
+
+var _ = registerEvent(voltageRecoveredEvent{})
 
 func (e voltageRecoveredEvent) String() string { return "voltageRecoveredEvent" }
 
@@ -155,37 +216,10 @@ func (bus *basicEventBus) publish(event event) {
 }
 
 // stringToEvent returns an event given its name.
-func stringToEvent(name string) (event, error) {
-	eventMap := map[string]event{
-		"timeEvent":                 timeEvent{},
-		"finishEvent":               finishEvent{},
-		"startEvent":                startEvent{},
-		"startedEvent":              startedEvent{},
-		"startFailedEvent":          startFailedEvent{},
-		"criticalFailureEvent":      criticalFailureEvent{},
-		"healthCheckDueEvent":       healthCheckDueEvent{},
-		"statusCheckDueEvent":       statusCheckDueEvent{},
-		"chatMessageDueEvent":       chatMessageDueEvent{},
-		"badHealthEvent":            badHealthEvent{},
-		"goodHealthEvent":           goodHealthEvent{},
-		"hardwareStartRequestEvent": hardwareStartRequestEvent{},
-		"hardwareStopRequestEvent":  hardwareStopRequestEvent{},
-		"hardwareResetRequestEvent": hardwareResetRequestEvent{},
-		"hardwareStartFailedEvent":  hardwareStartFailedEvent{},
-		"hardwareStopFailedEvent":   hardwareStopFailedEvent{},
-		"hardwareStartedEvent":      hardwareStartedEvent{},
-		"hardwareStoppedEvent":      hardwareStoppedEvent{},
-		"controllerFailureEvent":    controllerFailureEvent{},
-		"slateResetRequested":       slateResetRequested{},
-		"fixFailureEvent":           fixFailureEvent{},
-		"invalidConfigurationEvent": invalidConfigurationEvent{},
-		"lowVoltageEvent":           lowVoltageEvent{},
-		"voltageRecoveredEvent":     voltageRecoveredEvent{},
+func stringToEvent(name string) event {
+	e, err := registry.Get(name)
+	if err != nil {
+		panic(fmt.Errorf("could not get event for string %s: %w", name, err))
 	}
-
-	event, ok := eventMap[name]
-	if !ok {
-		panic(fmt.Sprintf("unknown event: %s", name))
-	}
-	return event, nil
+	return e.(event)
 }

--- a/cmd/oceantv/broadcast_events_test.go
+++ b/cmd/oceantv/broadcast_events_test.go
@@ -145,7 +145,7 @@ func TestStringToEvent(t *testing.T) {
 				}
 			}()
 
-			got, _ := stringToEvent(tt.name)
+			got := stringToEvent(tt.name)
 			if !tt.wantPanic && !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("stringToEvent() got = %v, expected %v", got, tt.expected)
 			}

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.4.0"
+	version            = "v0.4.1"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.

--- a/cmd/oceantv/registry/map.go
+++ b/cmd/oceantv/registry/map.go
@@ -1,0 +1,53 @@
+/*
+AUTHORS
+	Saxon Nelson-Milton <saxon@ausocean.org>
+
+LICENSE
+	Copyright (C) 2024 the Australian Ocean Lab (AusOcean)
+
+	This file is part of Ocean TV. Ocean TV is free software: you can
+	redistribute it and/or modify it under the terms of the GNU
+	General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or (at your option)
+	any later version.
+
+	Ocean TV is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package registry
+
+import "sync"
+
+// SafeMap is a thread-safe map that stores any type of value.
+type SafeMap struct {
+	mu sync.RWMutex
+	m  map[string]any
+}
+
+// NewSafeMap creates a new SafeMap.
+func NewSafeMap() *SafeMap {
+	return &SafeMap{
+		m: make(map[string]any),
+	}
+}
+
+// Get retrieves a value from the map.
+func (s *SafeMap) Get(key string) (any, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	val, ok := s.m[key]
+	return val, ok
+}
+
+// Set stores a value in the map.
+func (s *SafeMap) Set(key string, value any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = value
+}

--- a/cmd/oceantv/registry/registry.go
+++ b/cmd/oceantv/registry/registry.go
@@ -1,0 +1,144 @@
+/*
+AUTHORS
+	Saxon Nelson-Milton <saxon@ausocean.org>
+
+LICENSE
+	Copyright (C) 2024 the Australian Ocean Lab (AusOcean)
+
+	This file is part of Ocean TV. Ocean TV is free software: you can
+	redistribute it and/or modify it under the terms of the GNU
+	General Public License as published by the Free Software
+	Foundation, either version 3 of the License, or (at your option)
+	any later version.
+
+	Ocean TV is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package registry provides a thread-safe registry for storing and retrieving
+// values of types via a string key.
+// It ensures that each type is registered only once and provides error
+// handling for duplicate registrations.
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Named is an interface that provides a method to return the name of a type.
+type Named interface {
+	Name() string
+}
+
+// Newable is an interface that provides a method to create a fresh value of a type.
+type Newable interface {
+	New(...interface{}) (any, error)
+}
+
+type registry struct {
+	m *SafeMap
+}
+
+var (
+	instantiated *registry
+	once         sync.Once
+)
+
+// ErrObjectAlreadyRegistered is an error that is returned when a type is
+// registered more than once.
+type ErrTypeAlreadyRegistered struct{ Name string }
+
+// Error returns the error message.
+func (e ErrTypeAlreadyRegistered) Error() string {
+	return fmt.Sprintf("type %s already registered", e.Name)
+}
+
+// Is returns true if the error is of type ErrTypeAlreadyRegistered.
+func (e ErrTypeAlreadyRegistered) Is(err error) bool {
+	_, ok := err.(ErrTypeAlreadyRegistered)
+	return ok
+}
+
+// ErrTypeDoesNotExist is an error that is returned when a type is not found
+// in the registry.
+type ErrTypeNotRegistered struct{ Name string }
+
+// Error returns the error message.
+func (e ErrTypeNotRegistered) Error() string {
+	return fmt.Sprintf("type %s is not registered", e.Name)
+}
+
+// Is returns true if the error is of type ErrTypeNotRegistered.
+func (e ErrTypeNotRegistered) Is(err error) bool {
+	_, ok := err.(ErrTypeNotRegistered)
+	return ok
+}
+
+// Register stores a type in the registry. It returns an error if the type is
+// already registered, or if the type does not implement the Named interface
+// and cannot be registered.
+//
+// To register, a value of a type is provided. Implementing the Newable interface
+// allows the registry to create and initialize a new value of the type for you
+// based on the provided args, otherwise any initialization must be done
+// manually.
+func Register(a any) error {
+	r := get()
+	if n, ok := a.(Named); ok {
+		_, err := Get(n.Name())
+		if err == nil {
+			return ErrTypeAlreadyRegistered{Name: n.Name()}
+		}
+		if !errors.Is(err, ErrTypeNotRegistered{Name: n.Name()}) {
+			return fmt.Errorf("error checking for type %s: %w", n.Name(), err)
+		}
+		r.m.Set(n.Name(), a)
+		return nil
+	}
+
+	// This is here only for legacy support of things that incorrectly implement
+	// Stringer instead of Named.
+	if n, ok := a.(fmt.Stringer); ok {
+		_, err := Get(n.String())
+		if err == nil {
+			return ErrTypeAlreadyRegistered{Name: n.String()}
+		}
+		if !errors.Is(err, ErrTypeNotRegistered{Name: n.String()}) {
+			return fmt.Errorf("error checking for type %s: %w", n.String(), err)
+		}
+		r.m.Set(n.String(), a)
+		return nil
+	}
+	return errors.New("type does not implement Named or Stringer")
+}
+
+// Get retrieves value with provide type name from the registry.
+func Get(name string, args ...interface{}) (any, error) {
+	r := get()
+	obj, ok := r.m.Get(name)
+	if !ok {
+		return nil, ErrTypeNotRegistered{Name: name}
+	}
+	if n, ok := obj.(Newable); ok {
+		var err error
+		obj, err = n.New(args...)
+		if err != nil {
+			return nil, fmt.Errorf("error call New for type %s: %w", name, err)
+		}
+	}
+	return obj, nil
+}
+
+func get() *registry {
+	once.Do(func() {
+		instantiated = &registry{m: NewSafeMap()}
+	})
+	return instantiated
+}

--- a/cmd/oceantv/registry/registry_test.go
+++ b/cmd/oceantv/registry/registry_test.go
@@ -1,0 +1,247 @@
+package registry
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func cleanup() {
+	instantiated = nil
+	once = sync.Once{}
+}
+
+func TestRegistrySingleton(t *testing.T) {
+	registry1 := get()
+	registry2 := get()
+	if registry1 != registry2 {
+		t.Errorf("expected registry1 to be equal to registry2")
+	}
+	t.Cleanup(cleanup)
+}
+
+var ErrInvalidArgumentType = errors.New("invalid argument type")
+
+type testType struct {
+	str string
+}
+
+func (testType) Name() string {
+	return "testType"
+}
+
+func newTestType(str string) *testType {
+	return &testType{str}
+}
+
+func (o testType) New(args ...interface{}) (any, error) {
+	var str string
+	for _, arg := range args {
+		if _, ok := arg.(string); !ok {
+			return nil, ErrInvalidArgumentType
+		}
+		str = arg.(string)
+	}
+	return newTestType(str), nil
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	err := Register(testType{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	obj, err := Get("testType", "hello")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	testObj := obj.(*testType)
+	if testObj.str != "hello" {
+		t.Errorf("expected testType.str to be hello, got %s", testObj.str)
+	}
+	t.Cleanup(cleanup)
+}
+
+type testTypeNoNew struct {
+	str string
+}
+
+func (testTypeNoNew) Name() string {
+	return "testTypeNoNew"
+}
+
+func newTestObjectNoNew(str string) *testTypeNoNew {
+	return &testTypeNoNew{str}
+}
+
+func TestRegistryRegisterAndGetNoNewPointer(t *testing.T) {
+	obj := &testTypeNoNew{str: "pointer"}
+	err := Register(obj)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	valObj, err := Get("testTypeNoNew")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if valObj.(*testTypeNoNew) != obj {
+		t.Errorf("expected same pointer, got different instances")
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistryRegisterAndGetNoNewValue(t *testing.T) {
+	obj := testTypeNoNew{str: "pointer"}
+	err := Register(obj)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	valObj, err := Get("testTypeNoNew")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+
+	if valObj.(testTypeNoNew) != obj {
+		t.Errorf("expected same pointer, got different instances")
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistryDuplicateRegister(t *testing.T) {
+	err := Register(testType{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	err = Register(testType{})
+	if err == nil || !errors.As(err, &ErrTypeAlreadyRegistered{}) {
+		t.Errorf("expected ErrTypeAlreadyRegistered, got %v", err)
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistryGetUnregistered(t *testing.T) {
+	_, err := Get("unregisteredObject")
+	if err == nil || !errors.As(err, &ErrTypeNotRegistered{}) {
+		t.Errorf("expected ErrTypeNotRegistered, got %v", err)
+	}
+	t.Cleanup(cleanup)
+}
+
+type unnamedObject struct{}
+
+func TestRegistryRegisterNonNameable(t *testing.T) {
+	err := Register(unnamedObject{})
+	if err == nil {
+		t.Error("expected an error for non-Named type")
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistryThreadSafety(t *testing.T) {
+	iterations := 1000
+	wg := sync.WaitGroup{}
+	wg.Add(iterations * 2)
+
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			_ = Register(testType{})
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = Get("testType", "hello")
+		}()
+	}
+
+	wg.Wait()
+	t.Cleanup(cleanup)
+}
+
+type errorNewableObject struct{}
+
+func (errorNewableObject) Name() string {
+	return "errorNewableObject"
+}
+
+func (errorNewableObject) New(args ...interface{}) (any, error) {
+	return nil, errors.New("new failed")
+}
+
+func TestRegistryNewableError(t *testing.T) {
+	err := Register(errorNewableObject{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	_, err = Get("errorNewableObject")
+	if err == nil || err.Error() != "error call New for type errorNewableObject: new failed" {
+		t.Errorf("expected New error, got %v", err)
+	}
+	t.Cleanup(cleanup)
+}
+
+type stringerObject struct{}
+
+func (stringerObject) String() string {
+	return "stringerObject"
+}
+
+func TestRegistryStringerFallback(t *testing.T) {
+	err := Register(stringerObject{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	_, err = Get("stringerObject")
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistrySingletonThreadSafety(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(10)
+
+	var instances []*registry
+	mu := sync.Mutex{}
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			r := get()
+			mu.Lock()
+			instances = append(instances, r)
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	for i := 1; i < len(instances); i++ {
+		if instances[i] != instances[0] {
+			t.Errorf("expected singleton instance, got different instances")
+		}
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistryRegisterNil(t *testing.T) {
+	err := Register(nil)
+	if err == nil {
+		t.Errorf("expected error when registering nil")
+	}
+	t.Cleanup(cleanup)
+}
+
+func TestRegistryInvalidArgumentType(t *testing.T) {
+	err := Register(testType{})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	_, err = Get("testType", 123) // Passing a non-string argument
+	if err == nil || !errors.Is(err, ErrInvalidArgumentType) {
+		t.Errorf("expected ErrInvalidArgumentType, got %v", err)
+	}
+	t.Cleanup(cleanup)
+}

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -155,11 +155,7 @@ func (bs *broadcastSystem) tick() error {
 	}
 
 	for _, event := range bs.ctx.cfg.Events {
-		e, err := stringToEvent(event)
-		if err != nil {
-			bs.log("could not convert event string to event: %v", err)
-			continue
-		}
+		e := stringToEvent(event)
 		bs.log("publishing stored event: %s", e.String())
 		bs.ctx.bus.publish(e)
 	}


### PR DESCRIPTION
The current pattern of adding an event or state type and then adding to
the stringTo function map was error prone and clunky. By using a
registry we can register events immediately, which is much more
intuitive and clear. The stringTo functions then just uses the registry
to retrieve an event of the provided type.

The registry employs a singleton i.e. the registry is only ever
instantiated once, and cannot be externally re-instantiated or
replaced.