### PR TITLE
AOTV: Add endpoints for subscriptions

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -81,7 +81,8 @@ func registerAPIRoutes(app *fiber.App) {
 
 	v1.Group("/stripe").
 		Options("/create-payment-intent", svc.preFlightOK).
-		Post("/create-payment-intent", svc.handleCreatePaymentIntent)
+		Post("/create-payment-intent", svc.handleCreatePaymentIntent).
+		Post("/cancel", svc.cancelSubscription)
 }
 
 func main() {

--- a/model/subscription.go
+++ b/model/subscription.go
@@ -37,6 +37,10 @@ const (
 )
 
 const (
+	NoFeedID = 0 // Corresponds to a subscription witout a specified Feed ID.
+)
+
+const (
 	typeSubscription = "Subscription" // Subscription datastore type.
 )
 


### PR DESCRIPTION
This change adds 2 new endpoints, ```/get/subscription``` and ```/stripe/cancel```. These will allow the front-end to get data about the subscription and cancel the subscription respectively.