### PR TITLE
oceantv: add and use composite store

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -188,7 +188,7 @@ func checkBroadcastsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	skey := int64(claims["skey"].(float64))
-	site, err := model.GetSite(ctx, settingsStore, skey)
+	site, err := model.GetSite(ctx, store, skey)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Errorf("error getting site %d: %v", skey, err))
 		return
@@ -206,7 +206,7 @@ func checkBroadcastsHandler(w http.ResponseWriter, r *http.Request) {
 func checkBroadcastsForSites(ctx context.Context, sites []model.Site) error {
 	var cfgVars []model.Variable
 	for _, s := range sites {
-		vars, err := model.GetVariablesBySite(ctx, settingsStore, s.Skey, broadcastScope)
+		vars, err := model.GetVariablesBySite(ctx, store, s.Skey, broadcastScope)
 		if err != nil {
 			log.Printf("could not get broadcast entities for site, skey: %d, name: %s, %v", s.Skey, s.Name, err)
 			continue
@@ -230,7 +230,7 @@ func checkBroadcastsForSites(ctx context.Context, sites []model.Site) error {
 	}
 
 	for i := range cfgs {
-		err := performChecks(ctx, &cfgs[i], settingsStore)
+		err := performChecks(ctx, &cfgs[i], store)
 		if err != nil {
 			return fmt.Errorf("could not perform checks for broadcast: %s, ID: %s: %w", cfgs[i].Name, cfgs[i].ID, err)
 		}
@@ -292,7 +292,7 @@ func (e ErrInvalidEndTime) Error() string {
 func saveLinkFunc() func(string, string) error {
 	return func(key, link string) error {
 		key = removeDate(key)
-		return model.PutVariable(context.Background(), settingsStore, -1, liveScope+"."+key, link)
+		return model.PutVariable(context.Background(), store, -1, liveScope+"."+key, link)
 	}
 }
 
@@ -306,7 +306,7 @@ func extStart(ctx context.Context, cfg *BroadcastConfig, log func(string, ...int
 	}
 
 	onActions := cfg.OnActions + "," + cfg.RTMPVar + "=" + rtmpDestinationAddress + cfg.RTMPKey
-	err := setActionVars(ctx, cfg.SKey, onActions, settingsStore, log)
+	err := setActionVars(ctx, cfg.SKey, onActions, store, log)
 	if err != nil {
 		return fmt.Errorf("could not set device variables required to start stream: %w", err)
 	}
@@ -321,7 +321,7 @@ func extShutdown(ctx context.Context, cfg *BroadcastConfig, log func(string, ...
 		return errNoShutdownActions
 	}
 
-	err := setActionVars(ctx, cfg.SKey, cfg.ShutdownActions, settingsStore, log)
+	err := setActionVars(ctx, cfg.SKey, cfg.ShutdownActions, store, log)
 	if err != nil {
 		return fmt.Errorf("could not set device variables to end stream: %w", err)
 	}
@@ -336,7 +336,7 @@ func extStop(ctx context.Context, cfg *BroadcastConfig, log func(string, ...inte
 		return nil
 	}
 
-	err := setActionVars(ctx, cfg.SKey, cfg.OffActions, settingsStore, log)
+	err := setActionVars(ctx, cfg.SKey, cfg.OffActions, store, log)
 	if err != nil {
 		return fmt.Errorf("could not set device variables to end stream: %w", err)
 	}
@@ -440,7 +440,7 @@ func liveHandler(w http.ResponseWriter, r *http.Request) {
 	setup(ctx)
 
 	key := strings.ReplaceAll(r.URL.Path, r.URL.Host+"/live/", "")
-	v, err := model.GetVariable(ctx, settingsStore, -1, liveScope+"."+key)
+	v, err := model.GetVariable(ctx, store, -1, liveScope+"."+key)
 	if err != nil {
 		fmt.Fprintf(w, "livestream %s does not exist", key)
 		return

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -261,7 +261,7 @@ func (m *OceanBroadcastManager) HandleChatMessage(ctx Ctx, cfg *Cfg) error {
 		// Get the latest signal for the sensor.
 		var qty string
 
-		scalar, err := model.GetLatestScalar(ctx, mediaStore, model.ToSID(model.MacDecode(sensor.DeviceMac), sensor.Sensor.Pin))
+		scalar, err := model.GetLatestScalar(ctx, m.store, model.ToSID(model.MacDecode(sensor.DeviceMac), sensor.Sensor.Pin))
 		if err == datastore.ErrNoSuchEntity {
 			continue
 		} else if err != nil {

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,22 +46,21 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.5.0"
+	version            = "v0.6.0"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.
 )
 
 var (
-	setupMutex    sync.Mutex
-	settingsStore datastore.Store
-	mediaStore    datastore.Store
-	debug         bool
-	standalone    bool
-	notifier      notify.Notifier
-	ofsvc         openfish.OpenfishService
-	cronSecret    []byte
-	storePath     string
+	setupMutex sync.Mutex
+	store      *CompositeStore
+	debug      bool
+	standalone bool
+	notifier   notify.Notifier
+	ofsvc      openfish.OpenfishService
+	cronSecret []byte
+	storePath  string
 )
 
 func main() {
@@ -150,7 +149,7 @@ func errNoGlobalNotifierHandler(secrets map[string]string) utils.RecoveryHandler
 			notifier, err = notify.NewMailjetNotifier(
 				notify.WithSecrets(secrets),
 				notify.WithRecipientLookup(tvRecipients),
-				notify.WithStore(notify.NewStore(settingsStore)),
+				notify.WithStore(notify.NewStore(store)),
 			)
 			if err != nil {
 				log.Printf("could not remediate missing global notifier: %v", err)
@@ -180,11 +179,14 @@ func setup(ctx context.Context) {
 	setupMutex.Lock()
 	defer setupMutex.Unlock()
 
-	if settingsStore != nil {
+	if store != nil {
 		return
 	}
 
-	var err error
+	var (
+		err                       error
+		settingsStore, mediaStore datastore.Store
+	)
 	if standalone {
 		log.Printf("Running in standalone mode")
 		settingsStore, err = datastore.NewStore(ctx, "file", "vidgrind", storePath)
@@ -203,6 +205,8 @@ func setup(ctx context.Context) {
 	}
 	model.RegisterEntities()
 
+	store = ausOceanCompositeStore(settingsStore, mediaStore)
+
 	cronSecret, err = gauth.GetHexSecret(ctx, projectID, "cronSecret")
 	if err != nil || cronSecret == nil {
 		log.Printf("could not get cronSecret: %v", err)
@@ -216,7 +220,7 @@ func setup(ctx context.Context) {
 	notifier, err = notify.NewMailjetNotifier(
 		notify.WithSecrets(secrets),
 		notify.WithRecipientLookup(tvRecipients),
-		notify.WithStore(notify.NewStore(settingsStore)),
+		notify.WithStore(notify.NewStore(store)),
 	)
 	if err != nil {
 		log.Fatalf("could not set up email notifier: %v", err)
@@ -232,7 +236,7 @@ func setup(ctx context.Context) {
 // for the given site,
 func tvRecipients(skey int64, kind notify.Kind) ([]string, time.Duration, error) {
 	ctx := context.Background()
-	site, err := model.GetSite(ctx, settingsStore, skey)
+	site, err := model.GetSite(ctx, store, skey)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error getting site: %w", err)
 	}
@@ -301,7 +305,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	// Use the broadcast manager to save the broadcast.
 	// We can provide a nil BroadcastService given that Save
 	// won't need this.
-	err = newOceanBroadcastManager(nil, &cfg, settingsStore, log).Save(ctx, nil)
+	err = newOceanBroadcastManager(nil, &cfg, store, log).Save(ctx, nil)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return

--- a/cmd/oceantv/store.go
+++ b/cmd/oceantv/store.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// ausOceanCompositeStore returns a composite store that delegates to the
+// appropriate store based on the kind of the entity. This tries to fix the
+// awkwardness of selecting the right store based on the kind of the entity
+// you're dealing with.
+func ausOceanCompositeStore(settingsStore, mediaStore datastore.Store) *CompositeStore {
+	getKindFromQuery := func(query datastore.Query) string {
+		getKindField := func(v reflect.Value) string {
+			const kindField = "kind"
+			field := v.Elem().FieldByName(kindField)
+			if !field.IsValid() {
+				panic("kind field not found")
+			}
+			return *(*string)(unsafe.Pointer(field.UnsafeAddr()))
+		}
+
+		switch q := query.(type) {
+		case *datastore.CloudQuery:
+			// CloudQuery wraps a google.Query, so we have to get this
+			// first.
+			const googleQueryField = "query"
+			queryField := reflect.ValueOf(q).Elem().FieldByName(googleQueryField)
+			if !queryField.IsValid() || queryField.IsNil() {
+				panic("query field not found or nil")
+			}
+			return getKindField(queryField)
+		case *datastore.FileQuery:
+			return getKindField(reflect.ValueOf(q))
+		default:
+			panic(fmt.Sprintf("unsupported query type: %T", query))
+		}
+	}
+
+	return NewCompositeStore(
+		map[string]datastore.Store{
+			"Scalar":     mediaStore,
+			"Text":       mediaStore,
+			"MtsMedia":   mediaStore,
+			"Device":     settingsStore,
+			"Site":       settingsStore,
+			"Signal":     settingsStore,
+			"Notice":     settingsStore,
+			"Trigger":    settingsStore,
+			"Cron":       settingsStore,
+			"Request":    settingsStore,
+			"Variable":   settingsStore,
+			"BinaryData": settingsStore,
+			"User":       settingsStore,
+		},
+		getKindFromQuery,
+	)
+}
+
+// CompositeStore is a datastore "facade" that delegates to the appropriate
+// store based on the kind of the entity. This is useful when you have multiple
+// stores that you want to treat as a single store.
+// CompositeStore implements the datastore.Store interface and can therefore
+// substitute for any particular store instance.
+type CompositeStore struct {
+	stores        map[string]datastore.Store
+	kindFromQuery KindFromQuery
+}
+
+// KindFromQuery is a function that returns the kind of the entity from the
+// given query. Given that the datastore.Query interface does not expose the
+// kind via a method this function mast assert a particular query type and
+// extract the kind from it in some manner. This will probably look like an
+// assertion switch if there are multiple query types to be handled.
+type KindFromQuery func(datastore.Query) string
+
+// NewCompositeStore returns a new CompositeStore with the given stores.
+// The stores map should be keyed by the kind of the entity.
+func NewCompositeStore(stores map[string]datastore.Store, kindFromQuery KindFromQuery) *CompositeStore {
+	return &CompositeStore{stores, kindFromQuery}
+}
+
+// IDKey implements the Store.IDKey by calling IDKey on the appropriate
+// store based on the kind.
+func (s *CompositeStore) IDKey(kind string, id int64) *Key {
+	return s.stores[kind].IDKey(kind, id)
+}
+
+// NameKey implements the Store.NameKey by calling NameKey on the appropriate
+// store based on the kind.
+func (s *CompositeStore) NameKey(kind, name string) *Key {
+	return s.stores[kind].NameKey(kind, name)
+}
+
+// IncompleteKey implements the Store.IncompleteKey by calling IncompleteKey
+// on the appropriate store based on the kind.
+func (s *CompositeStore) IncompleteKey(kind string) *Key {
+	return s.stores[kind].IncompleteKey(kind)
+}
+
+// NewQuery implements the Store.NewQuery by calling NewQuery on the appropriate
+// store based on the kind.
+func (s *CompositeStore) NewQuery(kind string, keysOnly bool, keyParts ...string) datastore.Query {
+	return s.stores[kind].NewQuery(kind, keysOnly, keyParts...)
+}
+
+// Get implements the Store.Get by calling Get on the appropriate store based
+// on the kind.
+func (s *CompositeStore) Get(ctx context.Context, key *Key, dst datastore.Entity) error {
+	return s.stores[key.Kind].Get(ctx, key, dst)
+}
+
+// GetAll implements the Store.GetAll by calling GetAll on the appropriate store.
+// We find the appropriate store through trial and error given that the query
+// does not contain the kind. We look at possible stores and try to find the matching
+// one.
+func (s *CompositeStore) GetAll(ctx context.Context, query datastore.Query, dst interface{}) ([]*Key, error) {
+	return s.stores[s.kindFromQuery(query)].GetAll(ctx, query, dst)
+}
+
+// Create implements the Store.Create by calling Create on the appropriate store
+// based on the kind.
+func (s *CompositeStore) Create(ctx context.Context, key *Key, src datastore.Entity) error {
+	return s.stores[key.Kind].Create(ctx, key, src)
+}
+
+// Put implements the Store.Put by calling Put on the appropriate store
+// based on the kind.
+func (s *CompositeStore) Put(ctx context.Context, key *Key, src datastore.Entity) (*Key, error) {
+	return s.stores[key.Kind].Put(ctx, key, src)
+}
+
+// Update implements the Store.Update by calling Update on the appropriate store
+// based on the kind.
+func (s *CompositeStore) Update(ctx context.Context, key *Key, fn func(datastore.Entity), dst datastore.Entity) error {
+	return s.stores[key.Kind].Update(ctx, key, fn, dst)
+}
+
+// DeleteMulti implements the Store.DeleteMulti by calling DeleteMulti on the
+// appropriate store based on the kind.
+func (s *CompositeStore) DeleteMulti(ctx context.Context, keys []*Key) error {
+	return s.stores[keys[0].Kind].DeleteMulti(ctx, keys)
+}
+
+// Delete implements the Store.Delete by calling Delete on the appropriate store
+// based on the kind.
+func (s *CompositeStore) Delete(ctx context.Context, key *Key) error {
+	return s.stores[key.Kind].Delete(ctx, key)
+}

--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -112,7 +112,7 @@ func setVar(ctx context.Context, store datastore.Store, name, value string, sKey
 // the datastore. An error is returned if there's no match or for other issues.
 func broadcastByName(sKey int64, name string) (*BroadcastConfig, error) {
 	// Load config information for any prior broadcasts that have been saved.
-	vars, err := model.GetVariablesBySite(context.Background(), settingsStore, sKey, broadcastScope)
+	vars, err := model.GetVariablesBySite(context.Background(), store, sKey, broadcastScope)
 	if err != nil {
 		return nil, fmt.Errorf("could not get broadcast variables by site: %w", err)
 	}


### PR DESCRIPTION
Closes issue #360 

It's awkward to need to provide a different datastore based on the entity kind, and is also error prone. We're trying to improve this situation by creating a "facade" datastore, CompositeStore, which selects the appropriate datastore instance based on the kind.