### PR TITLE
bench: add device throughput graphing

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -238,6 +238,7 @@ func main() {
 	http.HandleFunc("/admin/broadcast", adminHandler)
 	http.HandleFunc("/admin/utils", adminHandler)
 	http.HandleFunc("/data/", dataHandler)
+	http.HandleFunc("/throughputs", throughputsHandler)
 	http.HandleFunc("/", indexHandler)
 
 	if standalone {

--- a/cmd/oceanbench/search.go
+++ b/cmd/oceanbench/search.go
@@ -212,6 +212,11 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	// Calculate search period.
 	sd.Period = calcPeriod(sd.St, sd.Ft)
 
+	if sd.Pn == "throughput" {
+		writeTemplate(w, r, searchTemplate, &sd, "")
+		return
+	}
+
 	sd.PinType = sd.Pn[0]
 	switch sd.PinType {
 	case 'T':


### PR DESCRIPTION
This is useful to see throughput characteristics over time.

We're doing this by adding a quasi-pin i.e. it's not a real sensor pin, but we can set the pin to "throughput" on the UI for the device, and then have special handling of this case to use the throughputs endpoint which gets historical data to provide for graphing. The process is very similar to the data endpoint handling however, the datastore ops are different to get the data.