### PR TITLE
Add deployment script for cloud projects

### DIFF
--- a/cmd/ausoceantv/package.json
+++ b/cmd/ausoceantv/package.json
@@ -8,7 +8,9 @@
     "format": "prettier --write ./",
     "format:watch": "onchange \"**/*\" -- prettier --write --ignore-unknown {{changed}}",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "../../deploy.sh ausoceantv",
+    "deploy:dev": "../../deploy.sh -db ausoceantv"
   },
   "dependencies": {
     "@lit/context": "^1.1.3",

--- a/cmd/oceanbench/package.json
+++ b/cmd/oceanbench/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "build": "rollup -c",
     "build:watch": "rollup -c --watch",
-    "serve": "es-dev-server --node-resolve --watch"
+    "serve": "es-dev-server --node-resolve --watch",
+    "deploy": "../../deploy.sh -b oceanbench",
+    "deploy:dev": "../../deploy.sh -db oceanbench"
   },
   "dependencies": {
     "es-dev-server": "^2.1.0",

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+USAGE="
+Usage: $0 [-d] [-b] <projectID>
+
+Options:
+  -d  : Development Mode
+        Deploys with the --no-promote flag and sets the deployment version to 'dev'.
+        This will get deployed to dev-dot-<projectID>.ts.r.appspot.com.
+
+  -b  : Build Mode
+        Runs 'npm run build' to build the project before deploying.
+
+  <projectID>  : Required Argument
+        The Google Cloud project ID for deployment, passed to the 'gcloud app deploy' command.
+
+Description:
+This script automates the deployment of a project to Google Cloud. It supports two modes:
+1. Development Mode ('-d'): Deploys with the 'dev' version and no promotion.
+2. Build Mode ('-b'): Builds the project using 'npm run build' before deployment.
+By default, the script extracts the version from 'main.go' (using the middle number in the version).
+The script will deploy the project to Google Cloud using the specified projectID and version.
+
+Example Usage:
+  1. Deploy with build and version extraction:
+     ./deploy.sh -b myProjectID
+
+  2. Deploy in development mode:
+     ./deploy.sh -d myProjectID
+
+  3. Only build the project (no deployment):
+     ./deploy.sh -b
+
+Notes:
+- Ensure you have the correct Google Cloud credentials and project setup.
+- This script must be called from the same directory as the project files. (ie cmd/oceanbench)
+"
+
+# Displays the usage for the script.
+display_help() {
+    echo "$USAGE"
+}
+
+find_yaml() {
+    local FILENAME="$1.yaml"
+    local CURRENT_DIR=$(pwd)
+
+    # Traverse back up the tree looking for YAML.
+    while [[ "$CURRENT_DIR" != "/" ]]; do
+        # Check if the file exists in the current directory
+        if [[ -f "$CURRENT_DIR/$FILENAME" ]]; then
+            echo "$CURRENT_DIR/$FILENAME"
+            exit 0
+        fi
+        # Move to the parent directory
+        CURRENT_DIR=$(dirname "$CURRENT_DIR")
+    done
+    echo "Couldn't find $FILENAME file"
+    exit 1
+}
+
+# Check if --help is passed
+if [[ "$1" == "--help" ]]; then
+    display_help
+    exit 0
+fi
+
+DEVELOPMENT=false
+BUILD=false
+
+# Check options.
+while getopts ":db" opt; do
+    case ${opt} in
+        d)
+            # Deploy to a development environment.
+            DEVELOPMENT=true
+            ;;
+        b)
+            # Use npm run build.
+            BUILD=true
+            ;;
+        ?)
+            echo "Invalid option: -${OPTARG}."
+            display_help
+            exit 1
+            ;;
+  esac
+done
+
+# Remove options from arguments.
+shift $(($OPTIND - 1))
+
+if $BUILD; then
+    if ! npm run build; then
+      read -r -p "Build failed, do you want to continue? [y/N] " response
+      case "$response" in
+        [yY][eE][sS]|[yY])
+            echo "Continuing despite build failure..."
+            ;;
+        *)
+          echo "Exiting due to build failure."
+          exit 1
+          ;;
+      esac
+    fi
+fi
+
+# Find the YAML file in the tree.
+YAML=$(find_yaml $1)
+if [[ $? -ne 0 ]]; then
+    echo "Error: YAML file not found."
+    exit 1
+fi
+
+if $DEVELOPMENT; then
+    PROMOTE="--no-promote"
+    DEPLOYMENT_VERSION="dev"
+
+    TEMP="$(dirname "$YAML")/temp_$(basename "$YAML")"
+    cp $YAML $TEMP
+    YAML=$TEMP
+
+    sed -i "/^  OAUTH2_CALLBACK/d" $YAML
+    sed -i "s/# OAUTH2_CALLBACK/\OAUTH2_CALLBACK/g; s/# DEVELOPMENT/\DEVELOPMENT/g" $YAML
+else
+    # Get the version from main.go in the local directory.
+    echo "Looking for version number in main.go"
+    version_line=$(grep -oP 'version\s+=\s+"v\d+\.\d+\.\d+"' "main.go")
+    echo "Found version in main.go: $(echo "$version_line" | cut -d '"' -f 2)"
+
+    PROMOTE="--promote"
+    DEPLOYMENT_VERSION=$(echo "$version_line" | cut -d '.' -f 2)
+fi
+
+echo "Deploying to version: $DEPLOYMENT_VERSION"
+
+# Deploy using app.yaml file in cloud/ directory
+gcloud "app" "deploy" "--project=$1" "--version=$DEPLOYMENT_VERSION" "$PROMOTE" "--no-cache" "$YAML"
+
+if $DEVELOPMENT; then
+  rm $YAML
+fi

--- a/oceanbench.yaml
+++ b/oceanbench.yaml
@@ -8,6 +8,8 @@ env_variables:
   OCEANCRON_SECRETS: gs://ausocean/OceanCron-secrets.txt
   YOUTUBE_SECRETS: gs://ausocean/YouTube-secrets.json
   OAUTH2_CALLBACK: https://bench.cloudblue.org/oauth2callback
+  # This OAUTH2_CALLBACK variable is used by the deployment script and should be left commented out.
+  # OAUTH2_CALLBACK: https://dev-dot-oceanbench.ts.r.appspot.com/oauth2callback
 
 main: cmd/oceanbench
 
@@ -30,4 +32,4 @@ automatic_scaling:
   min_instances: 1
 
 inbound_services:
-- warmup
+  - warmup


### PR DESCRIPTION
This change adds a deploy.sh script which can be called from a cmd/ directory to build and deploy a service. This script can deploy to either a development mode (dev-dot-...) or to the most recent version (scraped from main.go version) with the version being promoted.

This script has been added to npm run deploy and deploy:dev for both ausoceantv and oceanbench.