### PR TITLE
Model: Use namekey for subscriber

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -53,7 +53,7 @@ const (
 	projectID     = "ausoceantv"
 	oauthClientID = "1005382600755-7st09cc91eqcqveviinitqo091dtcmf0.apps.googleusercontent.com"
 	oauthMaxAge   = 60 * 60 * 24 * 7 // 7 days.
-	version       = "v0.2.2"
+	version       = "v0.2.3"
 )
 
 // service defines the properties of our web service.

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -648,6 +648,7 @@ func TestVidgrindFileAccess(t *testing.T) {
 	testScalar(t, "file")
 	testActuator(t, "file")
 	testMtsDurations(t, "file")
+	testSubscriber(t, "file")
 }
 
 func TestVidgrindCloudAccess(t *testing.T) {
@@ -660,6 +661,7 @@ func TestVidgrindCloudAccess(t *testing.T) {
 	testScalar(t, "cloud")
 	testActuator(t, "cloud")
 	testMtsDurations(t, "cloud")
+	testSubscriber(t, "cloud")
 }
 
 // testMtsMedia tests MtsMedia methods.


### PR DESCRIPTION
This changes the key of the subscriber from a 10 digit ID to a concatenation of the ID and the email.

This was done so that the entity could be queried by email by the filestore.