### PR TITLE
AOTV: Add priceID to checkout links from plans (#383)

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -53,7 +53,7 @@ const (
 	projectID     = "ausoceantv"
 	oauthClientID = "1005382600755-7st09cc91eqcqveviinitqo091dtcmf0.apps.googleusercontent.com"
 	oauthMaxAge   = 60 * 60 * 24 * 7 // 7 days.
-	version       = "v0.2.0"
+	version       = "v0.2.1"
 )
 
 // service defines the properties of our web service.

--- a/cmd/ausoceantv/plans.html
+++ b/cmd/ausoceantv/plans.html
@@ -9,9 +9,9 @@
   </head>
   <body class="h-screen">
     <div class="container flex h-full items-center justify-center gap-5">
-      <plan-element plan-type="Day Pass" plan-cost="4" class="h-fit w-1/3" href="/checkout?product=day-pass"></plan-element>
-      <plan-element plan-type="Monthly Subscription" plan-cost="5" class="h-fit w-1/3" href="/checkout?product=month-subscription"></plan-element>
-      <plan-element plan-type="Yearly Subscription" plan-cost="30" comp-cost="60" class="h-fit w-1/3" href="/checkout?product=year-subscription"></plan-element>
+      <plan-element plan-type="Day Pass" plan-cost="4" class="h-fit w-1/3" href="/checkout.html?priceID=price_1QZMqMDMhXzQAv2TK0EFunPO"></plan-element>
+      <plan-element plan-type="Monthly Subscription" plan-cost="5" class="h-fit w-1/3" href="/checkout.html?priceID=price_1QZMp5DMhXzQAv2Thg1erujS"></plan-element>
+      <plan-element plan-type="Yearly Subscription" plan-cost="30" comp-cost="60" class="h-fit w-1/3" href="/checkout.html?priceID=price_1QZMpyDMhXzQAv2Txrpi9Cck"></plan-element>
     </div>
   </body>
 </html>


### PR DESCRIPTION
This change adds a priceID query parameter to the links from the plans page to the checkout. This will allow for the checkout to determine which product is being purchased.

These priceIDs come from stripe, and will need to be updated if the products ever get changed. We could potentially think about making these be loaded via an API call to make sure they are always up to date, but I think this works for now.