### PR TITLE
bench: use prettier to format our html

### DIFF
--- a/cmd/oceanbench/.prettierrc
+++ b/cmd/oceanbench/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "printWidth": 2000,
+    "tabWidth": 2,
+    "useTabs": false,
+    "singleQuote": false,
+    "htmlWhitespaceSensitivity": "ignore"
+}

--- a/cmd/oceanbench/package-lock.json
+++ b/cmd/oceanbench/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.2",
+        "prettier": "^3.4.2",
         "rollup": "^3.21.5",
         "rollup-plugin-resolve": "^0.0.1-predev.1",
         "stylelint": "^15.10.3",
@@ -5013,6 +5014,21 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",

--- a/cmd/oceanbench/package.json
+++ b/cmd/oceanbench/package.json
@@ -3,9 +3,8 @@
   "scripts": {
     "build": "rollup -c",
     "build:watch": "rollup -c --watch",
-    "serve": "es-dev-server --node-resolve --watch",
-    "deploy": "../../deploy.sh -b oceanbench",
-    "deploy:dev": "../../deploy.sh -db oceanbench"
+    "format": "prettier --write \"**/*.html\"",
+    "serve": "es-dev-server --node-resolve --watch"
   },
   "dependencies": {
     "es-dev-server": "^2.1.0",
@@ -17,6 +16,7 @@
   "author": "AusOcean",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.2",
+    "prettier": "^3.4.2",
     "rollup": "^3.21.5",
     "rollup-plugin-resolve": "^0.0.1-predev.1",
     "stylelint": "^15.10.3",

--- a/cmd/oceanbench/package.json
+++ b/cmd/oceanbench/package.json
@@ -4,7 +4,9 @@
     "build": "rollup -c",
     "build:watch": "rollup -c --watch",
     "format": "prettier --write \"**/*.html\"",
-    "serve": "es-dev-server --node-resolve --watch"
+    "serve": "es-dev-server --node-resolve --watch",
+    "deploy": "../../deploy.sh -b oceanbench",
+    "deploy:dev": "../../deploy.sh -db oceanbench"
   },
   "dependencies": {
     "es-dev-server": "^2.1.0",

--- a/cmd/oceanbench/s/download.html
+++ b/cmd/oceanbench/s/download.html
@@ -1,43 +1,56 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>VidGrind media downloader</title>
-  <script type="text/javascript" src="/s/main.js" ></script>
-</head>
-<body>
-<section>
-<h1><img src="/s/tiny_logo.png" alt="AusOcean logo"> Media downloader</h1>
-<form action="/play" method="GET">
-  <fieldset>
-    <label>App key:</label>
-    <input type="input" name="ak">
-    <br>
-    <label>Media ID:</label>
-    <input type="input" name="id" id="id">
-    <br>
-    <label>Timestamp*:</label>
-    <input type="input" name="ts">
-    <br>
-    <label>Output:</label>
-    <input type="radio" name="output" value="" checked>MPEG-TS&nbsp;<input type="radio" name="output" value="m3u">M3U8
-    <br>
-    <input type="submit" value="Download" name="submit">
-  </fieldset>
-</form>
-<br>
-<br>
-<button onClick="updateMID('ma','pn','id');">Convert to Media ID</button>
-MAC:<input type="input" id="ma" placeholder="00:00:00:00:00:00"> Pin:<input type="input" id="pn" value="V0">
-<br>
-<br>
-<p class="fineprint">* Either a single Unix timestamp or hyphen-separated timestamps (t1-t2).</p>
-</section>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>VidGrind media downloader</title>
+    <script type="text/javascript" src="/s/main.js"></script>
+  </head>
+  <body>
+    <section>
+      <h1>
+        <img src="/s/tiny_logo.png" alt="AusOcean logo" />
+        Media downloader
+      </h1>
+      <form action="/play" method="GET">
+        <fieldset>
+          <label>App key:</label>
+          <input type="input" name="ak" />
+          <br />
+          <label>Media ID:</label>
+          <input type="input" name="id" id="id" />
+          <br />
+          <label>Timestamp*:</label>
+          <input type="input" name="ts" />
+          <br />
+          <label>Output:</label>
+          <input type="radio" name="output" value="" checked />
+          MPEG-TS&nbsp;
+          <input type="radio" name="output" value="m3u" />
+          M3U8
+          <br />
+          <input type="submit" value="Download" name="submit" />
+        </fieldset>
+      </form>
+      <br />
+      <br />
+      <button onClick="updateMID('ma','pn','id');">Convert to Media ID</button>
+      MAC:
+      <input type="input" id="ma" placeholder="00:00:00:00:00:00" />
+      Pin:
+      <input type="input" id="pn" value="V0" />
+      <br />
+      <br />
+      <p class="fineprint">* Either a single Unix timestamp or hyphen-separated timestamps (t1-t2).</p>
+    </section>
 
-<footer id="footer">
-  <p>&copy;2019-2021 Australian Ocean Laboratory Limited (AusOcean) (<a rel="license" href="https://www.ausocean.org/license">License</a>)</p>
-</footer>
-</body>
+    <footer id="footer">
+      <p>
+        &copy;2019-2021 Australian Ocean Laboratory Limited (AusOcean) (
+        <a rel="license" href="https://www.ausocean.org/license">License</a>
+        )
+      </p>
+    </footer>
+  </body>
 </html>

--- a/cmd/oceanbench/s/player/audio-player.html
+++ b/cmd/oceanbench/s/player/audio-player.html
@@ -1,17 +1,15 @@
-<!DOCTYPE html>
-<link href="https://unpkg.com/css.gg@2.0.0/icons/css/play-button.css" rel="stylesheet">
-<link href="https://unpkg.com/css.gg@2.0.0/icons/css/play-pause.css" rel="stylesheet">
-<link href="https://unpkg.com/css.gg@2.0.0/icons/css/software-upload.css" rel="stylesheet">
+<!doctype html>
+<link href="https://unpkg.com/css.gg@2.0.0/icons/css/play-button.css" rel="stylesheet" />
+<link href="https://unpkg.com/css.gg@2.0.0/icons/css/play-pause.css" rel="stylesheet" />
+<link href="https://unpkg.com/css.gg@2.0.0/icons/css/software-upload.css" rel="stylesheet" />
 <div class="row inputs">
   <form action="/play/input" method="GET" id="player-form" class="w-100">
     <div class="row">
       <div class="col">
-        <progress hidden max="100" value="0" style="width:100%" id="progress-bar"></progress>
-        <div id="waveform">
-        </div>
+        <progress hidden max="100" value="0" style="width: 100%" id="progress-bar"></progress>
+        <div id="waveform"></div>
         <div id="wave-spectrogram"></div>
-        <div class="controls">
-        </div>
+        <div class="controls"></div>
       </div>
     </div>
     <div class="w-100 d-flex justify-content-between">
@@ -27,7 +25,7 @@
           &ensp;Upload File
         </div>
       </label>
-      <input name="audio-file" style="display: none" class="form-control-file form-control w-50" type="file" id="fileinput" accept=".adpcm,.pcm,.wav,.raw"/>
+      <input name="audio-file" style="display: none" class="form-control-file form-control w-50" type="file" id="fileinput" accept=".adpcm,.pcm,.wav,.raw" />
     </div>
     <details class="my-1">
       <summary>Advanced</summary>
@@ -106,7 +104,7 @@
             </div>
           </div>
           <div class="col-auto right-col w-25">
-            <input name="fc-lower" id="fc-lower-input" max="22100" min="0" step="100" type="number" class="form-control parameter-input" value="5000"/>
+            <input name="fc-lower" id="fc-lower-input" max="22100" min="0" step="100" type="number" class="form-control parameter-input" value="5000" />
           </div>
         </div>
       </div>
@@ -123,33 +121,33 @@
             </div>
           </div>
           <div class="col-auto right-col w-25">
-            <input name="fc-upper" id="fc-upper-input" max="22100" min="0" step="100" type="number" class="form-control parameter-input" value="10000"/>
+            <input name="fc-upper" id="fc-upper-input" max="22100" min="0" step="100" type="number" class="form-control parameter-input" value="10000" />
           </div>
         </div>
       </div>
       <div id="amp-factor-input-container" class="container-fluid hidable-form form-section">
         <div class="d-flex">
-            <div class="col-auto left-col">
-              <div class="container-fluid">
-                <div class="col-auto left-col">
-                  <label for="amp-factor-input" class="form-label mb-0">Amplifying Factor:</label>
-                </div>
-                <div class="col-auto left-col">
-                  <small class="text-muted w-100 d-block text-end">0 &lt; factor</small>
-                </div>
+          <div class="col-auto left-col">
+            <div class="container-fluid">
+              <div class="col-auto left-col">
+                <label for="amp-factor-input" class="form-label mb-0">Amplifying Factor:</label>
+              </div>
+              <div class="col-auto left-col">
+                <small class="text-muted w-100 d-block text-end">0 &lt; factor</small>
               </div>
             </div>
-            <div class="col-auto right-col w-25">
-              <input name="amp-factor" id="amp-factor-input" min="0" step="0.1" type="number" class="form-control parameter-input" value="2"/>
-            </div>
+          </div>
+          <div class="col-auto right-col w-25">
+            <input name="amp-factor" id="amp-factor-input" min="0" step="0.1" type="number" class="form-control parameter-input" value="2" />
+          </div>
         </div>
       </div>
       <div class="container-fluid form-section">
         <div class="d-flex">
-            <div class="col-auto left-col"></div>
-            <div class="col-auto right-col">
-              <button type="button" class="btn btn-primary" id="continue-btn" disabled>Apply Filter</button>
-            </div>
+          <div class="col-auto left-col"></div>
+          <div class="col-auto right-col">
+            <button type="button" class="btn btn-primary" id="continue-btn" disabled>Apply Filter</button>
+          </div>
         </div>
       </div>
     </details>

--- a/cmd/oceanbench/s/player/audio/index.html
+++ b/cmd/oceanbench/s/player/audio/index.html
@@ -1,78 +1,82 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Audio Player</title>
+    <script type="text/javascript" src="pcm-to-wav.js"></script>
+    <script type="text/javascript" src="adpcm.js"></script>
+    <script type="text/javascript" src="main.js"></script>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>Audio Player</title>
-  <script type="text/javascript" src="pcm-to-wav.js"></script>
-  <script type="text/javascript" src="adpcm.js"></script>
-  <script type="text/javascript" src="main.js"></script>
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-</head>
-
-<body style="height: 100%">
-  <div class="card m-auto" style="width: 40rem;">
-    <div class="card-body">
-      <div class="container-fluid">
-        <div class="row">
-          <div class="col-sm-auto">
-            <label for="urlinput">URL: </label>
+  <body style="height: 100%">
+    <div class="card m-auto" style="width: 40rem">
+      <div class="card-body">
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-sm-auto">
+              <label for="urlinput">URL:</label>
+            </div>
+            <div class="col">
+              <input type="text" id="url" class="form-control" />
+            </div>
+            <div class="col-sm-auto">
+              <button id="loadBtn">Load</button>
+            </div>
           </div>
-          <div class="col">
-            <input type="text" id="url" class="form-control">
+          <div class="row">
+            <a id="link" href=""></a>
           </div>
-          <div class="col-sm-auto">
-            <button id="loadBtn">Load</button>
+          <div class="row">
+            <div class="col">
+              <label for="bdinput">Bit Depth</label>
+              <select class="form-control" id="bdinput">
+                <option value="16">16</option>
+                <option value="32">32</option>
+              </select>
+            </div>
+            <div class="col">
+              <label for="chaninput">Channels</label>
+              <select class="form-control" id="chaninput">
+                <option value="1">1</option>
+                <option value="2">2</option>
+              </select>
+            </div>
+            <div class="col">
+              <label for="rateinput">Sample Rate</label>
+              <select class="form-control" id="rateinput">
+                <option value="8000">8000</option>
+                <option value="16000">16000</option>
+                <option value="32000">32000</option>
+                <option value="44100">44100</option>
+                <option value="48000" selected>48000</option>
+              </select>
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <a id="link" href=""></a>
-        </div>
-        <div class="row">
-          <div class="col">
-            <label for="bdinput">Bit Depth</label>
-            <select class="form-control" id="bdinput">
-              <option value="16">16</option>
-              <option value="32">32</option>
-            </select>
+          <div class="row">
+            <div class="col">
+              <input class="form-control-file form-control" type="file" id="fileinput" accept=".adpcm,.pcm,.wav,.raw" />
+            </div>
           </div>
-          <div class="col">
-            <label for="chaninput">Channels</label>
-            <select class="form-control" id="chaninput">
-              <option value="1">1</option>
-              <option value="2">2</option>
-            </select>
+          <div class="row">
+            <audio class="col" controls="controls" id="audio">
+              Your browser does not support the
+              <code>audio</code>
+              element.
+              <source id="source" src="" type="audio/wav" />
+            </audio>
           </div>
-          <div class="col">
-            <label for="rateinput">Sample Rate</label>
-            <select class="form-control" id="rateinput">
-              <option value="8000">8000</option>
-              <option value="16000">16000</option>
-              <option value="32000">32000</option>
-              <option value="44100">44100</option>
-              <option value="48000" selected>48000</option>
-            </select>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <input class="form-control-file form-control" type="file" id="fileinput" accept=".adpcm,.pcm,.wav,.raw">
-          </div>
-        </div>
-        <div class="row">
-          <audio class="col" controls="controls" id="audio">
-            Your browser does not support the <code>audio</code> element.
-            <source id="source" src="" type="audio/wav" />
-          </audio>
         </div>
       </div>
     </div>
-  </div>
-  <footer id="sticky-footer" class="footer fixed-bottom py-4 bg-dark text-white-50" style="width: 100%;">
-    <div class="container text-center">
-      <small>&copy;2019-2021 Australian Ocean Laboratory Limited (AusOcean) (<a rel="license" href="https://www.ausocean.org/license">License</a>)</small>
-    </div>
-  </footer>
-</body>
-
+    <footer id="sticky-footer" class="footer fixed-bottom py-4 bg-dark text-white-50" style="width: 100%">
+      <div class="container text-center">
+        <small>
+          &copy;2019-2021 Australian Ocean Laboratory Limited (AusOcean) (
+          <a rel="license" href="https://www.ausocean.org/license">License</a>
+          )
+        </small>
+      </div>
+    </footer>
+  </body>
 </html>

--- a/cmd/oceanbench/t/admin.html
+++ b/cmd/oceanbench/t/admin.html
@@ -1,136 +1,164 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>CloudBlue | Admin</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js" ></script>
-  <script type="text/javascript">
-  function updateUser() {
-    return copyFormValues('update_user', 'users', {'email':'input', 'perm':'select'});
-  }
-  function deleteUser() {
-    return copyFormValues('delete_user', 'users', {'email':'input'});
-  }
-  </script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>CloudBlue | Admin</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript">
+      function updateUser() {
+        return copyFormValues("update_user", "users", {
+          email: "input",
+          perm: "select",
+        });
+      }
+      function deleteUser() {
+        return copyFormValues("delete_user", "users", { email: "input" });
+      }
+    </script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-  {{if .Msg}}
-  <div class="red">{{.Msg}}</div><br>
-  {{end}}
-	<h1 class="container-md">Site Admin</h1>
-  <!-- site details -->
-  <div class="border rounded p-4 container-md bg-white">
-    <span class="bold">Site</span>
-    <hr>
-    <div>
-      <form class="inline" enctype="multipart/form-data" action="/admin/site/update" method="post">
-        <label>Name:</label>
-        <input type="text" name="sn" value="{{ .Site.Name }}" class="dbl bold w-25"><br>
-        <label>Site Key:</label>
-        <input type="text" name="sk" value="{{ .Site.Skey }}" class="w-25" readonly><br>
-        <label>Description:</label>
-        <input type="text" name="sd" value="{{ .Site.Description }}"><br>
-        <label>Org:</label>
-        <input type="text" name="org" value="{{ .Site.OrgID }}"><br>
-        <label>Timezone:</label>
-        <input type="text" name="tz" value="{{ .Site.Timezone }}" class="half"> hours &plusmn; UTC<br>
-        <label>Location:</label>
-        <input type="text" name="ll" value="{{ .Site.Latitude}},{{ .Site.Longitude }}" class="w-25"> (lat,lng)<br>
-        <label>Ops email:</label>
-        <input type="text" name="ops" value="{{ .Site.OpsEmail }}"><br>
-        <label>YouTube email:</label>
-        <input type="text" name="yt" value="{{ .Site.YouTubeEmail }}"><br>
-        <label>Notify period:</label>
-        <input type="text" name="np" value="{{ .Site.NotifyPeriod }}" class="half"> hour{{if gt .Site.NotifyPeriod 1 }}s{{end}}<br>
-        <label>Public:</label>
-        <input type="checkbox" name="pb" {{if .Site.Public }}checked{{end}}><br>
-        <label>Confirmed:</label>
-        <input type="checkbox" name="cf" {{if .Site.Confirmed }}checked{{end}}><br>
-        <label>Enabled:</label>
-        <input type="checkbox" name="en" {{if .Site.Enabled }}checked{{end}}><br>
-        <input type="submit" value="Update" class="btn btn-primary"/>
-      </form>
-      <form class="inline" enctype="multipart/form-data" action="/admin/site/delete" method="post" onsubmit="return confirm('Really delete site?');">
-        <input type="submit" value="Delete" class="btn btn-primary">
-      </form>
-    </div> 
-  </div><!--rounded box --> 
-  <br>
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{ if .Msg }}
+      <div class="red">{{ .Msg }}</div>
+      <br />
+      {{ end }}
+      <h1 class="container-md">Site Admin</h1>
+      <!-- site details -->
+      <div class="border rounded p-4 container-md bg-white">
+        <span class="bold">Site</span>
+        <hr />
+        <div>
+          <form class="inline" enctype="multipart/form-data" action="/admin/site/update" method="post">
+            <label>Name:</label>
+            <input type="text" name="sn" value="{{ .Site.Name }}" class="dbl bold w-25" />
+            <br />
+            <label>Site Key:</label>
+            <input type="text" name="sk" value="{{ .Site.Skey }}" class="w-25" readonly />
+            <br />
+            <label>Description:</label>
+            <input type="text" name="sd" value="{{ .Site.Description }}" />
+            <br />
+            <label>Org:</label>
+            <input type="text" name="org" value="{{ .Site.OrgID }}" />
+            <br />
+            <label>Timezone:</label>
+            <input type="text" name="tz" value="{{ .Site.Timezone }}" class="half" />
+            hours &plusmn; UTC
+            <br />
+            <label>Location:</label>
+            <input type="text" name="ll" value="{{ .Site.Latitude }},{{ .Site.Longitude }}" class="w-25" />
+            (lat,lng)
+            <br />
+            <label>Ops email:</label>
+            <input type="text" name="ops" value="{{ .Site.OpsEmail }}" />
+            <br />
+            <label>YouTube email:</label>
+            <input type="text" name="yt" value="{{ .Site.YouTubeEmail }}" />
+            <br />
+            <label>Notify period:</label>
+            <input type="text" name="np" value="{{ .Site.NotifyPeriod }}" class="half" />
+            hour{{ if gt .Site.NotifyPeriod 1 }}s{{ end }}
+            <br />
+            <label>Public:</label>
+            <input type="checkbox" name="pb" {{ if .Site.Public }}checked{{ end }} />
+            <br />
+            <label>Confirmed:</label>
+            <input type="checkbox" name="cf" {{ if .Site.Confirmed }}checked{{ end }} />
+            <br />
+            <label>Enabled:</label>
+            <input type="checkbox" name="en" {{ if .Site.Enabled }}checked{{ end }} />
+            <br />
+            <input type="submit" value="Update" class="btn btn-primary" />
+          </form>
+          <form class="inline" enctype="multipart/form-data" action="/admin/site/delete" method="post" onsubmit="return confirm('Really delete site?');">
+            <input type="submit" value="Delete" class="btn btn-primary" />
+          </form>
+        </div>
+      </div>
+      <!--rounded box -->
+      <br />
 
-  <!-- user details -->
-  <div class="border rounded p-4 container-md bg-white">
-    <span class="bold">Users</span>
-    <hr>
-    <table id="users">
-      <tr>
-        <th class="select"></th>
-        <th class="full">Email</th>
-        <th class="half">Role</th>
-      </tr>
-      {{ range .SiteUsers }}
-      {{$perm := .Perm}}
-      <tr>
-      <form id="{{ .Email }}">
-        <td class="select"><input type="checkbox" name="select"></td>
-        <td class="full"><input type="text" name="email" value="{{ .Email }}" class="full id" readonly></td>
-        <td class="half">
-          <select name="perm" class="half">
-            <option value="">- Select -</option>{{ range $.Roles }}
-            <option value="{{ .Perm }}"{{if eq .Perm $perm }} selected{{end}}>{{ .Name }}</option>{{end}}
-          </select>
-        </td>
-      </form>
-      </tr>
-      {{end}}
-      <tr>
-      <form enctype="multipart/form-data" action="/admin/user/add" method="post">
-        <td class="select"><button type="submit" value="Add" class="border-0 bg-white">
-          <img src="/s/add.png" />
-        </button>
-        </td>
-        <td class="full"><input type="text" name="email" class="full"></td>
-        <td class="half">
-          <select name="perm" class="half">
-            <option value="">- Select -</option>{{ range .Roles }}
-            <option value="{{ .Perm }}">{{ .Name }}</option>{{end}}
-          </select>
-        </td>
-      </form>
-      </tr>
-    </table>
-    <div>
-      <form class="inline" enctype="multipart/form-data" id="update_user" action="/admin/user/update" method="post" onsubmit="return updateUser();">
-        <input type="hidden" name="email">
-        <input type="hidden" name="perm">
-        <input type="submit" value="Update" class="btn btn-primary">
-      </form>
-      <form class="inline" enctype="multipart/form-data" id="delete_user" action="/admin/user/delete" method="post" onsubmit="return deleteUser();">
-        <input type="hidden" name="email">
-        <input type="submit" value="Delete" class="btn btn-primary">
-      </form>
-    </div>
-  </div><!--rounded box --> 
-
-  </section>
-  {{.Footer}}
+      <!-- user details -->
+      <div class="border rounded p-4 container-md bg-white">
+        <span class="bold">Users</span>
+        <hr />
+        <table id="users">
+          <tr>
+            <th class="select"></th>
+            <th class="full">Email</th>
+            <th class="half">Role</th>
+          </tr>
+          {{ range .SiteUsers }} {{ $perm := .Perm }}
+          <tr>
+            <form id="{{ .Email }}">
+              <td class="select"><input type="checkbox" name="select" /></td>
+              <td class="full">
+                <input type="text" name="email" value="{{ .Email }}" class="full id" readonly />
+              </td>
+              <td class="half">
+                <select name="perm" class="half">
+                  <option value="">- Select -</option>
+                  {{ range $.Roles }}
+                  <option value="{{ .Perm }}" {{ if eq .Perm $perm }}selected{{ end }}>{{ .Name }}</option>
+                  {{ end }}
+                </select>
+              </td>
+            </form>
+          </tr>
+          {{ end }}
+          <tr>
+            <form enctype="multipart/form-data" action="/admin/user/add" method="post">
+              <td class="select">
+                <button type="submit" value="Add" class="border-0 bg-white">
+                  <img src="/s/add.png" />
+                </button>
+              </td>
+              <td class="full">
+                <input type="text" name="email" class="full" />
+              </td>
+              <td class="half">
+                <select name="perm" class="half">
+                  <option value="">- Select -</option>
+                  {{ range .Roles }}
+                  <option value="{{ .Perm }}">{{ .Name }}</option>
+                  {{ end }}
+                </select>
+              </td>
+            </form>
+          </tr>
+        </table>
+        <div>
+          <form class="inline" enctype="multipart/form-data" id="update_user" action="/admin/user/update" method="post" onsubmit="return updateUser();">
+            <input type="hidden" name="email" />
+            <input type="hidden" name="perm" />
+            <input type="submit" value="Update" class="btn btn-primary" />
+          </form>
+          <form class="inline" enctype="multipart/form-data" id="delete_user" action="/admin/user/delete" method="post" onsubmit="return deleteUser();">
+            <input type="hidden" name="email" />
+            <input type="submit" value="Delete" class="btn btn-primary" />
+          </form>
+        </div>
+      </div>
+      <!--rounded box -->
+    </section>
+    {{ .Footer }}
   </body>
 </html>

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -1,45 +1,45 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>Broadcast</title>
-  <style type="text/css">
-    .actions { width: 400px; }
-  </style>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-  <script type="text/javascript" src="/s/broadcast.js"></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>Broadcast</title>
+    <style type="text/css">
+      .actions {
+        width: 400px;
+      }
+    </style>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript" src="/s/broadcast.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{range .Pages -}}
         <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+          <a {{if .URL}}href="{{.URL}}" {{end}}{{if .Selected}} class="selected" {{end}}>{{.Name}}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu" custom-handling>
-      {{range .Users -}}
+        {{- end}}
+      </nav-menu>
+      <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}" {{end}} slot="site-menu" custom-handling>
+        {{range .Users -}}
         <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    {{if .Msg}}
-      <div class="red">
-        {{.Msg}}
-      </div>
-      <br>
-    {{end}}
-    <br>
+        {{- end}}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{if .Msg}}
+      <div class="red">{{.Msg}}</div>
+      <br />
+      {{end}}
+      <br />
 
-    <h1 class="container-md">Broadcast</h1>
-    <div class="border rounded p-4 container-md bg-white">
-      <form action="/admin/broadcast" enctype="multipart/form-data" method="post">
+      <h1 class="container-md">Broadcast</h1>
+      <div class="border rounded p-4 container-md bg-white">
+        <form action="/admin/broadcast" enctype="multipart/form-data" method="post">
           <div class="d-flex align-items-center gap-1 mb-1">
             <button class="advanced btn btn-primary btn-sm" onclick="submitSelect()">Refresh</button>
           </div>
@@ -47,53 +47,53 @@
             <label for="broadcast-select" class="w-25 text-end">Select Broadcast:</label>
             <select id="broadcast-select" name="broadcast-select" class="form-select w-50 h-auto align-items-center" onchange="submitSelect(this)" id="broadcast-name-select">
               <option value="">-- New Broadcast --</option>
-              {{range .BroadcastVars}}
-                <option value="{{ .Name }}" {{if eq (part (split .Name ".") 1) $.CurrentBroadcast.Name}}selected{{end -}}>{{ .Name }}</option>
+              {{range .BroadcastVars}} {{$isSelected := eq (part (split .Name ".") 1) $.CurrentBroadcast.Name}}
+              <option value="{{ .Name }}" {{if $isSelected}}selected{{end}}>{{ .Name }}</option>
               {{end}}
             </select>
           </div>
           <div class="d-flex align-items-center gap-1 mb-1">
             <div class="w-25"></div>
-            <input class="advanced h-auto" type="checkbox" name="list-secondaries" value="listing-secondaries" onchange="this.form.submit()" {{if .ListingSecondaries}}checked{{end}}>
+            <input class="advanced h-auto" type="checkbox" name="list-secondaries" value="listing-secondaries" onchange="this.form.submit()" {{if .ListingSecondaries}}checked{{end}} />
             <small class="advanced">List Secondary Broadcasts</small>
           </div>
           <h2 class="pt-5">Stream Settings</h2>
-          <hr>
+          <hr />
           <fieldset class="mx-auto">
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="broadcast-name" class="w-25 text-end">Broadcast Name:</label>
-              <input type="input" name="broadcast-name" class="form-control align-items-center w-50" value="{{.CurrentBroadcast.Name}}">
+              <input type="input" name="broadcast-name" class="form-control align-items-center w-50" value="{{.CurrentBroadcast.Name}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <div class="w-25"></div>
               <div class="form-check form-switch d-flex align-items-center gap-1 p-0">
-                <input type="checkbox" name="enabled" class="form-check-input m-0" role="switch" value="enabled" {{if .CurrentBroadcast.Enabled}}checked{{end}}>
+                <input type="checkbox" name="enabled" class="form-check-input m-0" role="switch" value="enabled" {{if .CurrentBroadcast.Enabled}}checked{{end}} />
                 <small>Enabled</small>
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <div class="w-25"></div>
               <div class="form-check form-switch d-flex align-items-center gap-1 p-0">
-                <input type="checkbox" name="in-failure" class="form-check-input m-0" role="switch" value="in-failure" {{if .CurrentBroadcast.InFailure}}checked{{end}}>
+                <input type="checkbox" name="in-failure" class="form-check-input m-0" role="switch" value="in-failure" {{if .CurrentBroadcast.InFailure}}checked{{end}} />
                 <small>Failure Mode</small>
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="account" class="w-25 text-end">Channel:</label>
               <div class="d-flex align-items-center gap-2 w-50">
-                <input type="input" name="account" class="form-control align-items-center" value="{{.CurrentBroadcast.Account}}" readonly>
+                <input type="input" name="account" class="form-control align-items-center" value="{{.CurrentBroadcast.Account}}" readonly />
                 <button class="btn btn-primary w-50" onclick="buttonClick(this)" value="broadcast-token">Generate Token</button>
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <div class="w-25"></div>
               <div class="d-flex align-items-center gap-3 flex-row">
-              {{range .Settings.Privacy}}
+                {{range .Settings.Privacy}}
                 <div>
-                  <input type="radio" name="privacy" value="{{.}}" id="{{.}}-radio" {{if eq . $.CurrentBroadcast.Privacy}}checked{{end}}>
+                  <input type="radio" name="privacy" value="{{.}}" id="{{.}}-radio" {{if eq . $.CurrentBroadcast.Privacy}}checked{{end}} />
                   <label class="text-capitalize" for="{{.}}-radio">{{.}}</label>
                 </div>
-              {{end}}
+                {{end}}
               </div>
             </div>
             <div class="d-flex align-items-top gap-1 mb-1">
@@ -102,45 +102,45 @@
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="stream-name" class="w-25 text-end">Stream Name:</label>
-              <input type="input" class="form-control w-50" name="stream-name" value="{{.CurrentBroadcast.StreamName}}">
+              <input type="input" class="form-control w-50" name="stream-name" value="{{.CurrentBroadcast.StreamName}}" />
             </div>
             <div id="set-times">
               <div class="d-flex align-items-center gap-1 mb-1">
                 <label for="start-time" class="w-25 text-end">Start Date/Time:</label>
                 <div class="d-flex gap-2 w-50">
-                  <input name="start-time" class="form-control" type="datetime-local" id="start-time" onchange="sync('start-time', 'start-timestamp', 'time-zone', true)" size="14">
-                  <input class="advanced form-control"  name="start-timestamp" type="input" id="start-timestamp" onchange="sync('start-time', 'start-timestamp', 'time-zone', false);" value="{{if .CurrentBroadcast.StartTimestamp}}{{.CurrentBroadcast.StartTimestamp}}{{end}}" size="15">
+                  <input name="start-time" class="form-control" type="datetime-local" id="start-time" onchange="sync('start-time', 'start-timestamp', 'time-zone', true)" size="14" />
+                  <input class="advanced form-control" name="start-timestamp" type="input" id="start-timestamp" onchange="sync('start-time', 'start-timestamp', 'time-zone', false);" value="{{if .CurrentBroadcast.StartTimestamp}}{{.CurrentBroadcast.StartTimestamp}}{{end}}" size="15" />
                 </div>
               </div>
               <div class="d-flex align-items-center gap-1 mb-1">
                 <label for="end-time" class="w-25 text-end">End Date/Time:</label>
                 <div class="d-flex gap-2 w-50">
-                  <input name="end-time" class="form-control" type="datetime-local" id="end-time" onchange="sync('end-time', 'end-timestamp', 'time-zone', true)" size="14">
-                  <input class="advanced form-control" name="end-timestamp" type="input" id="end-timestamp" onchange="sync('end-time', 'end-timestamp', 'time-zone', false);" value="{{if .CurrentBroadcast.EndTimestamp}}{{.CurrentBroadcast.EndTimestamp}}{{end}}" size="15">
+                  <input name="end-time" class="form-control" type="datetime-local" id="end-time" onchange="sync('end-time', 'end-timestamp', 'time-zone', true)" size="14" />
+                  <input class="advanced form-control" name="end-timestamp" type="input" id="end-timestamp" onchange="sync('end-time', 'end-timestamp', 'time-zone', false);" value="{{if .CurrentBroadcast.EndTimestamp}}{{.CurrentBroadcast.EndTimestamp}}{{end}}" size="15" />
                 </div>
               </div>
               <div class="d-flex align-items-center gap-1 mb-1">
                 <label class="w-25 text-end">Timezone:</label>
                 <div class="w-25">
-                  <input class="w-50 form-control" id="time-zone" size="1" value="{{with .Site}}{{if .Timezone}}{{.Timezone}}{{end}}{{end}}" readonly>
+                  <input class="w-50 form-control" id="time-zone" size="1" value="{{with .Site}}{{if .Timezone}}{{.Timezone}}{{end}}{{end}}" readonly />
                 </div>
               </div>
               <div class="d-flex align-items-center gap-1 mb-1">
                 <label class="w-25 text-end">Broadcast State:</label>
-                <input class="w-50 align-items-center form-control" id="broadcast-state" size="1" value="{{.CurrentBroadcast.BroadcastState}}" readonly>
+                <input class="w-50 align-items-center form-control" id="broadcast-state" size="1" value="{{.CurrentBroadcast.BroadcastState}}" readonly />
               </div>
               <div class="d-flex align-items-center gap-1 mb-1">
                 <label class="w-25 text-end">Hardware State:</label>
-                <input class="w-50 align-items-center form-control" id="hardware-state" size="1" value="{{.CurrentBroadcast.HardwareState}}" readonly>
+                <input class="w-50 align-items-center form-control" id="hardware-state" size="1" value="{{.CurrentBroadcast.HardwareState}}" readonly />
               </div>
               <div class="d-flex align-items-center gap-1 mb-1">
                 <label class="w-25 text-end">Hardware State Data:</label>
-                <input class="w-50 align-items-center form-control" id="hardware-state-data" size="1" value="{{.CurrentBroadcast.PrettyHardwareStateData}}" readonly>
+                <input class="w-50 align-items-center form-control" id="hardware-state-data" size="1" value="{{.CurrentBroadcast.PrettyHardwareStateData}}" readonly />
               </div>
             </div>
           </fieldset>
           <h2 class="pt-5">Device Settings</h2>
-          <hr>
+          <hr />
           <fieldset>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="camera-mac" class="w-25 text-end">Camera:</label>
@@ -148,18 +148,17 @@
                 <select name="camera-mac" class="form-select w-50">
                   {{if not .CurrentBroadcast.CameraMac}}
                   <option>Select</option>
-                  {{end}}
-                  {{range .Cameras}}
-                    <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.CameraMac }}selected{{end}}>{{.Name}}</option>
-                {{ end }}
+                  {{end}} {{range .Cameras}}
+                  <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.CameraMac }}selected{{end}}>{{.Name}}</option>
+                  {{ end }}
                 </select>
                 <div class="d-flex gap-3 flex-row">
-                {{range .Settings.Resolution}}
+                  {{range .Settings.Resolution}}
                   <div>
-                    <input type="radio" name="resolution" value="{{.}}" {{if eq . $.CurrentBroadcast.Resolution}}checked{{end}}>
+                    <input type="radio" name="resolution" value="{{.}}" {{if eq . $.CurrentBroadcast.Resolution}}checked{{end}} />
                     {{.}}
                   </div>
-                {{end}}
+                  {{end}}
                 </div>
               </div>
             </div>
@@ -167,32 +166,31 @@
               <label for="controller-mac" class="w-25 text-end">Controller:</label>
               <select name="controller-mac" class="form-select w-50">
                 {{if not .CurrentBroadcast.ControllerMAC}}
-                  <option>Select</option>
-                {{end}}
-                {{range .Controllers}}
-                  <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.ControllerMAC }}selected{{end}}>{{.Name}}</option>
+                <option>Select</option>
+                {{end}} {{range .Controllers}}
+                <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.ControllerMAC }}selected{{end}}>{{.Name}}</option>
                 {{ end }}
               </select>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="on-actions" class="w-25 text-end">On Actions:</label>
-              <input type="input" name="on-actions" class="form-control w-50" value="{{.CurrentBroadcast.OnActions}}" class="actions">
+              <input type="input" name="on-actions" class="form-control w-50" value="{{.CurrentBroadcast.OnActions}}" class="actions" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="off-actions" class="w-25 text-end">Off Actions:</label>
-              <input type="input" name="off-actions" class="form-control w-50" value="{{.CurrentBroadcast.OffActions}}" class="actions">
+              <input type="input" name="off-actions" class="form-control w-50" value="{{.CurrentBroadcast.OffActions}}" class="actions" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="rtmp-key-var" class="w-25 text-end">RTMP URL Variable:</label>
-              <input type="input" name="rtmp-key-var" class="w-50 form-control" value="{{.CurrentBroadcast.RTMPVar}}">
+              <input type="input" name="rtmp-key-var" class="w-50 form-control" value="{{.CurrentBroadcast.RTMPVar}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label class="advanced w-25 text-end">RTMP Key:</label>
-              <input class="advanced w-50 form-control" type="input" name="rtmp-key" value="{{.CurrentBroadcast.RTMPKey}}">
+              <input class="advanced w-50 form-control" type="input" name="rtmp-key" value="{{.CurrentBroadcast.RTMPKey}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="report-sensor" class="w-25 text-end">Live Data in Chat:</label>
-              <input type="checkbox" name="report-sensor" id="report-sensor" value="Chat">
+              <input type="checkbox" name="report-sensor" id="report-sensor" value="Chat" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label class="advanced w-25 text-end">Sensors:</label>
@@ -203,81 +201,82 @@
               <div class="w-25"></div>
               <div class="d-flex align-items-center gap-2 flex-wrap">
                 {{ range .CurrentBroadcast.SensorList }}
-                  <div class="d-flex gap-1">
-                    <input class="advanced" type="checkbox" name="{{ .Name }}" id="{{ .Name }}" value="{{ .Sensor.Name }}">
-                    <p class="advanced">{{ .Sensor.Name }}</p>
-                  </div>
+                <div class="d-flex gap-1">
+                  <input class="advanced" type="checkbox" name="{{ .Name }}" id="{{ .Name }}" value="{{ .Sensor.Name }}" />
+                  <p class="advanced">{{ .Sensor.Name }}</p>
+                </div>
                 {{ end }}
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="check-health" class="advanced w-25 text-end">Health Check:</label>
-              <input class="advanced" type="checkbox" name="check-health" value="checking-health" {{if .CurrentBroadcast.CheckingHealth}}checked{{end}}>
+              <input class="advanced" type="checkbox" name="check-health" value="checking-health" {{if .CurrentBroadcast.CheckingHealth}}checked{{end}} />
             </div>
           </fieldset>
-          <h2 class=" advanced pt-5">Advanced Settings</h2>
-          <hr class="advanced">
+          <h2 class="advanced pt-5">Advanced Settings</h2>
+          <hr class="advanced" />
           <fieldset>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="use-vidforward" class="advanced w-25 text-end">Use Vidforward:</label>
-              <input class="advanced" type="checkbox" name="use-vidforward" value="using-vidforward" {{if .CurrentBroadcast.UsingVidforward}}checked{{end}}>
+              <input class="advanced" type="checkbox" name="use-vidforward" value="using-vidforward" {{if .CurrentBroadcast.UsingVidforward}}checked{{end}} />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="vidforward-host" class="advanced w-25 text-end">Vidforward Host:</label>
-              <input class="advanced w-50 form-control" type="input" name="vidforward-host" value="{{.CurrentBroadcast.VidforwardHost}}">
+              <input class="advanced w-50 form-control" type="input" name="vidforward-host" value="{{.CurrentBroadcast.VidforwardHost}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="slate-file" class="advanced w-25 text-end">Slate File:</label>
               <div class="d-flex w-50 gap-2">
-                <input class="advanced form-control" type="file" name="slate-file">
+                <input class="advanced form-control" type="file" name="slate-file" />
                 <button class="advanced w-50 btn btn-primary" onclick="buttonClick(this)" value="vidforward-slate-update">Upload Slate</button>
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="required-streaming-voltage" class="advanced w-25 text-end">Required Streaming Voltage:</label>
-              <input class="advanced w-50 form-control" type="input" name="required-streaming-voltage" value="{{.CurrentBroadcast.RequiredStreamingVoltage}}">
+              <input class="advanced w-50 form-control" type="input" name="required-streaming-voltage" value="{{.CurrentBroadcast.RequiredStreamingVoltage}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="voltage-recovery-timeout" class="advanced w-25 text-end">Voltage Recovery Timeout (hr):</label>
-              <input class="advanced w-50 form-control" type="input" name="voltage-recovery-timeout" value="{{.CurrentBroadcast.VoltageRecoveryTimeout}}">
+              <input class="advanced w-50 form-control" type="input" name="voltage-recovery-timeout" value="{{.CurrentBroadcast.VoltageRecoveryTimeout}}" />
+            </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="register-openfish" class="advanced w-25 text-end">Register stream with OpenFish:</label>
-              <input class="advanced" type="checkbox" name="register-openfish" value="register-openfish" {{if .CurrentBroadcast.RegisterOpenFish}}checked{{end}}>
+              <input class="advanced" type="checkbox" name="register-openfish" value="register-openfish" {{if .CurrentBroadcast.RegisterOpenFish}}checked{{end}} />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="openfish-capturesource" class="advanced w-25 text-end">OpenFish Capture Source:</label>
-              <input class="advanced w-50 form-control" type="input" name="openfish-capturesource" value="{{.CurrentBroadcast.OpenFishCaptureSource}}">
+              <input class="advanced w-50 form-control" type="input" name="openfish-capturesource" value="{{.CurrentBroadcast.OpenFishCaptureSource}}" />
             </div>
           </fieldset>
-        <input type="hidden" name="broadcast-id" value="{{.CurrentBroadcast.ID}}">
-        <input type="hidden" name="active" value="{{.CurrentBroadcast.Active}}">
-        <div class="d-flex w-100 gap-2">
-          <div class="w-25"></div>
-          <button class="btn btn-primary" onclick="buttonClick(this)" value="broadcast-save">Save</button>
-          <button class="btn btn-primary" onclick="buttonClick(this)" value="broadcast-delete">Delete</button>
-        </div>
-        <div class="w-100 d-flex justify-content-end gap-1">
-          <label for="adv-toggle">Advanced Options:</label>
-          <input type="checkbox" id="adv-options-toggle" name="adv-toggle" onchange="toggleAdvanced(checked)">
-        </div>
+          <input type="hidden" name="broadcast-id" value="{{.CurrentBroadcast.ID}}" />
+          <input type="hidden" name="active" value="{{.CurrentBroadcast.Active}}" />
+          <div class="d-flex w-100 gap-2">
+            <div class="w-25"></div>
+            <button class="btn btn-primary" onclick="buttonClick(this)" value="broadcast-save">Save</button>
+            <button class="btn btn-primary" onclick="buttonClick(this)" value="broadcast-delete">Delete</button>
+          </div>
+          <div class="w-100 d-flex justify-content-end gap-1">
+            <label for="adv-toggle">Advanced Options:</label>
+            <input type="checkbox" id="adv-options-toggle" name="adv-toggle" onchange="toggleAdvanced(checked)" />
+          </div>
 
-        <!--This hidden field stores the value of button presses.-->
-        <input type="hidden" name="action" value="">
-      </form>
-    </div>
-
-    {{if .CurrentBroadcast.ID}}
-    <div class="border rounded p-4 container-md bg-white mt-5 d-flex justify-content-center">
-      <div class="rounded overflow-hidden" style="height: 315px; width: 560px;"> 
-          <iframe width="560" height="315" src="https://www.youtube.com/embed/{{.CurrentBroadcast.ID}}" frameborder="0" allowfullscreen></iframe>
+          <!--This hidden field stores the value of button presses.-->
+          <input type="hidden" name="action" value="" />
+        </form>
       </div>
-    </div>
-    {{end}}
-  </section>
-  <!-- These only exist to hold the data from the templates, these will be read by javascript. -->
-  <div id="sensor-list" style="display: none;" data-sensor-list='{{json .CurrentBroadcast.SensorList}}'></div>
-  <div id="send-msg" style="display: none;" data-send-msg="{{.CurrentBroadcast.SendMsg}}"></div>
 
-  {{.Footer}}
-</body>
+      {{if .CurrentBroadcast.ID}}
+      <div class="border rounded p-4 container-md bg-white mt-5 d-flex justify-content-center">
+        <div class="rounded overflow-hidden" style="height: 315px; width: 560px">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/{{.CurrentBroadcast.ID}}" frameborder="0" allowfullscreen></iframe>
+        </div>
+      </div>
+      {{end}}
+    </section>
+    <!-- These only exist to hold the data from the templates, these will be read by javascript. -->
+    <div id="sensor-list" style="display: none" data-sensor-list="{{json .CurrentBroadcast.SensorList}}"></div>
+    <div id="send-msg" style="display: none" data-send-msg="{{.CurrentBroadcast.SendMsg}}"></div>
+
+    {{.Footer}}
+  </body>
 </html>

--- a/cmd/oceanbench/t/configure.html
+++ b/cmd/oceanbench/t/configure.html
@@ -1,93 +1,92 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>Devices</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-  <script type="text/javascript" src="/s/configure.js"></script>
-</head>
-<body onload="init();">
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>Devices</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript" src="/s/configure.js"></script>
+  </head>
+  <body onload="init();">
+    <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{range .Pages -}}
         <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+          <a {{if .URL}}href="{{.URL}}" {{end}}{{if .Selected}} class="selected" {{end}}>{{.Name}}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
+        {{- end}}
+      </nav-menu>
+      <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}" {{end}} slot="site-menu">
+        {{range .Users -}}
         <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    <h1 class="container-md">Configure</h1>
-    <div class="red" style="display:none" id="msg">
-      {{if .Msg}}{{.Msg}}{{end}}
-    </div>
-    <div class="border rounded p-4 container-md bg-white">
-      <a href="/set/devices?ma={{.MAC}}">Manual Configuration</a>
-      <form action="/set/devices/configure" enctype="multipart/form-data" method="post" class="needs-validation" novalidate>
-        <input name="ma" value="{{.MAC}}" hidden>
-        <div class="row d-flex gx-1 pb-1">
-          <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Name:</label>
-          <div class="col-sm-10 col-md-6 col-12">
-            <input name="dn" class="form-control" placeholder="Device Name" type="text" required>
-            <p class="invalid-feedback">Device Name is required</p>
+        {{- end}}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      <h1 class="container-md">Configure</h1>
+      <div class="red" style="display: none" id="msg">{{if .Msg}}{{.Msg}}{{end}}</div>
+      <div class="border rounded p-4 container-md bg-white">
+        <a href="/set/devices?ma={{.MAC}}">Manual Configuration</a>
+        <form action="/set/devices/configure" enctype="multipart/form-data" method="post" class="needs-validation" novalidate>
+          <input name="ma" value="{{.MAC}}" hidden />
+          <div class="row d-flex gx-1 pb-1">
+            <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Name:</label>
+            <div class="col-sm-10 col-md-6 col-12">
+              <input name="dn" class="form-control" placeholder="Device Name" type="text" required />
+              <p class="invalid-feedback">Device Name is required</p>
+            </div>
           </div>
-        </div>
-        <div class="row d-flex gx-1 pb-1">
-          <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Site:</label>
-          <div class="col-sm-10 col-md-6 col-12">
-            <select name="sk" class="form-select h-auto align-items-center" required>
-              <option value="">-- Site --</option>
-              {{range .Sites}}
-                  <option value="{{ .Skey }}">{{ .Name }}</option>
-              {{end}}
-            </select>
-            <p class="invalid-feedback">Target Site is required</p>
-        </div>
-        <div class="row d-flex gx-1 pb-1">
-          <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Type:</label>
-          <div class="col-sm-10 col-md-6 col-12">
-            <select name="dt" class="form-select h-auto align-items-center" required>
-              <option value="">-- Device Type --</option>
-              {{range .DevTypes}}
+          <div class="row d-flex gx-1 pb-1">
+            <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Site:</label>
+            <div class="col-sm-10 col-md-6 col-12">
+              <select name="sk" class="form-select h-auto align-items-center" required>
+                <option value="">-- Site --</option>
+                {{range .Sites}}
+                <option value="{{ .Skey }}">{{ .Name }}</option>
+                {{end}}
+              </select>
+              <p class="invalid-feedback">Target Site is required</p>
+            </div>
+          </div>
+          <div class="row d-flex gx-1 pb-1">
+            <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Type:</label>
+            <div class="col-sm-10 col-md-6 col-12">
+              <select name="dt" class="form-select h-auto align-items-center" required>
+                <option value="">-- Device Type --</option>
+                {{range .DevTypes}}
                 <option value="{{ . }}">{{ . }}</option>
-              {{end}}
-            </select>
-            <p class="invalid-feedback">Device Type is required</p>
+                {{end}}
+              </select>
+              <p class="invalid-feedback">Device Type is required</p>
+            </div>
           </div>
-        </div>
-        <div class="row d-flex gx-1 pb-1">
-          <label class="col-sm-2 col-md-3 col-1 text-end pt-2">WiFi:</label>
-          <div class="col-sm-5 col-md-3 col-12">
-            <input name="ssid" class="form-control" placeholder="SSID" type="text">
+          <div class="row d-flex gx-1 pb-1">
+            <label class="col-sm-2 col-md-3 col-1 text-end pt-2">WiFi:</label>
+            <div class="col-sm-5 col-md-3 col-12">
+              <input name="ssid" class="form-control" placeholder="SSID" type="text" />
+            </div>
+            <div class="col-sm-5 col-md-3 col-12">
+              <input name="pass" class="form-control" placeholder="Password" type="text" />
+            </div>
           </div>
-          <div class="col-sm-5 col-md-3 col-12">
-            <input name="pass" class="form-control" placeholder="Password" type="text">
+          <div class="row d-flex gx-1 pb-1">
+            <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Location:</label>
+            <div class="col-sm-5 col-md-3 col-12">
+              <input name="lat" class="form-control" placeholder="Latitude" type="text" />
+            </div>
+            <div class="col-sm-5 col-md-3 col-12">
+              <input name="long" class="form-control" placeholder="Longitude" type="text" />
+            </div>
           </div>
-        </div>
-        <div class="row d-flex gx-1 pb-1">
-          <label class="col-sm-2 col-md-3  col-1 text-end pt-2">Location:</label>
-          <div class="col-sm-5 col-md-3 col-12">
-            <input name="lat" class="form-control" placeholder="Latitude" type="text">
+          <div class="d-flex justify-content-center">
+            <input type="submit" class="btn btn-primary col-12 col-sm-6" value="Configure Device" />
           </div>
-          <div class="col-sm-5 col-md-3 col-12">
-            <input name="long" class="form-control" placeholder="Longitude" type="text">
-          </div>
-        </div>
-        <div class="d-flex justify-content-center">
-          <input type="submit" class="btn btn-primary col-12 col-sm-6" value="Configure Device">
-        </div>
-      </form>
-    </div>
-  </section>
-  {{.Footer}}
-</body>
+        </form>
+      </div>
+    </section>
+    {{.Footer}}
+  </body>
 </html>

--- a/cmd/oceanbench/t/cron-index.html
+++ b/cmd/oceanbench/t/cron-index.html
@@ -1,25 +1,32 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>Ocean Cron</title>
-</head>
-<body>
-  <header id="header" class="header">
-    <div class="heading">
-       <img src="/s/tiny_logo.png" alt="AusOcean logo"> Ocean Cron v{{.Version}}
-    </div>
-  </header>
-  <section id="main" class="main">
-    <p>
-    Welcome to <em>Ocean Cron</em> by <a href="https://www.ausocean.org">AusOcean</a>.
-    </p>
-    <p>
-    Manage crons at <a href="{{if .Standalone}}http://localhost:8080{{else}}https://vidgrind.ausocean.org{{end}}">Ocean Bench</a>.
-    </p>
-  </section>
-  {{.Footer}}
-</body>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>Ocean Cron</title>
+  </head>
+  <body>
+    <header id="header" class="header">
+      <div class="heading">
+        <img src="/s/tiny_logo.png" alt="AusOcean logo" />
+        Ocean Cron v{{ .Version }}
+      </div>
+    </header>
+    <section id="main" class="main">
+      <p>
+        Welcome to
+        <em>Ocean Cron</em>
+        by
+        <a href="https://www.ausocean.org">AusOcean</a>
+        .
+      </p>
+      <p>
+        Manage crons at
+        <a href="{{ if .Standalone }}http://localhost:8080{{ else }}https://vidgrind.ausocean.org{{ end }}">Ocean Bench</a>
+        .
+      </p>
+    </section>
+    {{ .Footer }}
+  </body>
 </html>

--- a/cmd/oceanbench/t/footer.html
+++ b/cmd/oceanbench/t/footer.html
@@ -1,4 +1,8 @@
 <!-- This a template fragment, not a complete HTML template. -->
-  <footer>
-    <p>&copy;2019-2024 Australian Ocean Laboratory Limited (AusOcean) (<a rel="license" href="https://www.ausocean.org/license">License</a>)</p>
-  </footer>
+<footer>
+  <p>
+    &copy;2019-2024 Australian Ocean Laboratory Limited (AusOcean) (
+    <a rel="license" href="https://www.ausocean.org/license">License</a>
+    )
+  </p>
+</footer>

--- a/cmd/oceanbench/t/index.html
+++ b/cmd/oceanbench/t/index.html
@@ -1,50 +1,56 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>CloudBlue</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js" ></script>
-  <script type="text/javascript" src="/s/index.js"></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>CloudBlue</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript" src="/s/index.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    <h1 class="container-md">Home</h1>
-    <div class="border rounded p-4 container-md bg-white">
-      <p>
-        Welcome to <em>CloudBlue</em> by <a href="https://www.ausocean.org">AusOcean</a>.
-      </p>
-      {{if .Profile}}
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu"></site-menu>
+    </header-group>
+    <section id="main" class="main">
+      <h1 class="container-md">Home</h1>
+      <div class="border rounded p-4 container-md bg-white">
         <p>
-          You are logged in as {{ .Profile.Email}} and have <span id="num-sites" class="spinner-border spinner-border-sm" role="status"></span> sites.
+          Welcome to
+          <em>CloudBlue</em>
+          by
+          <a href="https://www.ausocean.org">AusOcean</a>
+          .
+        </p>
+        {{ if .Profile }}
+        <p>
+          You are logged in as {{ .Profile.Email }} and have
+          <span id="num-sites" class="spinner-border spinner-border-sm" role="status"></span>
+          sites.
         </p>
         <p>
           <a href="/admin/site/add">Register a new site</a>
         </p>
-      {{else}}
+        {{ else }}
         <div>
-          <a href="{{.LoginURL}}" style="text-transform:none">
-             <img width="20px" alt="Google logo" src="/s/google.png"/> Login with Google
+          <a href="{{ .LoginURL }}" style="text-transform: none">
+            <img width="20px" alt="Google logo" src="/s/google.png" />
+            Login with Google
           </a>
         </div>
-      {{end}}
-    </div>
-  </section>
-</body>
-{{.Footer}}
+        {{ end }}
+      </div>
+    </section>
+  </body>
+  {{ .Footer }}
 </html>

--- a/cmd/oceanbench/t/monitor.html
+++ b/cmd/oceanbench/t/monitor.html
@@ -1,58 +1,70 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css" />
-  <title>CloudBlue | Monitor</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>CloudBlue | Monitor</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
     <section id="main" class="main">
       <h1 class="container-md">Monitor</h1>
       <div>
         {{ range .Devices }}
-          <div class="border rounded p-4 container-md bg-white">
-            <span value="{{ .Device.MAC }}" {{if eq .Device.MAC $.Ma}} selected{{end}}>
-              <span class="monitor-title">{{ if $.WritePerm }}<a href="/set/devices/?ma={{ .Device.MAC }}">{{ .Device.Name }}</a>{{ else }}{{ .Device.Name }}{{ end }}</span> ({{ .Device.MAC }})<br>
-              Address: {{if (.Address)}}{{ .Address }}{{end}}<br>
-              Protocol: {{ .Device.Protocol }}<br>
-              Configured: <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}"><br>
-              Status: <img src="/s/{{ .Sending }}.png" alt="{{ .Sending }}"><br>
-              {{if eq .Sending "green"}}Uptime: {{ .Uptime }}<br>
-              {{else}} Last Reported: {{localdatetime .LastReportedTimestamp $.Timezone}}
-              {{end}}
-              {{ if eq .Count 0 }}{{ else }}Throughput: {{ .Throughput }}% {{ .Count }}/{{ .MaxCount }}{{ end }}
+        <div class="border rounded p-4 container-md bg-white">
+          <span value="{{ .Device.MAC }}" {{ if eq .Device.MAC $.Ma }}selected{{ end }}>
+            <span class="monitor-title">
+              {{ if $.WritePerm }}
+              <a href="/set/devices/?ma={{ .Device.MAC }}">{{ .Device.Name }}</a>
+              {{ else }} {{ .Device.Name }} {{ end }}
             </span>
-            {{ range .Sensors }}
-              <hr>
-              <span>
-                <span class=monitor-title>{{ .Name }}</span><br>
-                <span class="signal-date">{{ .Date }}</span>
-                <span class="signal-value">{{ .Scalar }} {{ .Units }}</span>
-              </span>
-            {{end}}
-          </div>
-          <br>
-        {{end}}
+            ({{ .Device.MAC }})
+            <br />
+            Address: {{ if (.Address) }}{{ .Address }}{{ end }}
+            <br />
+            Protocol: {{ .Device.Protocol }}
+            <br />
+            Configured:
+            <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}" />
+            <br />
+            Status:
+            <img src="/s/{{ .Sending }}.png" alt="{{ .Sending }}" />
+            <br />
+            {{ if eq .Sending "green" }} Uptime: {{ .Uptime }}
+            <br />
+            {{ else }} Last Reported: {{ localdatetime .LastReportedTimestamp $.Timezone }} {{ end }} {{ if eq .Count 0 }}{{ else }}Throughput: {{ .Throughput }}% {{ .Count }}/{{ .MaxCount }}{{ end }}
+          </span>
+          {{ range .Sensors }}
+          <hr />
+          <span>
+            <span class="monitor-title">{{ .Name }}</span>
+            <br />
+            <span class="signal-date">{{ .Date }}</span>
+            <span class="signal-value">{{ .Scalar }} {{ .Units }}</span>
+          </span>
+          {{ end }}
+        </div>
+        <br />
+        {{ end }}
       </div>
     </section>
-    {{.Footer}}
-</body>
+    {{ .Footer }}
+  </body>
 </html>

--- a/cmd/oceanbench/t/mooring.html
+++ b/cmd/oceanbench/t/mooring.html
@@ -1,14 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.2/p5.js"></script>
-    <link rel="stylesheet" type="text/css" href="/s/mooring-sim/style.css">
+    <link rel="stylesheet" type="text/css" href="/s/mooring-sim/style.css" />
     <meta charset="utf-8" />
-
   </head>
   <body>
-    <main>
-    </main>
+    <main></main>
     <script src="/s/mooring-sim/sketch.js"></script>
   </body>
 </html>

--- a/cmd/oceanbench/t/play.html
+++ b/cmd/oceanbench/t/play.html
@@ -1,70 +1,69 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>CloudBlue | Play</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <link href="/s/main.css" rel="stylesheet" type="text/css" />
-  <link href="/s/play.css" rel="stylesheet" type="text/css" />
-  <link href="/s/filter.css" rel="stylesheet" type="text/css" />
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest/dist/hls.min.js"></script>
-  <script type="text/javascript" src="/s/player/audio/pcm-to-wav.js"></script>
-  <script type="text/javascript" src="/s/player/audio/adpcm.js"></script>
-  <script type="module" src="https://unpkg.com/wavesurfer.js@6.6.3/dist/wavesurfer.js"></script>
-  <script type="module" src="https://unpkg.com/wavesurfer.js@6.6.3/dist/plugin/wavesurfer.spectrogram.js"></script>
-  <script type="module" src="/s/play.js"></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CloudBlue | Play</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <link href="/s/play.css" rel="stylesheet" type="text/css" />
+    <link href="/s/filter.css" rel="stylesheet" type="text/css" />
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@latest/dist/hls.min.js"></script>
+    <script type="text/javascript" src="/s/player/audio/pcm-to-wav.js"></script>
+    <script type="text/javascript" src="/s/player/audio/adpcm.js"></script>
+    <script type="module" src="https://unpkg.com/wavesurfer.js@6.6.3/dist/wavesurfer.js"></script>
+    <script type="module" src="https://unpkg.com/wavesurfer.js@6.6.3/dist/plugin/wavesurfer.spectrogram.js"></script>
+    <script type="module" src="/s/play.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    <h1 class="container-md">Play</h1>
-    <div id="msg" class="red"></div>
-    <div class="border rounded p-4 container-md bg-white">
-      <div class="d-flex flex-column gap-2">
-        <div class="d-flex gap-2">
-          <a class="btn btn-primary" id="mjpeg-tab" href="/play?out=x-motion-jpeg">Video (MJPEG)</a>
-          <a class="btn btn-primary" id="h264-tab" href="/play?out=h264">Video (H264)</a>
-          <a class="btn btn-primary" id="audio-tab" href="/play?out=pcm">Audio</a>
-        </div>
-        <div class="d-flex align-items-center gap-2">
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      <h1 class="container-md">Play</h1>
+      <div id="msg" class="red"></div>
+      <div class="border rounded p-4 container-md bg-white">
+        <div class="d-flex flex-column gap-2">
+          <div class="d-flex gap-2">
+            <a class="btn btn-primary" id="mjpeg-tab" href="/play?out=x-motion-jpeg">Video (MJPEG)</a>
+            <a class="btn btn-primary" id="h264-tab" href="/play?out=h264">Video (H264)</a>
+            <a class="btn btn-primary" id="audio-tab" href="/play?out=pcm">Audio</a>
+          </div>
+          <div class="d-flex align-items-center gap-2">
             URL:
-            <input type="text" id="url" class="form-control">
+            <input type="text" id="url" class="form-control" />
             <button id="loadBtn" class="btn btn-primary">Load</button>
-        </div>
-        <div id="liverow">
+          </div>
+          <div id="liverow">
             <fieldset class="d-flex align-items-center justify-content-between gap-2">
               Media ID:
-              <input type="input" id="id" {{if .MID}} value="{{ .MID}}" {{end}} class="form-control w-25">
+              <input type="input" id="id" {{ if .MID }}value="{{ .MID }}" {{ end }} class="form-control w-25" />
               Buffer:
-              <input type="input" id="fd" value="10" size="2" class="form-control w-25"> seconds
+              <input type="input" id="fd" value="10" size="2" class="form-control w-25" />
+              seconds
               <button id="liveBtn" class="btn btn-primary w-25">Live stream</button>
             </fieldset>
+          </div>
         </div>
+        <hr />
+        <div id="specific"></div>
+        <div id="view"></div>
       </div>
-      <hr>
-      <div id="specific"></div>
-      <div id="view"></div>
-    </div>
-  </section>
-  {{.Footer}}
-</body>
-
+    </section>
+    {{ .Footer }}
+  </body>
 </html>

--- a/cmd/oceanbench/t/register.html
+++ b/cmd/oceanbench/t/register.html
@@ -1,47 +1,49 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>CloudBlue | Register Site</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js" ></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>CloudBlue | Register Site</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-  {{if .Msg}}
-    <div class="red">{{.Msg}}</div><br>
-  {{end}}
-	
-  <div class="rounded-box width-600px">
-    <span class="bold">Site</span>
-    <hr>
-    <div>
-    <form class="inline" enctype="multipart/form-data" action="/admin/site/add" method="post">
-      <label>Name:</label>
-      <input type="text" name="sn" class="dbl bold"><br>
-      <input type="submit" value="Register" />
-    </form>
-    </div>
-  </div><!--rounded box --> 
-  <br>
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{ if .Msg }}
+      <div class="red">{{ .Msg }}</div>
+      <br />
+      {{ end }}
 
-  </section>
-  {{.Footer}}
+      <div class="rounded-box width-600px">
+        <span class="bold">Site</span>
+        <hr />
+        <div>
+          <form class="inline" enctype="multipart/form-data" action="/admin/site/add" method="post">
+            <label>Name:</label>
+            <input type="text" name="sn" class="dbl bold" />
+            <br />
+            <input type="submit" value="Register" />
+          </form>
+        </div>
+      </div>
+      <!--rounded box -->
+      <br />
+    </section>
+    {{ .Footer }}
   </body>
 </html>

--- a/cmd/oceanbench/t/sandbox.html
+++ b/cmd/oceanbench/t/sandbox.html
@@ -1,97 +1,93 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>Devices</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>Devices</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{range .Pages -}}
         <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+          <a {{if .URL}}href="{{.URL}}" {{end}}{{if .Selected}} class="selected" {{end}}>{{.Name}}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
+        {{- end}}
+      </nav-menu>
+      <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}" {{end}} slot="site-menu">
+        {{range .Users -}}
         <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    {{if .Msg}}
-      <div class="red">
-        {{.Msg}}
+        {{- end}}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{if .Msg}}
+      <div class="red">{{.Msg}}</div>
+      <br />
+      {{end}}
+      <h1 class="container-md">Devices</h1>
+      <div class="border rounded p-4 container-md bg-white">
+        <a href="/set/devices">Manual Configuration</a>
+        {{ if eq (len .Devices) 0 }} No Devices waiting to be configured {{else}}
+        <form action="/set/devices/configure" enctype="multipart/form-data" method="get">
+          <fieldset>
+            <div class="d-flex align-items-center gap-1 mb-1">
+              <label class="col-4 text-end">Device:</label>
+              <div class="col-6 d-flex gap-1">
+                <select name="ma" onchange="location.assign('?ma=' + this.value)" class="form-select h-auto align-items-center">
+                  {{range .Devices}}
+                  <option value="{{ .MAC }}" {{if eq .MAC $.Mac}} selected{{end}}>{{ .Name }}</option>
+                  {{end}}
+                </select>
+                <button class="btn btn-primary h-auto">Configure</button>
+              </div>
+            </div>
+          </fieldset>
+        </form>
+
+        {{with .Device}}
+        <div class="d-flex align-items-center gap-1 mb-1">
+          <label class="col-4 text-end">Device Key:</label>
+          <div class="col-6">
+            <input class="form-control" value="{{.Dkey}}" disabled />
+          </div>
+        </div>
+        <div class="d-flex align-items-center gap-1 mb-1">
+          <label class="col-4 text-end">MAC:</label>
+          <div class="col-6">
+            <input class="form-control" value="{{.MAC}}" readonly />
+          </div>
+        </div>
+        <div class="d-flex align-items-center gap-1 mb-1">
+          <label class="col-4 text-end">Last updated:</label>
+          <div class="col-6">
+            <input class="form-control" value="{{if .Name}}{{localdatetime .Updated.Unix $.Timezone}}{{end}}" disabled />
+          </div>
+        </div>
+        <div class="d-flex align-items-center gap-1 mb-1">
+          <label class="col-4 text-end">Uptime:</label>
+          <div class="col-6">
+            {{$uptime := .Other "uptime"}}
+            <input class="form-control" value="{{if $uptime}}{{$uptime}}{{end}}" disabled />
+          </div>
+        </div>
+        <div class="d-flex align-items-center gap-1 mb-1">
+          <label class="col-4 text-end">Enabled:</label>
+          <div class="col">
+            <input type="checkbox" name="de" id="de" {{if .Enabled }}checked{{end}} />
+            <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}" />
+            {{$sending := .Other "sending"}}
+            <img src="/s/{{$sending}}.png" alt="{{$sending}}" />
+          </div>
+        </div>
+
+        {{end}} {{end}}
       </div>
-      <br>
-    {{end}}
-    <h1 class="container-md">Devices</h1>
-    <div class="border rounded p-4 container-md bg-white">
-      <a href="/set/devices">Manual Configuration</a>
-      {{ if eq (len .Devices) 0 }}
-      No Devices waiting to be configured
-      {{else}}
-      <form action="/set/devices/configure" enctype="multipart/form-data" method="get">
-        <fieldset>
-          <div class="d-flex align-items-center gap-1 mb-1">
-            <label class="col-4 text-end">Device:</label>
-            <div class="col-6 d-flex gap-1">
-              <select name="ma" onchange="location.assign('?ma=' + this.value)" class="form-select h-auto align-items-center" >
-                {{range .Devices}}
-                  <option value="{{ .MAC }}"{{if eq .MAC $.Mac}} selected{{end}}>{{ .Name }}</option>
-                {{end}}
-              </select>
-              <button class="btn btn-primary h-auto">Configure</button>
-            </div>
-          </div>
-        </fieldset>
-      </form>
-
-      {{with .Device}}
-          <div class="d-flex align-items-center gap-1 mb-1">
-            <label class="col-4 text-end">Device Key:</label>
-            <div class="col-6">
-              <input class="form-control" value="{{.Dkey}}" disabled></input>
-            </div>
-          </div>
-          <div class="d-flex align-items-center gap-1 mb-1">
-            <label class="col-4 text-end">MAC:</label>
-            <div class="col-6">
-              <input class="form-control" value="{{.MAC}}" readonly></input>
-            </div>
-          </div>
-          <div class="d-flex align-items-center gap-1 mb-1">
-            <label class="col-4 text-end">Last updated:</label>
-            <div class="col-6">
-              <input class="form-control" value="{{if .Name}}{{localdatetime .Updated.Unix $.Timezone}}{{end}}" disabled>
-            </div>
-          </div>
-          <div class="d-flex align-items-center gap-1 mb-1">
-            <label class="col-4 text-end">Uptime:</label>
-            <div class="col-6">
-              <input class="form-control" value="{{if (.Other "uptime")}}{{.Other "uptime"}}{{end}}" disabled>
-            </div>
-          </div>
-          <div class="d-flex align-items-center gap-1 mb-1">
-            <label class="col-4 text-end">Enabled:</label>
-            <div class="col">
-              <input type="checkbox" name="de" id="de" {{if .Enabled }}checked{{end}}>
-              <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}">
-              <img src="/s/{{ .Other "sending"}}.png" alt="{{ .Other "sending"}}">
-            </div>
-          </div>
-
-
-      {{end}}
-      {{end}}
-    </div>
-  </section>
-  {{.Footer}}
-</body>
+    </section>
+    {{.Footer}}
+  </body>
 </html>

--- a/cmd/oceanbench/t/search.html
+++ b/cmd/oceanbench/t/search.html
@@ -1,270 +1,279 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>CloudBlue | Search</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js" ></script>
-  <script type="text/javascript" src="/s/logs.js"></script>
-  <script type="text/javascript" src="/s/graph.js"></script>
-  <script src="https://cdn.amcharts.com/lib/4/core.js"></script>
-  <script src="https://cdn.amcharts.com/lib/4/charts.js"></script>
-  <script src="https://cdn.amcharts.com/lib/4/themes/animated.js"></script>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <script src="https://cdn.rawgit.com/kimmobrunfeldt/progressbar.js/1.1.0/dist/progressbar.js"></script>
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <style type="text/css">
-  #id { display: {{if .Id}}block{{else}}none{{end}}; }
-  </style>
-  <script type="text/javascript">
-    function setActive(id) {
-      let timeOpts = document.getElementById("time-btns").children;
-      for (let i = 0; i< timeOpts.length; i++) {
-        if (timeOpts[i].classList.contains("active") && timeOpts[i].id != id) {
-          timeOpts[i].classList.remove("active");
-        } else if (timeOpts[i].id == id) {
-          timeOpts[i].classList.add("active");
-        }
-      }
-      if (id == "ex-btn") {
-        toggleDatePickers(true);
-      } else {
-        toggleDatePickers(false);
-      }
-    }
-    function toggleDatePickers(set) {
-      let dp = document.getElementById("datepickers");
-      if (set == true) {
-        dp.classList.remove("d-none");
-      } else {
-        dp.classList.add("d-none");
-      }
-    }
-    function toggleAdvanced(set) {
-      let advOpts = document.getElementsByClassName("adv-opt");
-      if (set) {
-        for (let i = 0; i < advOpts.length; i++) {
-          advOpts[i].classList.remove("d-none");
-          if (advOpts[i].id == "id") {
-            advOpts[i].classList.add("d-flex");
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CloudBlue | Search</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript" src="/s/logs.js"></script>
+    <script type="text/javascript" src="/s/graph.js"></script>
+    <script src="https://cdn.amcharts.com/lib/4/core.js"></script>
+    <script src="https://cdn.amcharts.com/lib/4/charts.js"></script>
+    <script src="https://cdn.amcharts.com/lib/4/themes/animated.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <script src="https://cdn.rawgit.com/kimmobrunfeldt/progressbar.js/1.1.0/dist/progressbar.js"></script>
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <style type="text/css">
+      #id { display: {{if .Id}}block{{else}}none{{end}}; }
+    </style>
+    <script type="text/javascript">
+      function setActive(id) {
+        let timeOpts = document.getElementById("time-btns").children;
+        for (let i = 0; i< timeOpts.length; i++) {
+          if (timeOpts[i].classList.contains("active") && timeOpts[i].id != id) {
+            timeOpts[i].classList.remove("active");
+          } else if (timeOpts[i].id == id) {
+            timeOpts[i].classList.add("active");
           }
         }
-      } else {
-        for (let i = 0; i < advOpts.length; i++) {
-          advOpts[i].classList.add("d-none");
-          if (advOpts[i].id == "id") {
-            advOpts[i].classList.remove("d-flex");
+        if (id == "ex-btn") {
+          toggleDatePickers(true);
+        } else {
+          toggleDatePickers(false);
+        }
+      }
+      function toggleDatePickers(set) {
+        let dp = document.getElementById("datepickers");
+        if (set == true) {
+          dp.classList.remove("d-none");
+        } else {
+          dp.classList.add("d-none");
+        }
+      }
+      function toggleAdvanced(set) {
+        let advOpts = document.getElementsByClassName("adv-opt");
+        if (set) {
+          for (let i = 0; i < advOpts.length; i++) {
+            advOpts[i].classList.remove("d-none");
+            if (advOpts[i].id == "id") {
+              advOpts[i].classList.add("d-flex");
+            }
+          }
+        } else {
+          for (let i = 0; i < advOpts.length; i++) {
+            advOpts[i].classList.add("d-none");
+            if (advOpts[i].id == "id") {
+              advOpts[i].classList.remove("d-flex");
+            }
           }
         }
       }
-    }
-    function setTimeRange(hours) {
-      var tz = document.getElementById('tz').value;
-      if (tz == "") {
-        tz = "0";
-      }
-      const z = parseFloat(tz);
-      const now = new Date();
-      const fd = new Date(now.getTime() + z * 60 * 60 * 1000);
-      const sd = new Date(fd.getTime() - hours * 60 * 60 * 1000);
-      document.getElementById('sd').value = sd.toISOString().slice(0, 16);
-      document.getElementById('fd').value = fd.toISOString().slice(0, 16);
-      sync('sd', 'st', 'tz', true);
-      sync('fd', 'ft', 'tz', true);
-    }
-    function presubmit() {
-      if (document.getElementById('st').value == "" && document.getElementById('sd').value != "") {
+      function setTimeRange(hours) {
+        var tz = document.getElementById('tz').value;
+        if (tz == "") {
+          tz = "0";
+        }
+        const z = parseFloat(tz);
+        const now = new Date();
+        const fd = new Date(now.getTime() + z * 60 * 60 * 1000);
+        const sd = new Date(fd.getTime() - hours * 60 * 60 * 1000);
+        document.getElementById('sd').value = sd.toISOString().slice(0, 16);
+        document.getElementById('fd').value = fd.toISOString().slice(0, 16);
         sync('sd', 'st', 'tz', true);
-      }
-      if (document.getElementById('ft').value == "" && document.getElementById('fd').value != "") {
         sync('fd', 'ft', 'tz', true);
       }
-      if (document.getElementById('ft').value == "") {
-        document.getElementById('ts').value = document.getElementById('st').value;
-      } else {
-        document.getElementById('ts').value = document.getElementById('st').value + '-' + document.getElementById('ft').value;
+      function presubmit() {
+        if (document.getElementById('st').value == "" && document.getElementById('sd').value != "") {
+          sync('sd', 'st', 'tz', true);
+        }
+        if (document.getElementById('ft').value == "" && document.getElementById('fd').value != "") {
+          sync('fd', 'ft', 'tz', true);
+        }
+        if (document.getElementById('ft').value == "") {
+          document.getElementById('ts').value = document.getElementById('st').value;
+        } else {
+          document.getElementById('ts').value = document.getElementById('st').value + '-' + document.getElementById('ft').value;
+        }
       }
-    }
-    function init() {
-      const inputs = document.querySelectorAll('input');
-      for (const input of inputs) {
-        input.addEventListener('keydown', (event) => {
-          if (event.keyCode === 13) {
-            event.preventDefault();
-          }
+      function init() {
+        const inputs = document.querySelectorAll('input');
+        for (const input of inputs) {
+          input.addEventListener('keydown', (event) => {
+            if (event.keyCode === 13) {
+              event.preventDefault();
+            }
+          });
+        }
+        {{if .Log -}}
+        initLogs({
+          {{if .Id}}id: {{.Id}},{{end}}
+          {{if .St}}st: {{.St}},{{end}}
+          {{if .Ft}}ft: {{.Ft}},{{end}}
+          {{if .Lv}}lv: {{.Lv}},{{end}}
         });
+        {{- end}}
       }
-      {{if .Log -}}
-      initLogs({
-        {{if .Id}}id: {{.Id}},{{end}}
-        {{if .St}}st: {{.St}},{{end}}
-        {{if .Ft}}ft: {{.Ft}},{{end}}
-        {{if .Lv}}lv: {{.Lv}},{{end}}
-      });
-      {{- end}}
-    }
-    function searchQuery(form) {
-      presubmit();
-      form.querySelector("input[name='search']").value = true;
-      form.submit();
-    }
-    function exportQuery(form) {
-      presubmit();
-      form.querySelector("input[name='export']").value = true;
-      document.getElementById("export-msg").innerHTML = "<p>Export may take several minutes...</p>";
-      form.submit();
-    }
-    function viewJPEG(url){
-      document.getElementById('jpeg-view').innerHTML = `<img style="max-height: 100%; max-width: 100%;" id = 'jpeg'>`;
-      l = window.location;
-      imgSrc = l.protocol + "//" + l.host + url;
-      document.getElementById('jpeg').src = imgSrc;
-    }
-    function sortResults(e) {
-      let results = document.getElementById("results")
-      if (e.value == "Newest") {
-        results.classList.remove("flex-column")
-        results.classList.add("flex-column-reverse")
-      } else {
-        results.classList.remove("flex-column-reverse")
-        results.classList.add("flex-column")
+      function searchQuery(form) {
+        presubmit();
+        form.querySelector("input[name='search']").value = true;
+        form.submit();
       }
-    }
-  </script>
-</head>
-<body onload="init()">
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+      function exportQuery(form) {
+        presubmit();
+        form.querySelector("input[name='export']").value = true;
+        document.getElementById("export-msg").innerHTML = "<p>Export may take several minutes...</p>";
+        form.submit();
+      }
+      function viewJPEG(url){
+        document.getElementById('jpeg-view').innerHTML = `<img style="max-height: 100%; max-width: 100%;" id = 'jpeg'>`;
+        l = window.location;
+        imgSrc = l.protocol + "//" + l.host + url;
+        document.getElementById('jpeg').src = imgSrc;
+      }
+      function sortResults(e) {
+        let results = document.getElementById("results")
+        if (e.value == "Newest") {
+          results.classList.remove("flex-column")
+          results.classList.add("flex-column-reverse")
+        } else {
+          results.classList.remove("flex-column-reverse")
+          results.classList.add("flex-column")
+        }
+      }
+    </script>
+  </head>
+  <body onload="init()">
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    {{if .Msg}}<div class="red">{{.Msg}}</div><br>{{end}}
-    <h1 class="container-md">Search</h1>
-    <form class="border rounded p-4 container-md bg-white" action="/search" enctype="multipart/form-data" method="post" id="search" onsubmit="event.preventDefault();">
-      <input type="hidden" name="search" value="false">
-      <input type="hidden" name="export" value="false">
-      <fieldset>
-        <legend>Input source</legend>
-        <div class="d-flex align-items-center gap-2">
-          <label>Device:</label>
-          <select class="form-select form-select-sm w-25" name="ma" onchange="this.form.submit();">
-            <option value="" selected>- Select device -</option>
-            {{range .Devices}}
-              <option value="{{ .MAC }}" {{if eq .MAC $.Ma}}selected{{end}}>{{ .Name }}</option>
-            {{end}}
-          </select>
-          {{if .Device}}
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{ if .Msg }}
+      <div class="red">{{ .Msg }}</div>
+      <br />
+      {{ end }}
+      <h1 class="container-md">Search</h1>
+      <form class="border rounded p-4 container-md bg-white" action="/search" enctype="multipart/form-data" method="post" id="search" onsubmit="event.preventDefault();">
+        <input type="hidden" name="search" value="false" />
+        <input type="hidden" name="export" value="false" />
+        <fieldset>
+          <legend>Input source</legend>
+          <div class="d-flex align-items-center gap-2">
+            <label>Device:</label>
+            <select class="form-select form-select-sm w-25" name="ma" onchange="this.form.submit();">
+              <option value="" selected>- Select device -</option>
+              {{ range .Devices }}
+              <option value="{{ .MAC }}" {{ if eq .MAC $.Ma }}selected{{ end }}>{{ .Name }}</option>
+              {{ end }}
+            </select>
+            {{ if .Device }}
             <div class="d-flex align-items-center">
               <span>Pin:</span>
               <select class="form-select form-select-sm" name="pn" onchange="this.form.submit();">
                 <option value="" selected>- Select pin -</option>
-                {{range .Device.InputList}}
-                <option value="{{ . }}" {{if eq . $.Pn}}selected{{end}}>{{ . }} ({{index $.PinNames .}})</option>
-                {{end}}
+                {{ range .Device.InputList }}
+                <option value="{{ . }}" {{ if eq . $.Pn }}selected{{ end }}>{{ . }} ({{ index $.PinNames . }})</option>
+                {{ end }}
               </select>
             </div>
-           {{end}}
-        </div>
-        <div id="id" class="adv-opt d-none gap-2">
-          <label>Data ID:</label>
-          <input class="form-control form-control-sm w-25" value="{{.Id}}" disabled>
-        </div>
-      </fieldset>
+            {{ end }}
+          </div>
+          <div id="id" class="adv-opt d-none gap-2">
+            <label>Data ID:</label>
+            <input class="form-control form-control-sm w-25" value="{{ .Id }}" disabled />
+          </div>
+        </fieldset>
 
-      <fieldset>
-        <legend>Time range</legend>
-        <div id="time-btns" class="d-flex justify-content-center align-items-center gap-2">
-          <button id="24-btn" class="btn btn-outline-primary w-25 {{ if eq 24 $.Period}}active{{end}}" onclick="setTimeRange(24); setActive(this.id);">Past 24 hours</button>
-          <button id="7-btn" class="btn btn-outline-primary w-25 {{ if eq 7 $.Period}}active{{end}}" onclick="setTimeRange(7*24); setActive(this.id)">Past 7 days</button>
-          <p class="pb-0">OR</p>
-          <button id="ex-btn" class="btn btn-outline-primary w-25 {{ if eq -1 $.Period}}active{{end}}" onclick="setActive(this.id)">Exact Range</button>
-        </div>
-        <div id="datepickers" class="{{ if eq -1 $.Period}}d-block{{else}}d-none{{end}}">
-          <div class="d-flex align-items-center mt-2">
-            <label class="flex-shrink-0">Start date/time:</label>
-            <input name="sd" class="form-control" type="datetime-local" id="sd" onchange="sync('sd', 'st', 'tz', true);" value="{{if .Sd}}{{.Sd}}{{end}}" size="14">
-            &nbsp;<input name="st" class="form-control adv-opt d-none" type="input" id="st" onchange="sync('sd', 'st', 'tz', false);" value="{{if .St}}{{.St}}{{end}}" size="15">
+        <fieldset>
+          <legend>Time range</legend>
+          <div id="time-btns" class="d-flex justify-content-center align-items-center gap-2">
+            <button id="24-btn" class="btn btn-outline-primary w-25 {{ if eq 24 $.Period }}active{{ end }}" onclick="setTimeRange(24); setActive(this.id);">Past 24 hours</button>
+            <button id="7-btn" class="btn btn-outline-primary w-25 {{ if eq 7 $.Period }}active{{ end }}" onclick="setTimeRange(7*24); setActive(this.id)">Past 7 days</button>
+            <p class="pb-0">OR</p>
+            <button id="ex-btn" class="btn btn-outline-primary w-25 {{ if eq -1 $.Period }}active{{ end }}" onclick="setActive(this.id)">Exact Range</button>
           </div>
-          <div class="d-flex align-items-center mt-2">
-            <label class="flex-shrink-0">Finish date/time:</label>
-            <input name="fd" class="form-control" type="datetime-local" id="fd" onchange="sync('fd', 'ft', 'tz', true);" value="{{if .Fd}}{{.Fd}}{{end}}" size="22">
-            &nbsp;<input name="ft" class="adv-opt d-none form-control" type="input" id="ft" onchange="sync('fd', 'ft', 'tz', false);" value="{{if .Ft}}{{.Ft}}{{end}}" size="15">
+          <div id="datepickers" class="{{ if eq -1 $.Period }}d-block{{ else }}d-none{{ end }}">
+            <div class="d-flex align-items-center mt-2">
+              <label class="flex-shrink-0">Start date/time:</label>
+              <input name="sd" class="form-control" type="datetime-local" id="sd" onchange="sync('sd', 'st', 'tz', true);" value="{{ if .Sd }}{{ .Sd }}{{ end }}" size="14" />
+              &nbsp;
+              <input name="st" class="form-control adv-opt d-none" type="input" id="st" onchange="sync('sd', 'st', 'tz', false);" value="{{ if .St }}{{ .St }}{{ end }}" size="15" />
+            </div>
+            <div class="d-flex align-items-center mt-2">
+              <label class="flex-shrink-0">Finish date/time:</label>
+              <input name="fd" class="form-control" type="datetime-local" id="fd" onchange="sync('fd', 'ft', 'tz', true);" value="{{ if .Fd }}{{ .Fd }}{{ end }}" size="22" />
+              &nbsp;
+              <input name="ft" class="adv-opt d-none form-control" type="input" id="ft" onchange="sync('fd', 'ft', 'tz', false);" value="{{ if .Ft }}{{ .Ft }}{{ end }}" size="15" />
+            </div>
+            <div class="d-flex align-items-center mt-2 adv-opt d-none">
+              <label>Timezone:</label>
+              <input name="tz" class="w-25 form-control" value="{{ .Tz }}" id="tz" size="1" onchange="sync('sd', 'st', 'tz', false); sync('fd', 'ft', 'tz', false);" />
+            </div>
           </div>
-          <div class="d-flex align-items-center mt-2 adv-opt d-none">
-            <label>Timezone:</label>
-            <input name="tz" class="w-25 form-control" value="{{.Tz}}" id="tz" size="1" onchange="sync('sd', 'st', 'tz', false); sync('fd', 'ft', 'tz', false);">
-          </div>
-        </div>
-        <input type="hidden" name="ts" id="ts">
-      </fieldset>
-      <fieldset class="adv-opt d-none">
-        <legend>Advanced Options</legend>
-        {{if or (eq .PinType 'V') (eq .PinType 'S') -}}
+          <input type="hidden" name="ts" id="ts" />
+        </fieldset>
+        <fieldset class="adv-opt d-none">
+          <legend>Advanced Options</legend>
+          {{ if or (eq .PinType 'V') (eq .PinType 'S') -}}
           <div class="d-flex align-items-center">
             <label>Clip period:</label>
             <div class="input-group w-25 d-flex align-items-start">
-              <input name="cp" class="form-control" type="text" value="{{if .Cp}}{{.Cp}}{{else}}60{{end}}">
+              <input name="cp" class="form-control" type="text" value="{{ if .Cp }}{{ .Cp }}{{ else }}60{{ end }}" />
               <span class="input-group-text">seconds</span>
             </div>
-              <br>
+            <br />
           </div>
-        {{- else if eq .PinType 'T' -}}
+          {{- else if eq .PinType 'T' -}}
           <div class="d-flex align-items-center">
             <label>Log level:</label>
             <select class="form-select form-select-sm w-25" name="lv" onchange="this.form.submit()">
-              <option value="all" {{if eq .Lv "all"}}selected{{- end}}>All logs</option>
-              <option value="info" {{if eq .Lv "info"}}selected{{- end}}>Info level or above</option>
-              <option value="warning" {{if eq .Lv "warning"}}selected{{- end}}>Warning level or above</option>
-              <option value="error" {{if eq .Lv "error"}}selected{{- end}}>Error level or above</option>
-              <option value="fatal" {{if eq .Lv "fatal"}}selected{{- end}}>Fatal only</option>
+              {{$all := "all"}} {{$info := "info"}} {{$warning := "warning"}} {{$error := "error"}} {{$fatal := "fatal"}}
+              <option value="all" {{if eq .Lv $all}}selected{{- end}}>All logs</option>
+              <option value="info" {{if eq .Lv $info}}selected{{- end}}>Info level or above</option>
+              <option value="warning" {{if eq .Lv $warning}}selected{{- end}}>Warning level or above</option>
+              <option value="error" {{if eq .Lv $error}}selected{{- end}}>Error level or above</option>
+              <option value="fatal" {{if eq .Lv $fatal}}selected{{- end}}>Fatal only</option>
             </select>
           </div>
-        {{- else if (or (eq .PinType 'A') (eq .PinType 'D') (eq .PinType 'X')) -}}
+          {{- else if (or (eq .PinType 'A') (eq .PinType 'D') (eq .PinType 'X')) -}}
           <label>Resolution:</label>
-          <input name="resolution" type="input" onchange="this.form.submit();" value="{{if .Resolution}}{{.Resolution}}{{else}}60{{end}}"> pts/hour
-          <br>
-        {{- else -}}
+          <input name="resolution" type="input" onchange="this.form.submit();" value="{{ if .Resolution }}{{ .Resolution }}{{ else }}60{{ end }}" />
+          pts/hour
+          <br />
+          {{- else -}}
           <p>No additional options available.</p>
-        {{end -}}
-      </fieldset>
-      
-    <div class="d-flex flex-row-reverse align-items-center justify-content-between mt-4">
-      <div class="d-flex mt-2">
-        <label for="advanced-opts">Advanced Options</label>
-        <input name="advanced-opts" type="checkbox" onclick="toggleAdvanced(this.checked)">
-      </div>
-      {{if or (or (eq .PinType 'V') (eq .PinType 'T')) (eq .PinType 'S') -}}
-        <button class="btn btn-primary" onclick="searchQuery(this.form)">Search</button>
-      {{end -}}
-      {{if or (eq .PinType 'A') (eq .PinType 'D') (eq .PinType 'X') -}}
-        <div class="d-flex gap-2 align-items-center">
-          <button class="btn btn-primary" onclick="exportQuery(this.form)">Export</button>
-          <p class="p-0">OR</p>
-          <button class="btn btn-primary" type="button" onclick="graphHandler({{.DataHost}},{{.SKey}},{{.Ma}},{{.Pn}},document.getElementById('st').value,document.getElementById('ft').value,document.getElementById('tz').value,{{.Resolution}})">Graph</button>
-          <div id="export-msg"></div>
-          <p class="p-0" id="graph-error"></p>
-        </div>
-      {{end -}}</div>
-    </form>
-  </section>
+          {{ end -}}
+        </fieldset>
 
-  {{if and .Searching .Log}}
+        <div class="d-flex flex-row-reverse align-items-center justify-content-between mt-4">
+          <div class="d-flex mt-2">
+            <label for="advanced-opts">Advanced Options</label>
+            <input name="advanced-opts" type="checkbox" onclick="toggleAdvanced(this.checked)" />
+          </div>
+          {{ if or (or (eq .PinType 'V') (eq .PinType 'T')) (eq .PinType 'S') -}}
+          <button class="btn btn-primary" onclick="searchQuery(this.form)">Search</button>
+          {{ end -}} {{ if or (eq .PinType 'A') (eq .PinType 'D') (eq .PinType 'X') -}}
+          <div class="d-flex gap-2 align-items-center">
+            <button class="btn btn-primary" onclick="exportQuery(this.form)">Export</button>
+            <p class="p-0">OR</p>
+            <button class="btn btn-primary" type="button" onclick="graphHandler({{ .DataHost }},{{ .SKey }},{{ .Ma }},{{ .Pn }},document.getElementById('st').value,document.getElementById('ft').value,document.getElementById('tz').value,{{ .Resolution }})">Graph</button>
+            <div id="export-msg"></div>
+            <p class="p-0" id="graph-error"></p>
+          </div>
+          {{ end -}}
+        </div>
+      </form>
+    </section>
+
+    {{ if and .Searching .Log }}
     <section>
       <h2>Results</h2>
       <p>
-        <span id="result-num">loading</span> results
-        (<a href="/get?id={{$.Id}}&ts={{$.St}}-{{$.Ft}}">download all</a>)
+        <span id="result-num">loading</span>
+        results (
+        <a href="/get?id={{ $.Id }}&ts={{ $.St }}-{{ $.Ft }}">download all</a>
+        )
       </p>
       <p>
         <a href="javascript:void(0)" onclick="prevPage()">&lt;&lt;Previous</a>
@@ -282,47 +291,44 @@
         <tbody></tbody>
       </table>
     </section>
-  {{- end}}
-  <div id="progress"></div>
-  <div id="graph"></div>
+    {{- end }}
+    <div id="progress"></div>
+    <div id="graph"></div>
 
-  {{if .Timestamps}}
-  {{with $subtype := part (split $.Type "/") 1}}
+    {{ if .Timestamps }} {{ with $subtype := part (split $.Type "/") 1 }}
     <section class="border rounded p-4 container-sm">
       <h2>Results</h2>
       <div class="d-flex justify-content-between">
-        {{len $.Timestamps}} results<br>
+        {{ len $.Timestamps }} results
+        <br />
         <select class="btn btn-outline-primary" onchange="sortResults(this)">
           <option>Oldest</option>
           <option>Newest</option>
         </select>
       </div>
       <div class="search d-flex flex-column align-items-center">
-          <div class="d-flex align-items-center gap-2 justify-content-center">
-            <div class="w-50 flex-shrink-0 text-center"><strong>All</strong></div>
-            <a class="btn btn-primary btn-sm" href="/play?id={{$.Id}}&ts={{$.St}}-{{$.Ft}}&out={{$subtype}}">Play</a>
-            <a class="btn btn-primary btn-sm" href="/get?id={{$.Id}}&ts={{$.St}}-{{$.Ft}}">Download</a>
-            <a class="btn btn-primary btn-sm flex-shrink-0" href="/get?id={{$.Id}}&ts={{$.St}}-{{$.Ft}}&out=media">Download as {{$subtype}}</a>
-          </div>
-          <hr class="w-100">
+        <div class="d-flex align-items-center gap-2 justify-content-center">
+          <div class="w-50 flex-shrink-0 text-center"><strong>All</strong></div>
+          <a class="btn btn-primary btn-sm" href="/play?id={{ $.Id }}&ts={{ $.St }}-{{ $.Ft }}&out={{ $subtype }}">Play</a>
+          <a class="btn btn-primary btn-sm" href="/get?id={{ $.Id }}&ts={{ $.St }}-{{ $.Ft }}">Download</a>
+          <a class="btn btn-primary btn-sm flex-shrink-0" href="/get?id={{ $.Id }}&ts={{ $.St }}-{{ $.Ft }}&out=media">Download as {{ $subtype }}</a>
+        </div>
+        <hr class="w-100" />
       </div>
       <div id="results" class="search d-flex flex-column align-items-center">
-        {{range $.Timestamps}}
-          <div class="d-flex align-items-center gap-2 mb-1 justify-content-center">
-            <div class="w-50">{{localdatetime . (float $.Tz)}}</div>
-            <a class="btn btn-outline-primary btn-sm" href="/play?id={{$.Id}}&ts={{.}}{{if $.Cp }},{{$.Cp}}{{end}}&out={{$subtype}}">Play</a>
-            <a class="btn btn-outline-primary btn-sm" href="/get?id={{$.Id}}&ts={{.}}{{if $.Cp }},{{$.Cp}}{{end}}">Download</a>
-            {{if $.Type -}}
-            <a class="btn btn-outline-primary btn-sm flex-shrink-0" href="/get?id={{$.Id}}&ts={{.}}{{if $.Cp }},{{$.Cp}}{{end}}&out=media">Download as {{$subtype}}</a>
-            {{- end}}
-          </div>
-        {{end}}
+        {{ range $.Timestamps }}
+        <div class="d-flex align-items-center gap-2 mb-1 justify-content-center">
+          <div class="w-50">{{ localdatetime . (float $.Tz) }}</div>
+          <a class="btn btn-outline-primary btn-sm" href="/play?id={{ $.Id }}&ts={{ . }}{{ if $.Cp }},{{ $.Cp }}{{ end }}&out={{ $subtype }}">Play</a>
+          <a class="btn btn-outline-primary btn-sm" href="/get?id={{ $.Id }}&ts={{ . }}{{ if $.Cp }},{{ $.Cp }}{{ end }}">Download</a>
+          {{ if $.Type -}}
+          <a class="btn btn-outline-primary btn-sm flex-shrink-0" href="/get?id={{ $.Id }}&ts={{ . }}{{ if $.Cp }},{{ $.Cp }}{{ end }}&out=media">Download as {{ $subtype }}</a>
+          {{- end }}
+        </div>
+        {{ end }}
       </div>
     </section>
-  {{end}}
-  {{end}}
-
-  {{if and .Searching (not (or .Log .Timestamps))}}No results.{{end}}
+    {{ end }} {{ end }} {{ if and .Searching (not (or .Log .Timestamps)) }}No results.{{ end }}
   </body>
-  {{.Footer}}
+  {{ .Footer }}
 </html>

--- a/cmd/oceanbench/t/set/cron.html
+++ b/cmd/oceanbench/t/set/cron.html
@@ -1,73 +1,89 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>Crons</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-  <script type="text/javascript" src="/s/cron.js"></script>
-</head>
-<body>
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>Crons</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript" src="/s/cron.js"></script>
+  </head>
+  <body>
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    {{if .Msg}}<div class="red">{{.Msg}}</div>
-    <br>
-    {{end}}
-    <h1 class="container-md">Crons</h1>
-    <div class="table border rounded p-4 container-md bg-white" id="crons">
-      <div class="tr">
-        <span class="td select"></span>
-        <span class="td std">ID</span>
-        <span class="td half">Time</span>
-        <span class="td half">Action</span>
-        <span class="td std">Variable</span>
-        <span class="td std">Value</span>
-        <span class="td half">Enabled</span>
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{ if .Msg }}
+      <div class="red">{{ .Msg }}</div>
+      <br />
+      {{ end }}
+      <h1 class="container-md">Crons</h1>
+      <div class="table border rounded p-4 container-md bg-white" id="crons">
+        <div class="tr">
+          <span class="td select"></span>
+          <span class="td std">ID</span>
+          <span class="td half">Time</span>
+          <span class="td half">Action</span>
+          <span class="td std">Variable</span>
+          <span class="td std">Value</span>
+          <span class="td half">Enabled</span>
+        </div>
+        {{ range $c := .Crons }}
+        <form class="tr" id="{{ .ID }}" enctype="multipart/form-data" action="/set/crons/edit" method="post" novalidate>
+          <span class="td select"><img src="/s/delete.png" onclick="deleteCron('{{ .ID }}');" /></span>
+          <span class="td std"><input type="text" name="ci" class="" value="{{ .ID }}" readonly /></span>
+          <span class="td half"><input type="text" name="ct" value="{{ .FormatTime $.Timezone }}" class="half" onchange="updateCron(this);" /></span>
+          <span class="td half">
+            <select name="ca" class="half" onchange="updateCron(this);">
+              {{ range $.Actions }}
+              <option value="{{ . }}" {{ if eq . $c.Action }}selected{{ end }}>{{ . }}</option>
+              {{ end }}
+            </select>
+          </span>
+          <span class="td std">
+            <select type="text" name="cv" class="std" onchange="updateCron(this);">
+              <option selected value="{{ .Var }}"></option>
+            </select>
+          </span>
+          <span class="td std"><input type="text" name="cd" value="{{ .Data }}" class="std" onchange="updateCron(this);" /></span>
+          <span class="td half"><input type="checkbox" name="ce" {{ if .Enabled }}checked{{ end }} onchange="updateCron(this);" /></span>
+        </form>
+        {{ end }}
+        <form class="tr" id="_newcron" enctype="multipart/form-data" action="/set/crons/edit" method="post" novalidate>
+          <span class="td select"><img src="/s/add.png" onclick="addCron();" /></span>
+          <span class="td std"><input type="text" name="ci" class="std" /></span>
+          <span class="td half"><input type="text" name="ct" class="half" /></span>
+          <span class="td half">
+            <select name="ca" class="half">
+              {{ range $.Actions }}
+              <option value="{{ . }}">{{ . }}</option>
+              {{ end }}
+            </select>
+          </span>
+          <span class="td std">
+            <select id="var-select" type="text" name="cv" class="std">
+              <option>-- Select Var --</option>
+            </select>
+          </span>
+          <span class="td std"><input type="text" name="cd" class="std" /></span>
+          <span class="td half"><input type="checkbox" name="ce" /></span>
+          <input type="hidden" name="task" value="Add" />
+        </form>
       </div>
-      {{range $c := .Crons}}
-      <form class="tr" id="{{ .ID }}" enctype="multipart/form-data" action="/set/crons/edit" method="post" novalidate>
-        <span class="td select"><img src="/s/delete.png" onclick="deleteCron('{{ .ID }}');"></span>
-        <span class="td std"><input type="text" name="ci" class="" value="{{ .ID }}" readonly></span>
-        <span class="td half"><input type="text" name="ct" value="{{ .FormatTime $.Timezone }}" class="half" onchange="updateCron(this);"></span>
-        <span class="td half"><select name="ca" class="half" onchange="updateCron(this);">{{range $.Actions }}
-          <option value="{{.}}"{{if eq . $c.Action }} selected{{end}}>{{.}}</option>{{end}}</select></span>
-        <span class="td std"><select type="text" name="cv" class="std" onchange="updateCron(this);">
-          <option selected value="{{.Var}}"></option>
-        </select></span>
-        <span class="td std"><input type="text" name="cd" value="{{ .Data }}" class="std" onchange="updateCron(this);"></span>
-        <span class="td half"><input type="checkbox" name="ce"{{if .Enabled}} checked{{end}} onchange="updateCron(this);"></span>
-      </form>{{end}}
-      <form class="tr" id="_newcron" enctype="multipart/form-data" action="/set/crons/edit" method="post" novalidate>
-        <span class="td select"><img src="/s/add.png" onclick="addCron();"></span>
-        <span class="td std"><input type="text" name="ci" class="std"></span>
-        <span class="td half"><input type="text" name="ct" class="half"></span>
-        <span class="td half"><select name="ca" class="half">{{range $.Actions }}
-          <option value="{{.}}">{{.}}</option>{{end}}</select></span>
-        <span class="td std"><select id="var-select" type="text" name="cv" class="std">
-          <option>-- Select Var --</option>
-        </select></span>
-        <span class="td std"><input type="text" name="cd" class="std"></span>
-        <span class="td half"><input type="checkbox" name="ce"></span>
-        <input type="hidden" name="task" value="Add">
-      </form>
-    </div>
-  </section>
-  {{.Footer}}
-</body>
+    </section>
+    {{ .Footer }}
+  </body>
 </html>

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -1,569 +1,565 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <style rel="stylesheet" type="text/css">
-  .advanced {
-    transition: all 0.3s ease; /* Optional: for smooth transition */
-  }
-
-  .advanced.hidden {
-    display: none;
-    height: 0;
-    padding: 0;
-    margin: 0;
-  }
-  </style>
-  <title>Devices</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js"></script>
-  <script type="text/javascript">
-    var advancedOpts;
-    var adv = false;
-
-    var varTypes = { {{range $.VarTypes}}
-      {{.Basename}}:"{{.Value}}",{{end}}
-    };
-    var varEnums = {};
-    function deleteVar(ma, name) {
-      window.location = '/set/devices/edit/var?ma=' + ma + '&vn=' + name + '&vd=true';
-    }
-
-    function checkVar() {
-      let vn = document.getElementById('vn');
-      if (vn.value == '') {
-        setValue('_newvar');
-        return false;
-      }
-      return true;
-    }
-
-    function setValue(id) {
-      if (id == "") {
-        return;
-      }
-      let form = document.getElementById(id);
-      let span2 = form.firstElementChild.nextElementSibling;
-      let vn = span2.firstChild;
-      let span3 = span2.nextElementSibling;
-      let vv = span3.firstChild;
-      let msg = form.querySelector('.msg')
-
-      while (span3.firstChild) {
-        span3.removeChild(span3.firstChild);
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <style rel="stylesheet" type="text/css">
+      .advanced {
+        transition: all 0.3s ease; /* Optional: for smooth transition */
       }
 
-      let k = vn.value;
-      let v = varTypes[k];
-      if (v === 'int') {
-        msg.textContent = k + ' must be a whole number'
-        vv.required = true
-        vv.type = 'number'
-        vv.step = 1
-      } else if (v === 'uint') {
-        msg.textContent = k + ' must be a positive whole number'
-        vv.required = true
-        vv.type = 'number'
-        vv.step = 1
-        vv.min = 0
-      } else if (v === 'float') {
-        msg.textContent =  k + ' must be a number'
-        vv.required = true
-        vv.type = 'number'
-        vv.step = 'any'
+      .advanced.hidden {
+        display: none;
+        height: 0;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+    <title>Devices</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript">
+      var advancedOpts;
+      var adv = false;
+
+      var varTypes = { {{range $.VarTypes}}
+        {{.Basename}}:"{{.Value}}",{{end}}
+      };
+      var varEnums = {};
+      function deleteVar(ma, name) {
+        window.location = '/set/devices/edit/var?ma=' + ma + '&vn=' + name + '&vd=true';
       }
 
-      let enums = varEnums[k];
-      if (enums == null) {
-        span3.appendChild(vv);
-        vv.removeAttribute('hidden');
-        vv.removeAttribute('disabled');
-        return;
-      }
-
-      vv.setAttribute('hidden', 'true');
-      vv.setAttribute('disabled', 'true');
-
-      let type = 'radio';
-      if (varTypes[k].substring(0,6) == 'enums:') {
-        type = 'checkbox';
-      }
-      let values = vv.value.split(',');
-      for (let i = 0; i < enums.length; i++) {
-        let input = document.createElement('input');
-        input.type = type;
-        input.name = 'vv';
-        input.value = enums[i];
-        input.setAttribute('onchange', "document.getElementById('"+id+"').submit();")
-        if (values.includes(input.value)) {
-          input.checked = true;
+      function checkVar() {
+        let vn = document.getElementById('vn');
+        if (vn.value == '') {
+          setValue('_newvar');
+          return false;
         }
-        span3.appendChild(input);
-        let text = document.createTextNode(enums[i] + ' ');
-        span3.appendChild(text);
+        return true;
       }
-    }
 
-    function init() {
-      for (let k in varTypes) {
+      function setValue(id) {
+        if (id == "") {
+          return;
+        }
+        let form = document.getElementById(id);
+        let span2 = form.firstElementChild.nextElementSibling;
+        let vn = span2.firstChild;
+        let span3 = span2.nextElementSibling;
+        let vv = span3.firstChild;
+        let msg = form.querySelector('.msg')
+
+        while (span3.firstChild) {
+          span3.removeChild(span3.firstChild);
+        }
+
+        let k = vn.value;
         let v = varTypes[k];
-        if (v == "bool") {
-          varEnums[k] = ['true', 'false'];
-        } else if (v.substring(0,5) == 'enum:') {
-          varEnums[k] = v.substring(5).split(',');
-        } else if (v.substring(0,6) == 'enums:') {
-          varEnums[k] = v.substring(6).split(',');
+        if (v === 'int') {
+          msg.textContent = k + ' must be a whole number'
+          vv.required = true
+          vv.type = 'number'
+          vv.step = 1
+        } else if (v === 'uint') {
+          msg.textContent = k + ' must be a positive whole number'
+          vv.required = true
+          vv.type = 'number'
+          vv.step = 1
+          vv.min = 0
+        } else if (v === 'float') {
+          msg.textContent =  k + ' must be a number'
+          vv.required = true
+          vv.type = 'number'
+          vv.step = 'any'
+        }
+
+        let enums = varEnums[k];
+        if (enums == null) {
+          span3.appendChild(vv);
+          vv.removeAttribute('hidden');
+          vv.removeAttribute('disabled');
+          return;
+        }
+
+        vv.setAttribute('hidden', 'true');
+        vv.setAttribute('disabled', 'true');
+
+        let type = 'radio';
+        if (varTypes[k].substring(0,6) == 'enums:') {
+          type = 'checkbox';
+        }
+        let values = vv.value.split(',');
+        for (let i = 0; i < enums.length; i++) {
+          let input = document.createElement('input');
+          input.type = type;
+          input.name = 'vv';
+          input.value = enums[i];
+          input.setAttribute('onchange', "document.getElementById('"+id+"').submit();")
+          if (values.includes(input.value)) {
+            input.checked = true;
+          }
+          span3.appendChild(input);
+          let text = document.createTextNode(enums[i] + ' ');
+          span3.appendChild(text);
         }
       }
-      let elems = document.querySelectorAll('input[name=vn]');
-      for (let elem of elems){
-        setValue(elem.value);
-      }
 
-      // Read the cookie for the advanced settings.
-      let cookies = document.cookie.split(";", 5);
-      for (c of cookies) {
-        let cpair = c
-          .trim()
-          .split("=", 2);
-        if (cpair[0] == "advanced") {
-          adv = cpair[1] == "on" ? true : false;
+      function init() {
+        for (let k in varTypes) {
+          let v = varTypes[k];
+          if (v == "bool") {
+            varEnums[k] = ['true', 'false'];
+          } else if (v.substring(0,5) == 'enum:') {
+            varEnums[k] = v.substring(5).split(',');
+          } else if (v.substring(0,6) == 'enums:') {
+            varEnums[k] = v.substring(6).split(',');
+          }
+        }
+        let elems = document.querySelectorAll('input[name=vn]');
+        for (let elem of elems){
+          setValue(elem.value);
+        }
+
+        // Read the cookie for the advanced settings.
+        let cookies = document.cookie.split(";", 5);
+        for (c of cookies) {
+          let cpair = c
+            .trim()
+            .split("=", 2);
+          if (cpair[0] == "advanced") {
+            adv = cpair[1] == "on" ? true : false;
+          }
+        }
+
+        advancedOpts = document.getElementsByClassName("advanced");
+        for (opt of advancedOpts) {
+          adv ? document.getElementById("adv-options-toggle").checked = true : opt.style.display = "none";
         }
       }
 
-      advancedOpts = document.getElementsByClassName("advanced");
-      for (opt of advancedOpts) {
-        adv ? document.getElementById("adv-options-toggle").checked = true : opt.style.display = "none";
-      }
-    }
-
-    function submitVar(vv) {
-      if (vv.validity.valid) {
-        vv.form.submit()
-      }
-    }
-
-    function validateVar(vv) {
-      if (vv.validity.valid) {
-        vv.form.querySelector('.msg').className = 'td msg hidden'
-      } else {
-        vv.form.querySelector('.msg').className = 'td msg'
-      }
-    }
-
-    function deleteSensor(mac, pin) {
-      window.location = '/set/devices/edit/sensor?ma=' + mac + '&pin=' + pin + '&delete=true';
-    }
-
-    function submitSensor(field) {
-      field.form.submit()
-    }
-
-    function deleteActuator(mac, pin) {
-      window.location = '/set/devices/edit/actuator?ma=' + mac + '&pin=' + pin + '&delete=true';
-    }
-
-    function submitActuator(field) {
-      field.form.submit()
-    }
-
-    function toggleAdvanced(checked) {
-      for (opt of advancedOpts) {
-        checked ? opt.style.display = "flex" : opt.style.display = "none";
+      function submitVar(vv) {
+        if (vv.validity.valid) {
+          vv.form.submit()
+        }
       }
 
-      document.cookie = (checked ? "advanced=on;" : "advanced=off;") + " path=/set/devices";
-    }
+      function validateVar(vv) {
+        if (vv.validity.valid) {
+          vv.form.querySelector('.msg').className = 'td msg hidden'
+        } else {
+          vv.form.querySelector('.msg').className = 'td msg'
+        }
+      }
 
-  </script>
-</head>
-<body onload="init();">
-  <div id="data">
-    <datalist id="list_vars">{{range $.VarTypes}}
-      <option>{{ .Basename }}</option>{{end}}
-    </datalist>
-  </div>
+      function deleteSensor(mac, pin) {
+        window.location = '/set/devices/edit/sensor?ma=' + mac + '&pin=' + pin + '&delete=true';
+      }
 
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
+      function submitSensor(field) {
+        field.form.submit()
+      }
+
+      function deleteActuator(mac, pin) {
+        window.location = '/set/devices/edit/actuator?ma=' + mac + '&pin=' + pin + '&delete=true';
+      }
+
+      function submitActuator(field) {
+        field.form.submit()
+      }
+
+      function toggleAdvanced(checked) {
+        for (opt of advancedOpts) {
+          checked ? opt.style.display = "flex" : opt.style.display = "none";
+        }
+
+        document.cookie = (checked ? "advanced=on;" : "advanced=off;") + " path=/set/devices";
+      }
+    </script>
+  </head>
+  <body onload="init();">
+    <div id="data">
+      <datalist id="list_vars">
+        {{range $.VarTypes}}
+        <option>{{ .Basename }}</option>
+        {{end}}
+      </datalist>
+    </div>
+
+    <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{range .Pages -}}
         <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+          <a {{if .URL}}href="{{.URL}}" {{end}}{{if .Selected}} class="selected" {{end}}>{{.Name}}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
+        {{- end}}
+      </nav-menu>
+      <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}" {{end}} slot="site-menu">
+        {{range .Users -}}
         <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    {{if .Msg}}
-      <div class="red">
-        {{.Msg}}
-      </div>
-      <br>
-    {{end}}
-    <h1 class="container-md">Devices</h1>
-    <div class="border rounded p-4 container-md bg-white">
-      <form action="/set/devices/" enctype="multipart/form-data" method="post">
-        <fieldset class="row d-flex gx-1 align-items-center">
-          <label class="col-sm-2 col-md-3 col-1 text-end pt-1">Select Device:</label>
+        {{- end}}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{if .Msg}}
+      <div class="red">{{.Msg}}</div>
+      <br />
+      {{end}}
+      <h1 class="container-md">Devices</h1>
+      <div class="border rounded p-4 container-md bg-white">
+        <form action="/set/devices/" enctype="multipart/form-data" method="post">
+          <fieldset class="row d-flex gx-1 align-items-center">
+            <label class="col-sm-2 col-md-3 col-1 text-end pt-1">Select Device:</label>
             <div class="col-sm-10 col-md-6 col-12">
               <select name="ma" onchange="this.form.submit();" class="form-select h-auto">
                 <option value="">-- New device --</option>
                 {{range .Devices}}
-                  <option value="{{ .MAC }}"{{if eq .MAC $.Mac}} selected{{end}}>{{ .Name }}</option>
+                <option value="{{ .MAC }}" {{if eq .MAC $.Mac}} selected{{end}}>{{ .Name }}</option>
                 {{end}}
               </select>
             </div>
-        </fieldset>
-      </form>
-      {{with .Device}}
+          </fieldset>
+        </form>
+        {{with .Device}}
         <form action="/set/devices/edit" enctype="multipart/form-data" method="post">
           <fieldset>
             <div class="d-flex justify-content-between h-auto pt-5">
               <h2>Configuration</h2>
               <a href="?new-configuration=true">Try Auto Configuration (Controllers Only)</a>
             </div>
-            <hr>
+            <hr />
             <div class="d-flex flex-column gap-1">
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Name:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="dn" value="{{.Name}}">
+                  <input class="form-control" type="input" name="dn" value="{{.Name}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">MAC:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="ma" value="{{.MAC}}" {{if .MAC}}readonly{{end}}>
+                  <input class="form-control" type="input" name="ma" value="{{.MAC}}" {{if .MAC}}readonly{{end}} />
                 </div>
               </div>
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Type:</label>
                 <div class="col-sm-10 col-md-6 col-12">
                   {{if .Type}}
-                  <input class="form-control" value="{{.Type}}" name="ct" readonly>
+                  <input class="form-control" value="{{.Type}}" name="ct" readonly />
                   {{else}}
                   <select name="ct" class="form-select h-auto">
-                    <option value="">-- Select type --</option>{{range $.DevTypes}}
-                    <option value="{{.}}"{{if eq . $.Device.Type}} selected{{end}}>{{.}}</option>
-                  {{end}}
-                  {{end}}
+                    <option value="">-- Select type --</option>
+                    {{range $.DevTypes}}
+                    <option value="{{.}}" {{if eq . $.Device.Type}} selected{{end}}>{{.}}</option>
+                    {{end}} {{end}}
                   </select>
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Inputs:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="ip" value="{{.Inputs}}">
+                  <input class="form-control" type="input" name="ip" value="{{.Inputs}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Outputs:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="op" value="{{.Outputs}}">
+                  <input class="form-control" type="input" name="op" value="{{.Outputs}}" />
                 </div>
               </div>
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">WiFi:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="wi" value="{{.Wifi}}">
+                  <input class="form-control" type="input" name="wi" value="{{.Wifi}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Mon Period:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="number" name="mp" value="{{.MonitorPeriod}}">
+                  <input class="form-control" type="number" name="mp" value="{{.MonitorPeriod}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Act Period:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="number" name="ap" value="{{.ActPeriod}}">
+                  <input class="form-control" type="number" name="ap" value="{{.ActPeriod}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Client Version:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="cv" value="{{.Version}}">
+                  <input class="form-control" type="input" name="cv" value="{{.Version}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Client Protocol:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="ns" value="{{.Protocol}}">
+                  <input class="form-control" type="input" name="ns" value="{{.Protocol}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Latitude:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="number" name="lt" value="{{.Latitude}}">
+                  <input class="form-control" type="number" name="lt" value="{{.Latitude}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Longitude:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="number" name="ln" value="{{.Longitude}}">
+                  <input class="form-control" type="number" name="ln" value="{{.Longitude}}" />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Device Key:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="number" name="dk" value="{{.Dkey}}" disabled>
+                  <input class="form-control" type="number" name="dk" value="{{.Dkey}}" disabled />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Local Address:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="la" value="{{if (.Other "localaddr")}}{{.Other "localaddr"}}{{end}}" disabled>
+                  {{$localAddr := .Other "localaddr"}}
+                  <input class="form-control" type="input" name="la" value="{{if $localAddr}}{{$localAddr}}{{end}}" disabled />
                 </div>
               </div>
               <div class="advanced row gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Last Updated:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="up" value="{{if .Name}}{{localdatetime .Updated.Unix $.Timezone}}{{end}}" disabled>
+                  <input class="form-control" type="input" name="up" value="{{if .Name}}{{localdatetime .Updated.Unix $.Timezone}}{{end}}" disabled />
                 </div>
               </div>
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Uptime:</label>
                 <div class="col-sm-10 col-md-6 col-12">
-                  <input class="form-control" type="input" name="ut" value="{{if (.Other "uptime")}}{{.Other "uptime"}}{{end}}" disabled>
+                  {{$uptime := .Other "uptime"}}
+                  <input class="form-control" type="input" name="ut" value="{{if $uptime}}{{$uptime}}{{end}}" disabled />
                 </div>
               </div>
               <div class="row d-flex gx-1">
                 <label class="col-sm-2 col-md-3 col-1 text-end">Enabled:</label>
                 <div class="col-sm-10 col-md-6 col-12 d-flex align-items-center gap-2">
-                  <input type="checkbox" name="de" id="de" {{if .Enabled }}checked{{end}}>
+                  <input type="checkbox" name="de" id="de" {{if .Enabled }}checked{{end}} />
                   {{if .Name}}
-                    <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}">
-                    <img src="/s/{{ .Other "sending"}}.png" alt="{{ .Other "sending"}}">
+                  <img src="/s/{{ .StatusText }}.png" alt="{{ .StatusText }}" />
+                  {{ $sending := "sending" }}
+                  <img src="/s/{{ .Other $sending }}.png" alt="{{ .Other $sending }}" />
                   {{end}}
                 </div>
               </div>
             </div>
             {{if .Name}}
-              <div class="d-flex justify-content-center">
-                <div class="d-flex gap-1">
-                  <input class="btn btn-primary" type="submit" name="task" value="Update">
-                  <input class="btn btn-primary" type="submit" name="task" value="Shutdown">
-                  <input class="btn btn-primary" type="submit" name="task" value="Reboot">
-                  <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Debug">
-                  <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Upgrade">
-                  <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Alarm">
-                  <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Test">
-                  <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Delete" onclick="return confirm('Are you sure?')">
-                </div>
+            <div class="d-flex justify-content-center">
+              <div class="d-flex gap-1">
+                <input class="btn btn-primary" type="submit" name="task" value="Update" />
+                <input class="btn btn-primary" type="submit" name="task" value="Shutdown" />
+                <input class="btn btn-primary" type="submit" name="task" value="Reboot" />
+                <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Debug" />
+                <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Upgrade" />
+                <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Alarm" />
+                <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Test" />
+                <input class="advanced btn btn-outline-primary" type="submit" name="task" value="Delete" onclick="return confirm('Are you sure?')" />
               </div>
-              {{else}}
-              <div class="d-flex justify-content-center pb-1">
-                <input class="btn btn-primary w-50" type="submit" name="task" value="Add">
-              </div>
-              {{end}}
+            </div>
+            {{else}}
+            <div class="d-flex justify-content-center pb-1">
+              <input class="btn btn-primary w-50" type="submit" name="task" value="Add" />
+            </div>
+            {{end}}
           </fieldset>
         </form>
         <div class="row d-flex gx-1">
           <label for="adv-toggle" class="col-sm-2 col-md-3 col-1 text-end">Advanced Options:</label>
           <div class="col-sm-10 col-md-6 col-12">
-              <input type="checkbox" id="adv-options-toggle" name="adv-toggle" onchange="toggleAdvanced(checked)">
+            <input type="checkbox" id="adv-options-toggle" name="adv-toggle" onchange="toggleAdvanced(checked)" />
           </div>
         </div>
-      {{end}}
-
-      {{if .Device }}
+        {{end}} {{if .Device }}
         <div class="advanced flex-column">
-            <h2>Variables</h2>
-            <hr>
-            <table class="table mx-auto" style="max-width: 500px;">
+          <h2>Variables</h2>
+          <hr />
+          <table class="table mx-auto" style="max-width: 500px">
             <thead>
-                <th></th>
-                <th class="text-center">Name</th>
-                <th class="text-center">Value</th>
+              <th></th>
+              <th class="text-center">Name</th>
+              <th class="text-center">Value</th>
             </thead>
             <tbody>
-            {{range .Vars}}
-            <tr>
+              {{range .Vars}}
+              <tr>
                 <form class="row gx-1 d-flex align-items-center" id="{{ .Basename }}" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" novalidate>
-                <td class="d-flex justify-content-end h-75"><img src="/s/delete.png" onclick="deleteVar('{{$.Device.MAC}}','{{ .Basename }}');"></td>
-                <td><input class="form-control form-control-sm w-100" type="text" name="vn" value="{{ .Basename }}" readonly></td>
-                <td><input class="form-control form-control-sm w-100" type="text" name="vv" value="{{ .Value }}" onchange="submitVar(this)" oninput="validateVar(this)">
+                  <td class="d-flex justify-content-end h-75"><img src="/s/delete.png" onclick="deleteVar('{{$.Device.MAC}}','{{ .Basename }}');" /></td>
+                  <td><input class="form-control form-control-sm w-100" type="text" name="vn" value="{{ .Basename }}" readonly /></td>
+                  <td>
+                    <input class="form-control form-control-sm w-100" type="text" name="vv" value="{{ .Value }}" onchange="submitVar(this)" oninput="validateVar(this)" />
                     {{if .IsLink }}
-                    <a href="{{ .Value }}" target="_blank"><img src="/s/link.png"></a>
+                    <a href="{{ .Value }}" target="_blank"><img src="/s/link.png" /></a>
                     {{end}}
-                </td>
-                <span class="td msg hidden"></span>
-                <input type="hidden" name="ma" value="{{$.Device.MAC}}">
+                  </td>
+                  <span class="td msg hidden"></span>
+                  <input type="hidden" name="ma" value="{{$.Device.MAC}}" />
                 </form>
-            </tr>
-            {{end}}
-            <tr>
+              </tr>
+              {{end}}
+              <tr>
                 <form class="row gx-1 d-flex align-items-center" id="_newvar" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" onsubmit="return checkVar();" novalidate>
-                <td class="d-flex justify-content-end h-75"><input type="image" src="/s/add.png"></td>
-                <td><input type="text" class="form-control form-control-sm w-100" name="vn" id="vn" list="list_vars" onchange="setValue('_newvar');"></td>
-                <td><input type="text" class="form-control form-control-sm w-100" name="vv" oninput="validateVar(this)"></td>
-                <td class="td msg hidden"></td>
-                <input type="hidden" name="ma" value="{{$.Device.MAC}}">
+                  <td class="d-flex justify-content-end h-75"><input type="image" src="/s/add.png" /></td>
+                  <td><input type="text" class="form-control form-control-sm w-100" name="vn" id="vn" list="list_vars" onchange="setValue('_newvar');" /></td>
+                  <td><input type="text" class="form-control form-control-sm w-100" name="vv" oninput="validateVar(this)" /></td>
+                  <td class="td msg hidden"></td>
+                  <input type="hidden" name="ma" value="{{$.Device.MAC}}" />
                 </form>
-            </tr>
+              </tr>
             </tbody>
-            </table>
+          </table>
         </div>
         <div class="advanced flex-column">
-        <h2 class="pt-5">Sensors</h2>
-        <hr>
-        <table class="table" id="sensors">
-          <thead>
-            <tr>
-              <th class="text-center" scope="col"></th>
-              <th class="text-center" scope="col">Name</th>
-              <th class="text-center" scope="col">Input</th>
-              <th class="text-center" scope="col">Quantity</th>
-              <th class="text-center" scope="col">Function</th>
-              <th class="text-center" scope="col">Args</th>
-              <th class="text-center" scope="col">Units</th>
-              <th class="text-center" scope="col">Format</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{$dev := $.Device}}
-            {{$data := $}}
-            {{range $sensor := .Sensors}}
-            <tr>
-              <form class="row gx-1 d-flex align-items-center" id="{{ .Name }}" enctype="multipart/form-data" action="/set/devices/edit/sensor" method="post" novalidate>
-                <td><img class="mt-2" src="/s/delete.png" onclick="deleteSensor('{{$dev.MAC}}','{{ $sensor.Pin }}');"></td>
-                <td><input class="form-control form-control-sm" type="text" name="name" value="{{ $sensor.Name }}" onchange="submitSensor(this)"></td>
-                <td class="col-1"><input class="form-control form-control-sm" type="text" name="pin" value="{{ $sensor.Pin }}" readonly></td>
-                <td>
-                  <select class="form-select form-select-sm" name="sqty" onchange="submitSensor(this)">
-                    {{range $qty := $data.Quantities}}
-                      <option value="{{$qty.Code}}"{{if eq $qty.Code $sensor.Quantity}} selected{{end}}>{{$qty.Name}}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td class="td std">
-                  <select class="form-select form-select-sm" name="sfunc" onchange="submitSensor(this)">
-                    {{range $func := $data.Funcs}}
-                      <option value="{{$func}}"{{if eq $func $sensor.Func}} selected{{end}}>{{$func}}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td><input class="form-control form-control-sm" type="text" name="sargs" value="{{ $sensor.Args }}" class="std" onchange="submitSensor(this)"></td>
-                <td class="col-1"><input class="form-control form-control-sm" type="text" name="sunits" value="{{ $sensor.Units }}" class="std" onchange="submitSensor(this)"></td>
-                <td>
-                  <select class="form-select form-select-sm" name="sfmt" onchange="submitSensor(this)">
-                    {{range $fmt := $data.Formats}}
-                      <option value="{{$fmt}}"{{if eq $fmt $sensor.Format}} selected{{end}}>{{$fmt}}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td class="td msg hidden"></td>
-                <input type="hidden" name="ma" value="{{$dev.MAC}}">
-              </form>
-            </tr>
-            {{end}}
-            <tr>
-              <form class="row gx-1 d-flex align-items-center" id="new-sensor" enctype="multipart/form-data" action="/set/devices/edit/sensor" method="post" novalidate>
-                <td><input class="mt-2" type="image" src="/s/add.png"></td>
-                <td><input class="form-control form-control-sm" type="text" name="name"></td>
-                <td>
-                  <select class="form-select form-select-sm" name="pin">
-                    <option value="">--</option>
-                    {{range $pin := $dev.InputList}}
-                      <option value="{{ $pin }}">{{ $pin }}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td>
-                  <select class="form-select form-select-sm" class="dbl" name="sqty">
-                    <option value="">- Select -</option>
-                    {{range $qty := $data.Quantities}}
-                      <option value="{{$qty.Code}}">{{$qty.Name}}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td>
-                  <select class="form-select form-select-sm" name="sfunc">
-                    <option value="">--</option>
-                    {{range $func := $data.Funcs}}
-                      <option value="{{$func}}">{{$func}}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td><input class="form-control form-control-sm" type="text" name="sargs"></td>
-                <td><input class="form-control form-control-sm" type="text" name="sunits"></td>
-                <td>
-                  <select class="form-select form-select-sm" name="sfmt">
-                    <option value="">--</option>
-                    {{range $fmt := $data.Formats}}
-                      <option value="{{$fmt}}">{{$fmt}}</option>
-                    {{end}}
-                  </select>
-                </td>
-                <td class="td msg hidden"></td>
-                <input type="hidden" name="ma" value="{{$dev.MAC}}">
-              </form>
-            </tr>
-          </tbody>
-        </table>
-        </div>
-        <div class="advanced flex-column">
-            <h2 class="pt-5">Actuators</h2>
-            <hr>
-            <div class="d-flex justify-content-around">
-            <table class="table" id="actuators">
-                <thead>
-                <tr>
-                    <th></th>
-                    <th class="text-center">Name</th>
-                    <th class="text-center">Var</th>
-                    <th class="text-center">Pin</th>
-                </tr>
-                </thead>
-                <tbody>
-                {{$dev := $.Device}}
-                {{$data := $}}
-                {{range $act := .Actuators}}
-                <tr>
-                <form class="tr" id="{{ .Name }}" enctype="multipart/form-data" action="/set/devices/edit/actuator" method="post" novalidate>
-                    <td><img class="mt-2" src="/s/delete.png" onclick="deleteActuator('{{$dev.MAC}}','{{ $act.Pin }}');"></td>
-                    <td><input class="form-control form-control-sm" type="text" name="name" value="{{ $act.Name }}" onchange="submitActuator(this)"></td>
-                    <td><input class="form-control form-control-sm" type="text" name="var" value="{{ $act.Var}}" onchange="submitActuator(this)"></td>
-                    <td><input class="form-control form-control-sm" type="text" name="pin" value="{{ $act.Pin }}" readonly></td>
-                    <span class="td msg hidden"></span>
-                    <input type="hidden" name="ma" value="{{$dev.MAC}}">
+          <h2 class="pt-5">Sensors</h2>
+          <hr />
+          <table class="table" id="sensors">
+            <thead>
+              <tr>
+                <th class="text-center" scope="col"></th>
+                <th class="text-center" scope="col">Name</th>
+                <th class="text-center" scope="col">Input</th>
+                <th class="text-center" scope="col">Quantity</th>
+                <th class="text-center" scope="col">Function</th>
+                <th class="text-center" scope="col">Args</th>
+                <th class="text-center" scope="col">Units</th>
+                <th class="text-center" scope="col">Format</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{$dev := $.Device}} {{$data := $}} {{range $sensor := .Sensors}}
+              <tr>
+                <form class="row gx-1 d-flex align-items-center" id="{{ .Name }}" enctype="multipart/form-data" action="/set/devices/edit/sensor" method="post" novalidate>
+                  <td><img class="mt-2" src="/s/delete.png" onclick="deleteSensor('{{$dev.MAC}}','{{ $sensor.Pin }}');" /></td>
+                  <td><input class="form-control form-control-sm" type="text" name="name" value="{{ $sensor.Name }}" onchange="submitSensor(this)" /></td>
+                  <td class="col-1"><input class="form-control form-control-sm" type="text" name="pin" value="{{ $sensor.Pin }}" readonly /></td>
+                  <td>
+                    <select class="form-select form-select-sm" name="sqty" onchange="submitSensor(this)">
+                      {{range $qty := $data.Quantities}}
+                      <option value="{{$qty.Code}}" {{if eq $qty.Code $sensor.Quantity}} selected{{end}}>{{$qty.Name}}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td class="td std">
+                    <select class="form-select form-select-sm" name="sfunc" onchange="submitSensor(this)">
+                      {{range $func := $data.Funcs}}
+                      <option value="{{$func}}" {{if eq $func $sensor.Func}} selected{{end}}>{{$func}}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td><input class="form-control form-control-sm" type="text" name="sargs" value="{{ $sensor.Args }}" class="std" onchange="submitSensor(this)" /></td>
+                  <td class="col-1"><input class="form-control form-control-sm" type="text" name="sunits" value="{{ $sensor.Units }}" class="std" onchange="submitSensor(this)" /></td>
+                  <td>
+                    <select class="form-select form-select-sm" name="sfmt" onchange="submitSensor(this)">
+                      {{range $fmt := $data.Formats}}
+                      <option value="{{$fmt}}" {{if eq $fmt $sensor.Format}} selected{{end}}>{{$fmt}}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td class="td msg hidden"></td>
+                  <input type="hidden" name="ma" value="{{$dev.MAC}}" />
                 </form>
+              </tr>
+              {{end}}
+              <tr>
+                <form class="row gx-1 d-flex align-items-center" id="new-sensor" enctype="multipart/form-data" action="/set/devices/edit/sensor" method="post" novalidate>
+                  <td><input class="mt-2" type="image" src="/s/add.png" /></td>
+                  <td><input class="form-control form-control-sm" type="text" name="name" /></td>
+                  <td>
+                    <select class="form-select form-select-sm" name="pin">
+                      <option value="">--</option>
+                      {{range $pin := $dev.InputList}}
+                      <option value="{{ $pin }}">{{ $pin }}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-select form-select-sm" class="dbl" name="sqty">
+                      <option value="">- Select -</option>
+                      {{range $qty := $data.Quantities}}
+                      <option value="{{$qty.Code}}">{{$qty.Name}}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-select form-select-sm" name="sfunc">
+                      <option value="">--</option>
+                      {{range $func := $data.Funcs}}
+                      <option value="{{$func}}">{{$func}}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td><input class="form-control form-control-sm" type="text" name="sargs" /></td>
+                  <td><input class="form-control form-control-sm" type="text" name="sunits" /></td>
+                  <td>
+                    <select class="form-select form-select-sm" name="sfmt">
+                      <option value="">--</option>
+                      {{range $fmt := $data.Formats}}
+                      <option value="{{$fmt}}">{{$fmt}}</option>
+                      {{end}}
+                    </select>
+                  </td>
+                  <td class="td msg hidden"></td>
+                  <input type="hidden" name="ma" value="{{$dev.MAC}}" />
+                </form>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div class="advanced flex-column">
+          <h2 class="pt-5">Actuators</h2>
+          <hr />
+          <div class="d-flex justify-content-around">
+            <table class="table" id="actuators">
+              <thead>
+                <tr>
+                  <th></th>
+                  <th class="text-center">Name</th>
+                  <th class="text-center">Var</th>
+                  <th class="text-center">Pin</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{$dev := $.Device}} {{$data := $}} {{range $act := .Actuators}}
+                <tr>
+                  <form class="tr" id="{{ .Name }}" enctype="multipart/form-data" action="/set/devices/edit/actuator" method="post" novalidate>
+                    <td><img class="mt-2" src="/s/delete.png" onclick="deleteActuator('{{$dev.MAC}}','{{ $act.Pin }}');" /></td>
+                    <td><input class="form-control form-control-sm" type="text" name="name" value="{{ $act.Name }}" onchange="submitActuator(this)" /></td>
+                    <td><input class="form-control form-control-sm" type="text" name="var" value="{{ $act.Var}}" onchange="submitActuator(this)" /></td>
+                    <td><input class="form-control form-control-sm" type="text" name="pin" value="{{ $act.Pin }}" readonly /></td>
+                    <span class="td msg hidden"></span>
+                    <input type="hidden" name="ma" value="{{$dev.MAC}}" />
+                  </form>
                 </tr>
                 {{end}}
                 <tr>
-                <form class="tr" id="new-actuator" enctype="multipart/form-data" action="/set/devices/edit/actuator" method="post" novalidate>
-                <td><input class="mt-2" type="image" src="/s/add.png"></td>
-                <td><input class="form-control form-control-sm" type="text" name="name" class="width-302"></td>
-                <td><input class="form-control form-control-sm" type="text" name="var" class="width-302"></td>
-                <td>
-                    <select class="form-select form-select-sm" name="pin">
-                    <option value="">- Select -</option>
-                    {{range $pin:= $dev.OutputList}}
+                  <form class="tr" id="new-actuator" enctype="multipart/form-data" action="/set/devices/edit/actuator" method="post" novalidate>
+                    <td><input class="mt-2" type="image" src="/s/add.png" /></td>
+                    <td><input class="form-control form-control-sm" type="text" name="name" class="width-302" /></td>
+                    <td><input class="form-control form-control-sm" type="text" name="var" class="width-302" /></td>
+                    <td>
+                      <select class="form-select form-select-sm" name="pin">
+                        <option value="">- Select -</option>
+                        {{range $pin:= $dev.OutputList}}
                         <option value="{{$pin}}">{{$pin}}</option>
-                    {{end}}
-                    </select>
-                </td>
-                <span class="td msg hidden"></span>
-                <input type="hidden" name="ma" value="{{$dev.MAC}}">
-                </form>
+                        {{end}}
+                      </select>
+                    </td>
+                    <span class="td msg hidden"></span>
+                    <input type="hidden" name="ma" value="{{$dev.MAC}}" />
+                  </form>
                 </tr>
-                </tbody>
+              </tbody>
             </table>
-            </div>
-        {{end}}
+          </div>
+          {{end}}
         </div>
-    </div>
-
-  </section>
-  {{.Footer}}
-</body>
+      </div>
+    </section>
+    {{.Footer}}
+  </body>
 </html>

--- a/cmd/oceanbench/t/upload.html
+++ b/cmd/oceanbench/t/upload.html
@@ -1,151 +1,163 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>CloudBlue | Upload</title>
-  <style type="text/css">
-  #dropzone {
-    margin-left: 205px;
-    height: 100px;
-    border: 1px solid black;
-    border-radius: 10px;
-    background-color: #def;
-    line-height: 100px;
-    text-align: center;
-  }
-  #dropzone:hover {
-    background-color: #eef;
-  }
-  #dropzone.active {
-    background-color: #ddf;
-  }
-  .blinking {
-    animation: blink 1s infinite;
-  }
-  @keyframes blink {
-    0% { opacity: 1; }
-    50% { opacity: 0; }
-    100% { opacity: 1; }
-  }
-  </style>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js" ></script>
-  <script type="text/javascript">
-  function init() {
-    const dropzone = document.querySelector('#dropzone');
-    dropzone.addEventListener('dragover', (event) => {
-      event.preventDefault();
-      dropzone.classList.add('active');
-    });
-    dropzone.addEventListener('dragleave', (event) => {
-      dropzone.classList.remove('active');
-    });
-    dropzone.addEventListener('drop', (event) => {
-      event.preventDefault();
-      const files = event.dataTransfer.files;
-      const mid = document.getElementById("id").value;
-      if (mid == "") {
-        write(true, "MID missing");
-        return;
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>CloudBlue | Upload</title>
+    <style type="text/css">
+      #dropzone {
+        margin-left: 205px;
+        height: 100px;
+        border: 1px solid black;
+        border-radius: 10px;
+        background-color: #def;
+        line-height: 100px;
+        text-align: center;
       }
-      var stats = { total:files.length, uploaded:[], failed:[] };
-      write(true, '<span class="blinking">Uploading...</span>')
-      for (const file of files) {
-        upload(file, stats);
+      #dropzone:hover {
+        background-color: #eef;
       }
-    });
-  }
-  function upload(file, stats) {
-    const formData = new FormData(document.getElementById("form"));
-    formData.append('file', file);
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', '/upload', true);
-    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-    xhr.send(formData);
-    xhr.onload = function() {
-      if (xhr.status === 200) {
-        stats.uploaded.push(file)
-      } else {
-        stats.failed.push(file)
+      #dropzone.active {
+        background-color: #ddf;
       }
-      writeStats(stats);
-    }
-  }
-  function write(clear, ...args){
-    var msg = "";
-    if (!clear) {
-      msg = document.getElementById("msg").innerHTML;
-    }
-    for (var i = 0; i < args.length; i++) {
-      if (typeof args[i] === 'number') {
-        msg += args[i].toString();
-      } else {
-        msg += args[i];
+      .blinking {
+        animation: blink 1s infinite;
       }
-    }
-    msg += "<br>";
-    document.getElementById("msg").innerHTML = msg;
-  }
-  function writeStats(stats) {
-    write(true, "Total: ", stats.total);
-    write(false, "Uploaded: ", stats.uploaded.length);
-    for (var i = 0; i < stats.uploaded.length; i++) {
-      write(false, "&bull; ", stats.uploaded[i].name, " (", stats.uploaded[i].size, " bytes)");
-    }
-    if (stats.failed.length == 0) {
-      return;
-    }
-    write(false, "Failed to upload: ", stats.failed.length);
-    for (var i = 0; i < stats.failed.length; i++) {
-      write(false, "&bull; ", stats.failed[i].name, " (", stats.failed[i].size, " bytes)");
-    }
-  }
-</script>
-</head>
-<body onload="init();">
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+      @keyframes blink {
+        0% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0;
+        }
+        100% {
+          opacity: 1;
+        }
+      }
+    </style>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript">
+      function init() {
+        const dropzone = document.querySelector("#dropzone");
+        dropzone.addEventListener("dragover", (event) => {
+          event.preventDefault();
+          dropzone.classList.add("active");
+        });
+        dropzone.addEventListener("dragleave", (event) => {
+          dropzone.classList.remove("active");
+        });
+        dropzone.addEventListener("drop", (event) => {
+          event.preventDefault();
+          const files = event.dataTransfer.files;
+          const mid = document.getElementById("id").value;
+          if (mid == "") {
+            write(true, "MID missing");
+            return;
+          }
+          var stats = { total: files.length, uploaded: [], failed: [] };
+          write(true, '<span class="blinking">Uploading...</span>');
+          for (const file of files) {
+            upload(file, stats);
+          }
+        });
+      }
+      function upload(file, stats) {
+        const formData = new FormData(document.getElementById("form"));
+        formData.append("file", file);
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", "/upload", true);
+        xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+        xhr.send(formData);
+        xhr.onload = function () {
+          if (xhr.status === 200) {
+            stats.uploaded.push(file);
+          } else {
+            stats.failed.push(file);
+          }
+          writeStats(stats);
+        };
+      }
+      function write(clear, ...args) {
+        var msg = "";
+        if (!clear) {
+          msg = document.getElementById("msg").innerHTML;
+        }
+        for (var i = 0; i < args.length; i++) {
+          if (typeof args[i] === "number") {
+            msg += args[i].toString();
+          } else {
+            msg += args[i];
+          }
+        }
+        msg += "<br>";
+        document.getElementById("msg").innerHTML = msg;
+      }
+      function writeStats(stats) {
+        write(true, "Total: ", stats.total);
+        write(false, "Uploaded: ", stats.uploaded.length);
+        for (var i = 0; i < stats.uploaded.length; i++) {
+          write(false, "&bull; ", stats.uploaded[i].name, " (", stats.uploaded[i].size, " bytes)");
+        }
+        if (stats.failed.length == 0) {
+          return;
+        }
+        write(false, "Failed to upload: ", stats.failed.length);
+        for (var i = 0; i < stats.failed.length; i++) {
+          write(false, "&bull; ", stats.failed[i].name, " (", stats.failed[i].size, " bytes)");
+        }
+      }
+    </script>
+  </head>
+  <body onload="init();">
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
-    {{if .Msg}}<div class="red">{{.Msg}}</div><br>{{end}}
-    <h1 class="container-md">Upload</h1>
-    <div class="border rounded p-4 container-md bg-white">
-      <form action="/upload" method="POST" id="form" enctype="multipart/form-data">
-        <fieldset>
-          <label>Media ID*:</label>
-          <input type="input" name="id" id="id"{{if .MID}} value="{{ .MID}}"{{end}} class="w-50">
-          <br>
-          <label>MPEG-TS file:</label>
-          <input type="file" name="file" id="file" class="btn btn-primary w-50">
-          <br>
-          <div id="dropzone" class="w-50">or drop files here</div>
-          <br>
-          <input type="submit" name="task" value="Upload" class="btn btn-primary">
-        </fieldset>
-      </form>
-      <br>
-      <br>
-      <button onClick="updateMID('ma','pn','id');" class="btn btn-primary">Convert to Media ID</button>
-      MAC:<input type="input" id="ma" placeholder="00:00:00:00:00:00"> Pin:<input type="input" id="pn" value="V0">
-      <br>
-      <br>
-      <p class="fineprint">*If unsure, ask an AusOcean crew member to provide you one.</p>
-    </div>
-  </section>
-  {{.Footer}}
-</body>
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{ if .Msg }}
+      <div class="red">{{ .Msg }}</div>
+      <br />
+      {{ end }}
+      <h1 class="container-md">Upload</h1>
+      <div class="border rounded p-4 container-md bg-white">
+        <form action="/upload" method="POST" id="form" enctype="multipart/form-data">
+          <fieldset>
+            <label>Media ID*:</label>
+            <input type="input" name="id" id="id" {{ if .MID }}value="{{ .MID }}" {{ end }} class="w-50" />
+            <br />
+            <label>MPEG-TS file:</label>
+            <input type="file" name="file" id="file" class="btn btn-primary w-50" />
+            <br />
+            <div id="dropzone" class="w-50">or drop files here</div>
+            <br />
+            <input type="submit" name="task" value="Upload" class="btn btn-primary" />
+          </fieldset>
+        </form>
+        <br />
+        <br />
+        <button onClick="updateMID('ma','pn','id');" class="btn btn-primary">Convert to Media ID</button>
+        MAC:
+        <input type="input" id="ma" placeholder="00:00:00:00:00:00" />
+        Pin:
+        <input type="input" id="pn" value="V0" />
+        <br />
+        <br />
+        <p class="fineprint">*If unsure, ask an AusOcean crew member to provide you one.</p>
+      </div>
+    </section>
+    {{ .Footer }}
+  </body>
 </html>

--- a/cmd/oceanbench/t/utils.html
+++ b/cmd/oceanbench/t/utils.html
@@ -1,113 +1,113 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-  <link href="/s/main.css" rel="stylesheet" type="text/css"/>
-  <title>CloudBlue | Utilities</title>
-  <script type="module" src="/s/lit/header-group.js"></script>
-  <script type="text/javascript" src="/s/main.js" ></script>
-  <script type="text/javascript">
-  function updateMacEnc(mac, enc) {
-    var macElem = document.getElementById(mac);
-    var encElem = document.getElementById(enc);
-    encElem.value = encodeMAC(macElem.value).toString();
-  }
-  </script>
-</head>
-<body onload="history.pushState({}, '', '/admin/utils')">
-  <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true"{{end}}>
-    <nav-menu id="nav-menu" slot="nav-menu">
-      {{range .Pages -}}
-        <li data-perm="{{.Perm}}" class="indent-{{ .Level }}">
-          <a {{if .URL}}href="{{.URL}}"{{end}}{{if .Selected}} class="selected"{{end}}>{{.Name}}</a>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
+    <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <title>CloudBlue | Utilities</title>
+    <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="text/javascript" src="/s/main.js"></script>
+    <script type="text/javascript">
+      function updateMacEnc(mac, enc) {
+        var macElem = document.getElementById(mac);
+        var encElem = document.getElementById(enc);
+        encElem.value = encodeMAC(macElem.value).toString();
+      }
+    </script>
+  </head>
+  <body onload="history.pushState({}, '', '/admin/utils')">
+    <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
+      <nav-menu id="nav-menu" slot="nav-menu">
+        {{ range .Pages -}}
+        <li data-perm="{{ .Perm }}" class="indent-{{ .Level }}">
+          <a {{ if .URL }}href="{{ .URL }}" {{ end }}{{ if .Selected }}class="selected" {{ end }}>{{ .Name }}</a>
         </li>
-      {{- end}}
-    </nav-menu>
-    <site-menu id="sitemenu" {{if .Profile}}selected-data="{{.Profile.Data}}"{{end}} slot="site-menu">
-      {{range .Users -}}
-        <option style="display: none" slot="{{.PermissionText}}" value="{{.Skey}}"></option>
-      {{- end}}
-    </site-menu>
-  </header-group>
-  <section id="main" class="main">
+        {{- end }}
+      </nav-menu>
+      <site-menu id="sitemenu" {{ if .Profile }}selected-data="{{ .Profile.Data }}" {{ end }} slot="site-menu">
+        {{ range .Users -}}
+        <option style="display: none" slot="{{ .PermissionText }}" value="{{ .Skey }}"></option>
+        {{- end }}
+      </site-menu>
+    </header-group>
+    <section id="main" class="main">
+      {{ if .Msg }}
+      <div class="red">{{ .Msg }}</div>
+      <br />
+      {{ end }}
 
-  {{if .Msg}}
-  <div class="red">{{.Msg}}</div><br>
-  {{end}}
+      <h1 class="container-md">Admin Utilities</h1>
+      <div class="border rounded p-4 container-md bg-white">
+        <span class="bold">Device Management</span>
+        <hr />
+        <form class="d-flex align-items-center justify-content-between mb-1" enctype="multipart/form-data" action="/admin/utils" method="post">
+          <div class="d-flex w-50">
+            <input name="ma" value="{{ .Ma }}" placeholder="00:00:00:00:00:00" class="w-50" />
+            <p class="flex-grow-1 text-center">&rarr;</p>
+            <input value="{{ .Sn }}" readonly class="w-50" />
+          </div>
+          <button type="submit" class="btn btn-primary w-25">Find device</button>
+          <input type="hidden" name="task" value="find" />
+        </form>
 
-	<h1 class="container-md">Admin Utilities</h1>
-  <div class="border rounded p-4 container-md bg-white">
-    <span class="bold">Device Management</span>
-    <hr>  
-    <form class="d-flex align-items-center justify-content-between mb-1" enctype="multipart/form-data" action="/admin/utils" method="post">
-      <div class="d-flex w-50">
-        <input name="ma" value="{{ .Ma }}" placeholder="00:00:00:00:00:00" class="w-50">
-    	  <p class="flex-grow-1 text-center">&rarr;</p>
-        <input value="{{ .Sn }}" readonly class="w-50">
+        <form class="d-flex align-items-center justify-content-between mb-1" enctype="multipart/form-data" action="/admin/utils" method="post">
+          <div class="d-flex w-50">
+            <select name="ma" class="w-50">
+              <option value="">- Select device -</option>
+              {{ range .Devices }}
+              <option value="{{ .MAC }}" {{ if eq .MAC $.Ma }}selected{{ end }}>{{ .Name }}</option>
+              {{ end }}
+            </select>
+            <p class="flex-grow-1 text-center">&rarr;</p>
+            <select name="sk" class="w-50">
+              <option value="">- Select site -</option>
+              {{ range .Sites }}
+              <option value="{{ .Skey }}" {{ if eq .Name $.Sn }}selected{{ end }}>{{ .Name }}</option>
+              {{ end }}
+            </select>
+          </div>
+          <button type="submit" class="btn btn-primary w-25">Move device</button>
+          <input type="hidden" name="task" value="move" />
+        </form>
       </div>
-      <button type="submit" class="btn btn-primary w-25">Find device</button>
-      <input type="hidden" name="task" value="find">
-    </form>
-  
-    <form class="d-flex align-items-center justify-content-between mb-1" enctype="multipart/form-data"action="/admin/utils" method="post">
-      <div class="d-flex w-50">
-        <select name="ma" class="w-50">
-          <option value="">- Select device -</option>
-          {{range .Devices}}
-            <option value="{{ .MAC }}"{{if eq .MAC $.Ma}} selected{{end}}>{{ .Name }}</option>
-          {{end}}
-        </select>
-    	  <p class="flex-grow-1 text-center">&rarr;</p>
-        <select name="sk" class="w-50">
-          <option value="">- Select site -</option>
-          {{range .Sites}}
-            <option value="{{ .Skey }}"{{if eq .Name $.Sn}} selected{{end}}>{{ .Name }}</option>
-          {{end}}
-        </select>
-      </div>
-      <button type="submit" class="btn btn-primary w-25">Move device</button>
-      <input type="hidden" name="task" value="move">
-    </form>
-  </div>
-  <br>
-  
-  <div class="border rounded p-4 container-md bg-white">
-    <span class="bold">Device Information</span>
-    <hr>  
-    <div class="d-flex justify-content-between mb-1">
-  	  <div class="w-50 d-flex">
-  	    <input type="input" id="ma2" value="{{ .Ma }}" placeholder="00:00:00:00:00:00">
-    	  <p class="flex-grow-1 text-center">&rarr;</p>
-        <input id="me" readonly>
-  	  </div>
-      <button onClick="updateMacEnc('ma2','me');" class="btn btn-primary w-25">Encode MAC</button>
-    </div>
-    
-    <div class="d-flex justify-content-between mb-1">
-      <div class="w-50 d-flex">
-        <input type="input" id="ma3" value="{{ .Ma }}" placeholder="00:00:00:00:00:00">
-        <input type="input" id="pn" value="A0">
-    	  <p class="flex-grow-1 text-center">&rarr;</p>
-        <input id="id" readonly>
-      </div>
-      <button onClick="updateMID('ma3','pn','id');" class="btn btn-primary w-25">Convert to Data ID</button>
-    </div>
-  </div>
-  <br>
+      <br />
 
-  <div class="border rounded p-4 container-md bg-white">
-    <span class="bold">Build and Environment Info</span>
-    <hr>
-    {{range $key, $value := .Info}}
-      <div class="d-flex gap-2">
-        <div class="w-50 text-end">{{$key}}</div>
-        <div class="w-50">{{$value}}</div>
+      <div class="border rounded p-4 container-md bg-white">
+        <span class="bold">Device Information</span>
+        <hr />
+        <div class="d-flex justify-content-between mb-1">
+          <div class="w-50 d-flex">
+            <input type="input" id="ma2" value="{{ .Ma }}" placeholder="00:00:00:00:00:00" />
+            <p class="flex-grow-1 text-center">&rarr;</p>
+            <input id="me" readonly />
+          </div>
+          <button onClick="updateMacEnc('ma2','me');" class="btn btn-primary w-25">Encode MAC</button>
+        </div>
+
+        <div class="d-flex justify-content-between mb-1">
+          <div class="w-50 d-flex">
+            <input type="input" id="ma3" value="{{ .Ma }}" placeholder="00:00:00:00:00:00" />
+            <input type="input" id="pn" value="A0" />
+            <p class="flex-grow-1 text-center">&rarr;</p>
+            <input id="id" readonly />
+          </div>
+          <button onClick="updateMID('ma3','pn','id');" class="btn btn-primary w-25">Convert to Data ID</button>
+        </div>
       </div>
-    {{end}}
-  </div>
-  </section>
-  {{.Footer}}
-</body>
+      <br />
+
+      <div class="border rounded p-4 container-md bg-white">
+        <span class="bold">Build and Environment Info</span>
+        <hr />
+        {{ range $key, $value := .Info }}
+        <div class="d-flex gap-2">
+          <div class="w-50 text-end">{{ $key }}</div>
+          <div class="w-50">{{ $value }}</div>
+        </div>
+        {{ end }}
+      </div>
+    </section>
+    {{ .Footer }}
+  </body>
 </html>


### PR DESCRIPTION
For a long time our html format hasn't been consistent or checked. 
Running prettier with npm run format should help us keep our html formatting consistent. 
This change is the initial output from prettier.

I tested that bench compiles and the templates parse and the pages all look right.