### PR TITLE
oceantv: split stopping state into shutdown and power off

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -127,6 +127,7 @@ type BroadcastConfig struct {
 	CameraMac                int64         // Camera hardware's MAC address.
 	ControllerMAC            int64         // Controller hardware's MAC adress (controller used to power camera).
 	OnActions                string        // A series of actions to be used for power up of camera hardware.
+	ShutdownActions          string        // A series of actions to be used for shutdown of camera hardware.
 	OffActions               string        // A series of actions to be used for power down of camera hardware.
 	RTMPVar                  string        // The variable name that holds the RTMP URL and key.
 	Active                   bool          // This is true if the broadcast is currently active i.e. waiting for data or currently streaming.
@@ -332,6 +333,18 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		msg = "channel authenticated successfully"
 	case broadcastSave:
+		// Check if we've just pulled the hardware out of a failure state.
+		// We do this by checking if the hardware was in a failure state and
+		// now it's not.
+		curBroadcast, err := broadcastFromVars(req.BroadcastVars, cfg.Name)
+		if err != nil {
+			reportError(w, r, req, "could not get broadcast from vars to check hardware state: %v", err)
+			return
+		}
+		if r.FormValue("hardware-in-failure") == "false" && curBroadcast.HardwareState == "hardwareFailure" {
+			cfg.HardwareState = "hardwareOff"
+		}
+
 		// If we haven't just generated a token we should keep the same account
 		// that the config previously had.
 		cfg.Account, err = getExistingAccount(req.BroadcastVars, cfg)
@@ -339,7 +352,8 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			reportError(w, r, req, "could not get existing account for name: %s: %v", cfg.Name, err)
 			return
 		}
-		err := saveBroadcast(ctx, &req.CurrentBroadcast)
+
+		err = saveBroadcast(ctx, &req.CurrentBroadcast)
 		if err != nil {
 			reportError(w, r, req, "could not save broadcast: %v", err)
 			return

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.25.0"
+	version     = "v0.25.1"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -177,6 +177,10 @@
               <input type="input" name="on-actions" class="form-control w-50" value="{{.CurrentBroadcast.OnActions}}" class="actions" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
+              <label for="shutdown-actions" class="w-25 text-end">Shutdown Actions:</label>
+              <input type="input" name="shutdown-actions" class="form-control w-50" value="{{.CurrentBroadcast.ShutdownActions}}" class="actions">
+            </div>
+            <div class="d-flex align-items-center gap-1 mb-1">
               <label for="off-actions" class="w-25 text-end">Off Actions:</label>
               <input type="input" name="off-actions" class="form-control w-50" value="{{.CurrentBroadcast.OffActions}}" class="actions" />
             </div>

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -30,6 +30,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -104,6 +105,7 @@ type BroadcastConfig struct {
 	CameraMac                int64         // Camera hardware's MAC address.
 	ControllerMAC            int64         // Controller hardware's MAC adress (controller used to power camera).
 	OnActions                string        // A series of actions to be used for power up of camera hardware.
+	ShutdownActions          string        // A series of actions to be used for shutdown of camera hardware.
 	OffActions               string        // A series of actions to be used for power down of camera hardware.
 	RTMPVar                  string        // The variable name that holds the RTMP URL and key.
 	Active                   bool          // This is true if the broadcast is currently active i.e. waiting for data or currently streaming.
@@ -307,6 +309,21 @@ func extStart(ctx context.Context, cfg *BroadcastConfig, log func(string, ...int
 	err := setActionVars(ctx, cfg.SKey, onActions, settingsStore, log)
 	if err != nil {
 		return fmt.Errorf("could not set device variables required to start stream: %w", err)
+	}
+
+	return nil
+}
+
+var errNoShutdownActions = errors.New("no shutdown actions provided")
+
+func extShutdown(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
+	if cfg.ShutdownActions == "" {
+		return errNoShutdownActions
+	}
+
+	err := setActionVars(ctx, cfg.SKey, cfg.ShutdownActions, settingsStore, log)
+	if err != nil {
+		return fmt.Errorf("could not set device variables to end stream: %w", err)
 	}
 
 	return nil

--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -106,17 +106,19 @@ var _ = registerEvent(hardwareResetRequestEvent{})
 
 func (e hardwareResetRequestEvent) String() string { return "hardwareResetRequestEvent" }
 
-type hardwareStartFailedEvent struct{}
+type hardwareStartFailedEvent struct{ string }
 
 var _ = registerEvent(hardwareStartFailedEvent{})
 
 func (e hardwareStartFailedEvent) String() string { return "hardwareStartFailedEvent" }
+func (e hardwareStartFailedEvent) Error() string  { return e.string }
 
-type hardwareStopFailedEvent struct{}
+type hardwareStopFailedEvent struct{ string }
 
 var _ = registerEvent(hardwareStopFailedEvent{})
 
 func (e hardwareStopFailedEvent) String() string { return "hardwareStopFailedEvent" }
+func (e hardwareStopFailedEvent) Error() string  { return e.string }
 
 type hardwareStartedEvent struct{}
 
@@ -130,11 +132,12 @@ var _ = registerEvent(hardwareStoppedEvent{})
 
 func (e hardwareStoppedEvent) String() string { return "hardwareStoppedEvent" }
 
-type controllerFailureEvent struct{}
+type controllerFailureEvent struct{ string }
 
 var _ = registerEvent(controllerFailureEvent{})
 
 func (e controllerFailureEvent) String() string { return "controllerFailureEvent" }
+func (e controllerFailureEvent) Error() string  { return e.string }
 
 type slateResetRequested struct{}
 

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/ausocean/cloud/notify"
 )
 
 func TestGetHardwareStateStorage(t *testing.T) {
@@ -94,19 +100,19 @@ func TestHandleHardwareStopFailedEvent(t *testing.T) {
 		expectedState state
 	}{
 		{
-			desc:          "hardwareStopping transitions to hardwareOn",
+			desc:          "hardwareStopping transitions to hardwareFailure",
 			initialState:  newHardwareStopping(bCtx),
-			expectedState: newHardwareOn(),
+			expectedState: &hardwareFailure{},
 		},
 		{
-			desc:          "hardwareRestarting transitions to hardwareOn",
+			desc:          "hardwareRestarting transitions to hardwareFailure",
 			initialState:  newHardwareRestarting(bCtx),
-			expectedState: newHardwareOn(),
+			expectedState: &hardwareFailure{},
 		},
 		{
-			desc:          "hardwareStarting remains hardwareStarting",
+			desc:          "hardwareStarting stays as hardwareStarting",
 			initialState:  newHardwareStarting(bCtx),
-			expectedState: newHardwareStarting(bCtx), // Assuming this state remains unchanged.
+			expectedState: &hardwareStarting{}, // Assuming this state remains unchanged.
 		},
 		// Add other states and their transitions as needed.
 	}
@@ -145,14 +151,14 @@ func TestHandleHardwareStartFailedEvent(t *testing.T) {
 		expectedState state
 	}{
 		{
-			desc:          "hardwareStarting transitions to hardwareOff",
+			desc:          "hardwareStarting transitions to hardwareFailure",
 			initialState:  newHardwareStarting(bCtx),
-			expectedState: newHardwareOff(),
+			expectedState: &hardwareFailure{},
 		},
 		{
-			desc:          "hardwareRestarting transitions to hardwareOff",
+			desc:          "hardwareRestarting transitions to hardwareFailure",
 			initialState:  newHardwareRestarting(bCtx),
-			expectedState: newHardwareOff(),
+			expectedState: &hardwareFailure{},
 		},
 		// For other states that don't match the above, you might want a generic test to ensure
 		// they don't transition. Here's an example for hardwareOn:
@@ -298,6 +304,360 @@ func TestHandleHardwareResetRequestEvent(t *testing.T) {
 			if stateToString(sm.currentState) != stateToString(tt.expectedState) {
 				t.Errorf("unexpected state after handling reset request event: got %v, want %v",
 					stateToString(sm.currentState), stateToString(tt.expectedState))
+			}
+		})
+	}
+}
+
+type hardwareSystem struct {
+	ctx *broadcastContext
+	hsm *hardwareStateMachine
+	log func(string, ...interface{})
+}
+
+var hardwareSys hardwareSystem
+
+func (hs *hardwareSystem) tick() error {
+	for _, event := range hs.ctx.cfg.Events {
+		e := stringToEvent(event)
+		hs.log("publishing stored event: %s", e.String())
+		hs.ctx.bus.publish(e)
+	}
+
+	// Remove stored events we just published from the config.
+	err := hs.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.Events = nil })
+	if err != nil {
+		return fmt.Errorf("could not clear config events: %w", err)
+	}
+
+	hs.ctx.bus.publish(timeEvent{time.Now()})
+	return nil
+}
+
+type hardwareSystemOption func(*hardwareSystem) error
+
+func (h hardwareSystem) withBroadcastManager(bm BroadcastManager) hardwareSystemOption {
+	return func(bs *hardwareSystem) error {
+		bs.ctx.man = bm
+		return nil
+	}
+}
+
+func (h hardwareSystem) withBroadcastService(bs BroadcastService) hardwareSystemOption {
+	return func(b *hardwareSystem) error {
+		b.ctx.svc = bs
+		return nil
+	}
+}
+
+func (h hardwareSystem) withForwardingService(fs ForwardingService) hardwareSystemOption {
+	return func(bs *hardwareSystem) error {
+		bs.ctx.fwd = fs
+		return nil
+	}
+}
+
+func (h hardwareSystem) withHardwareManager(hm hardwareManager) hardwareSystemOption {
+	return func(bs *hardwareSystem) error {
+		bs.ctx.camera = hm
+		return nil
+	}
+}
+
+func (h hardwareSystem) withEventBus(bus eventBus) hardwareSystemOption {
+	return func(bs *hardwareSystem) error {
+		bs.ctx.bus = bus
+		bus.subscribe(bs.hsm.handleEvent)
+		return nil
+	}
+}
+
+func (h hardwareSystem) withNotifier(n notify.Notifier) hardwareSystemOption {
+	return func(bs *hardwareSystem) error {
+		bs.ctx.notifier = n
+		return nil
+	}
+}
+
+func newHardwareOnlySystem(ctx context.Context, store Store, cfg *BroadcastConfig, logOutput func(v ...any), options ...hardwareSystemOption) (*hardwareSystem, error) {
+	if ctx.Done() == nil {
+		return nil, errors.New("context must be cancellable")
+	}
+
+	// Handy log wrapper that shims with interfaces that like the
+	// classic func(string, ...interface{}) signature.
+	// This can be used by a lot of the components here.
+	log := func(msg string, args ...interface{}) {
+		logForBroadcast(cfg, logOutput, msg, args...)
+	}
+
+	var man BroadcastManager
+
+	// This will get called in the case that events are published to
+	// the event bus but our context is cancelled. This might happen if a routine
+	// is used to do a broadcast start and this function returns. We'll save them
+	// to the config and then load them next time we perform checks.
+	storeEventsAfterCtx := func(event event) {
+		log("storing event after cancel: %s", event.String())
+		try(
+			man.Save(nil, func(_cfg *BroadcastConfig) {
+				_cfg.Events = append(_cfg.Events, event.String())
+			}),
+			"could not update config with callback",
+			log,
+		)
+	}
+
+	bus := newBasicEventBus(ctx, storeEventsAfterCtx, log)
+
+	// This context will be used by the state machines for access to our bits and bobs.
+	broadcastContext := &broadcastContext{cfg, man, store, nil, nil, bus, nil, logOutput, nil}
+
+	// The hardware state machine will be responsible for the external camera hardware
+	// state.
+	hsm := newHardwareStateMachine(broadcastContext)
+	bus.subscribe(hsm.handleEvent)
+
+	sys := &hardwareSystem{broadcastContext, hsm, log}
+
+	// Apply any options to the system.
+	for _, opt := range options {
+		err := opt(sys)
+		if err != nil {
+			return nil, fmt.Errorf("could not apply option to broadcast system: %w", err)
+		}
+	}
+
+	return sys, nil
+}
+
+// TestHardwareStopAndRestart tests the hardware state machine handling of stop and reset
+// requests when shutdown actions are available and not available.
+func TestHardwareStopAndRestart(t *testing.T) {
+	const testSiteKey = 7845764367
+
+	_ = func(n int) []event {
+		var events []event
+		for i := 0; i < n; i++ {
+			events = append(events, timeEvent{})
+		}
+		return events
+	}
+
+	tests := []struct {
+		desc               string
+		cfg                func(*BroadcastConfig)
+		finalHardwareState state
+		initialEvent       event
+		hardwareMan        hardwareManager
+		newBroadcastMan    func(*testing.T, *BroadcastConfig) BroadcastManager
+
+		// Leave unset to use default max ticks.
+		// Some tests may require more ticks to reach the final state.
+		requiredTicks int
+
+		expectedEvents []event
+		expectedLogs   []string
+		expectedNotify map[int64]map[notify.Kind][]string
+	}{
+		{
+			desc: "normal hardware stop, without shutdown actions",
+			cfg: func(c *BroadcastConfig) {
+				c.Enabled = true
+				c.SKey = testSiteKey
+				c.Start = time.Now().Add(-1 * time.Hour)
+				c.End = time.Now().Add(1 * time.Hour)
+				c.HardwareState = "hardwareOn"
+				c.ControllerMAC = 1
+				c.CameraMac = 2
+			},
+			finalHardwareState: &hardwareOff{},
+			initialEvent:       hardwareStopRequestEvent{},
+			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
+			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+				return newDummyManager(t, c)
+			},
+			expectedEvents: []event{hardwareStopRequestEvent{},
+				hardwareShutdownFailedEvent{},
+				timeEvent{},
+				timeEvent{},
+				hardwareStoppedEvent{},
+			},
+			expectedLogs:   []string{},
+			expectedNotify: map[int64]map[notify.Kind][]string{},
+		},
+		{
+			desc: "normal hardware stop, with shutdown actions",
+			cfg: func(c *BroadcastConfig) {
+				c.Enabled = true
+				c.SKey = testSiteKey
+				c.Start = time.Now().Add(-1 * time.Hour)
+				c.End = time.Now().Add(1 * time.Hour)
+				c.HardwareState = "hardwareOn"
+				c.ControllerMAC = 1
+				c.CameraMac = 2
+				c.ShutdownActions = "shutdown"
+			},
+			finalHardwareState: &hardwareOff{},
+			initialEvent:       hardwareStopRequestEvent{},
+			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
+			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+				return newDummyManager(t, c)
+			},
+			expectedEvents: []event{hardwareStopRequestEvent{}, timeEvent{}, timeEvent{}, hardwareShutdownEvent{}, timeEvent{}, hardwareStoppedEvent{}},
+			expectedLogs:   []string{},
+			expectedNotify: map[int64]map[notify.Kind][]string{},
+		},
+		{
+			desc: "hardware restart, without shutdown actions",
+			cfg: func(c *BroadcastConfig) {
+				c.Enabled = true
+				c.SKey = testSiteKey
+				c.Start = time.Now().Add(-1 * time.Hour)
+				c.End = time.Now().Add(1 * time.Hour)
+				c.HardwareState = "hardwareOn"
+				c.ControllerMAC = 1
+				c.CameraMac = 2
+			},
+			finalHardwareState: &hardwareOn{},
+			initialEvent:       hardwareResetRequestEvent{},
+			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
+			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+				return newDummyManager(t, c)
+			},
+			expectedEvents: []event{
+				hardwareResetRequestEvent{},
+				hardwareShutdownFailedEvent{},
+				timeEvent{},
+				timeEvent{},
+				hardwareStoppedEvent{},
+				timeEvent{},
+				timeEvent{},
+				hardwareStartedEvent{},
+			},
+			expectedLogs:   []string{},
+			expectedNotify: map[int64]map[notify.Kind][]string{},
+		},
+		{
+			desc: "hardware restart, with shutdown actions",
+			cfg: func(c *BroadcastConfig) {
+				c.Enabled = true
+				c.SKey = testSiteKey
+				c.Start = time.Now().Add(-1 * time.Hour)
+				c.End = time.Now().Add(1 * time.Hour)
+				c.HardwareState = "hardwareOn"
+				c.ControllerMAC = 1
+				c.CameraMac = 2
+				c.ShutdownActions = "shutdown"
+			},
+			finalHardwareState: &hardwareOn{},
+			initialEvent:       hardwareResetRequestEvent{},
+			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
+			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+				return newDummyManager(t, c)
+			},
+			expectedEvents: []event{
+				hardwareResetRequestEvent{},
+				timeEvent{},
+				timeEvent{},
+				hardwareShutdownEvent{},
+				timeEvent{},
+				hardwareStoppedEvent{},
+				timeEvent{},
+				timeEvent{},
+				hardwareStartedEvent{},
+			},
+			expectedLogs:   []string{},
+			expectedNotify: map[int64]map[notify.Kind][]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			logRecorder := newLogRecorder(t)
+
+			ctx, _ := context.WithCancel(context.Background())
+
+			// Apply broadcast config modifications
+			// and update the broadcast state based on the initial state.
+			cfg := &BroadcastConfig{}
+			tt.cfg(cfg)
+
+			// Use a monkey patch to replace time.Now() with our own time.
+			// This will be updated before each tick to simulate time passing.
+			testTime := time.Now()
+			monkey.Patch(time.Now, func() time.Time { return testTime })
+			defer monkey.Unpatch(time.Now)
+
+			sys, err := newHardwareOnlySystem(
+				ctx,
+				newDummyStore(),
+				cfg,
+				logRecorder.log,
+				hardwareSys.withEventBus(newMockEventBus(func(msg string, args ...interface{}) { logForBroadcast(cfg, logRecorder.log, msg, args...) })),
+				hardwareSys.withBroadcastManager(tt.newBroadcastMan(t, cfg)),
+				hardwareSys.withHardwareManager(tt.hardwareMan),
+				hardwareSys.withNotifier(newMockNotifier()),
+			)
+			if err != nil {
+				t.Fatalf("failed to create broadcast system: %v", err)
+			}
+
+			if tt.initialEvent != nil {
+				sys.ctx.bus.publish(tt.initialEvent)
+			}
+
+			// Tick until we reach the final state. It's expected this occurs within
+			// reasonable time otherwise we have a problem.
+			const defaultMaxTicks = 10
+			for tick := 0; true; tick++ {
+				// Test test case overwrite the default max ticks.
+				maxTicks := defaultMaxTicks
+				if tt.requiredTicks > 0 {
+					maxTicks = tt.requiredTicks
+				}
+
+				if tick > maxTicks {
+					t.Errorf("failed to reach expected state after %d ticks", maxTicks)
+					return
+				}
+
+				// We've replaced time.Now() with the monkey patch, but it means we need to
+				// manually advance time before ticking the broadcast system.
+				testTime = testTime.Add(1 * time.Minute)
+
+				err = sys.tick()
+				if err != nil {
+					t.Errorf("failed to tick broadcast system: %v", err)
+					return
+				}
+				if stateToString(sys.hsm.currentState) == stateToString(tt.finalHardwareState) {
+					break
+				}
+			}
+
+			// Check the events that we got.
+			err = sys.ctx.bus.(*mockEventBus).checkEvents(tt.expectedEvents)
+			if err != nil {
+				t.Errorf("unexpected events: %v", err)
+			}
+
+			// Check the logs that we got.
+			err = logRecorder.checkLogs(tt.expectedLogs)
+			if err != nil {
+				t.Errorf("unexpected logs: %v", err)
+			}
+
+			// Check we got expected notifications.
+			err = sys.ctx.notifier.(*mockNotifier).checkNotifications(tt.expectedNotify)
+			if err != nil {
+				t.Errorf("unexpected notifications: %v", err)
+			}
+
+			// Also check if we ended up with the correct broadcast hardware machine state.
+			if stateToString(sys.hsm.currentState) != stateToString(tt.finalHardwareState) {
+				t.Errorf("unexpected state after handling started event: got %v, want %v",
+					stateToString(sys.hsm.currentState), stateToString(tt.finalHardwareState))
 			}
 		})
 	}

--- a/cmd/oceantv/broadcast_manager_test.go
+++ b/cmd/oceantv/broadcast_manager_test.go
@@ -78,6 +78,7 @@ func TestBroadcastCanBeReused(t *testing.T) {
 }
 
 func TestCreateBroadcast(t *testing.T) {
+	t.Skip("todo(#426): using obsolete setup code")
 	const testSiteKey = 7845764367
 
 	tests := []struct {
@@ -92,7 +93,7 @@ func TestCreateBroadcast(t *testing.T) {
 		{
 			desc: "create broadcast",
 			cfg: func(c *BroadcastConfig) {
-				c.CameraMac = 1
+				c.CameraMac = 2
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.4.1"
+	version            = "v0.5.0"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ausocean/cloud
 
 go 1.23
 
-toolchain go1.23.3
+toolchain go1.23.4
 
 require (
 	bou.ke/monkey v1.0.2


### PR DESCRIPTION
Closes issue #31 

We would like to start doing a proper shutdown to power down the cameras as opposed to just cutting the power. To do this we have decided to have two substates in the stopping state i.e. shutdown and power off.

Another change that has resulted is that the restart state actually has substates i.e. stopping and starting.

These changes have resulted in a cascade of changes especially to testing.