### PR TITLE
Bench: Add unique sandbox endpoint (#309)

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -53,7 +53,7 @@ const (
 	projectID     = "ausoceantv"
 	oauthClientID = "1005382600755-7st09cc91eqcqveviinitqo091dtcmf0.apps.googleusercontent.com"
 	oauthMaxAge   = 60 * 60 * 24 * 7 // 7 days.
-	version       = "v0.4.1"
+	version       = "v0.4.2"
 )
 
 // service defines the properties of our web service.

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.28.0"
+	version     = "v0.29.0"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"
@@ -235,6 +235,7 @@ func main() {
 	http.HandleFunc("/admin/user/delete", adminHandler)
 	http.HandleFunc("/admin/site", adminHandler)
 	http.HandleFunc("/admin/broadcast", adminHandler)
+	http.HandleFunc("/admin/sandbox", sandboxHandler)
 	http.HandleFunc("/admin/sandbox/configure", configDevicesHandler)
 	http.HandleFunc("/admin/utils", adminHandler)
 	http.HandleFunc("/data/", dataHandler)
@@ -625,6 +626,12 @@ func pages(selected string) []page {
 		{
 			Name:  "broadcast",
 			URL:   "/admin/broadcast",
+			Level: 1,
+			Perm:  model.AdminPermission,
+		},
+		{
+			Name:  "configuration",
+			URL:   "/admin/sandbox",
 			Level: 1,
 			Perm:  model.AdminPermission,
 		},

--- a/cmd/oceanbench/sandbox.go
+++ b/cmd/oceanbench/sandbox.go
@@ -35,6 +35,60 @@ import (
 	"github.com/ausocean/cloud/system"
 )
 
+type sandboxData struct {
+	Devices []model.Device
+	Mac     string
+	Device  model.Device
+	commonData
+}
+
+func sandboxHandler(w http.ResponseWriter, r *http.Request) {
+	profile, err := getProfile(w, r)
+	if err != nil {
+		if err != gauth.TokenNotFound {
+			log.Printf("authentication error: %v", err)
+		}
+		http.Redirect(w, r, "/", http.StatusUnauthorized)
+		return
+	}
+	skey, _ := profileData(profile)
+
+	data := sandboxData{
+		commonData: commonData{
+			Pages:   pages("home"),
+			Profile: profile,
+		},
+	}
+
+	if skey != model.SandboxSkey {
+		writeTemplate(w, r, "sandbox.html", &data, "Must be on Sandbox Site.")
+		return
+	}
+
+	ctx := context.Background()
+	data.Devices, err = model.GetDevicesBySite(ctx, settingsStore, skey)
+	if err != nil {
+		writeTemplate(w, r, "sandbox.html", &data, "could not get devices by site")
+		return
+	}
+
+	ma := r.FormValue("ma")
+	if !model.IsMacAddress(ma) && ma != "" {
+		writeTemplate(w, r, "sandbox.html", &data, "invalid mac address")
+		return
+	}
+
+	for _, d := range data.Devices {
+		if d.MAC() == ma {
+			data.Device = d
+			break
+		}
+	}
+
+	writeTemplate(w, r, "sandbox.html", &data, "")
+	return
+}
+
 // configDevicesHandler handles configuration of new devices.
 //
 // Form Fields:
@@ -70,6 +124,12 @@ func configDevicesHandler(w http.ResponseWriter, r *http.Request) {
 	ll := r.FormValue("ll")
 	sk := r.FormValue("sk")
 	r.ParseForm()
+
+	dev, err := model.GetDevice(ctx, settingsStore, model.MacEncode(ma))
+	if err != nil {
+		writeError(w, fmt.Errorf("unable to get device by mac: %w", err))
+		return
+	}
 
 	// Parse location.
 	var lat, long float64
@@ -120,7 +180,7 @@ func configDevicesHandler(w http.ResponseWriter, r *http.Request) {
 	switch dt {
 	case model.DevTypeController:
 		// Create a controller with all default values defined in rig_system.go.
-		sys, err = system.NewRigSystem(skey, ma, dn,
+		sys, err = system.NewRigSystem(skey, dev.Dkey, ma, dn,
 			system.WithRigSystemDefaults(),
 			system.WithWifi(ssid, pass),
 			system.WithLocation(lat, long),
@@ -177,6 +237,11 @@ func writeConfigure(w http.ResponseWriter, r *http.Request, profile *gauth.Profi
 
 	// Parse form values.
 	data.MAC = r.FormValue("ma")
+	if data.MAC == "" {
+		// TODO: Allow creation of new device from Sandbox page.
+		http.Redirect(w, r, "/admin/sandbox", http.StatusFound)
+		return
+	}
 	data.DevTypes = devTypes
 	r.ParseForm()
 

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -31,7 +31,6 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -105,12 +104,6 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 		return
 	}
 	skey, _ := profileData(profile)
-	sandbox := false
-	file := "set/device.html"
-	if skey == model.SandboxSkey && r.FormValue("new-configuration") == "true" {
-		sandbox = true
-		file = "sandbox.html"
-	}
 
 	data := devicesData{
 		commonData: commonData{
@@ -177,11 +170,8 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 		return
 	}
 
-	if !model.IsMacAddress(data.Mac) && !sandbox {
-		writeTemplate(w, r, file, &data, "")
-		return
-	} else if sandbox {
-		writeTemplate(w, r, file, &data, "")
+	if !model.IsMacAddress(data.Mac) {
+		writeTemplate(w, r, "set/device.html", &data, "")
 		return
 	}
 
@@ -239,28 +229,7 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 		return
 	}
 
-	writeTemplate(w, r, file, &data, msg)
-}
-
-func writeSandbox(w http.ResponseWriter, r *http.Request, data *devicesData) {
-	var _devices []model.Device
-	for _, d := range data.Devices {
-		re := regexp.MustCompile("(?i)New device detected at [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,3})?")
-		if !re.MatchString(d.Name) {
-			continue
-		}
-		d.Name = strings.Join(strings.Split(d.Name, " ")[4:6], " ")
-		if strings.HasPrefix(d.MAC(), "A0:A0:A0") {
-			d.Name = "Pi: " + d.Name
-		}
-		if d.Mac == model.MacEncode(data.Mac) {
-			data.Device.Name = d.Name
-		}
-		_devices = append(_devices, d)
-	}
-	data.Devices = _devices
-	writeTemplate(w, r, "sandbox.html", data, "")
-	return
+	writeTemplate(w, r, "set/device.html", &data, msg)
 }
 
 // reportDevicesError handles error encountered during writing of the devices page.

--- a/cmd/oceanbench/t/configure.html
+++ b/cmd/oceanbench/t/configure.html
@@ -30,7 +30,7 @@
       <div class="red" style="display: none" id="msg">{{if .Msg}}{{.Msg}}{{end}}</div>
       <div class="border rounded p-4 container-md bg-white">
         <a href="/set/devices?ma={{.MAC}}">Manual Configuration</a>
-        <form action="/set/devices/configure" enctype="multipart/form-data" method="post" class="needs-validation" novalidate>
+        <form enctype="multipart/form-data" method="post" class="needs-validation" novalidate>
           <input name="ma" value="{{.MAC}}" hidden />
           <div class="row d-flex gx-1 pb-1">
             <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Name:</label>

--- a/cmd/oceanbench/t/sandbox.html
+++ b/cmd/oceanbench/t/sandbox.html
@@ -29,18 +29,18 @@
       <div class="red">{{.Msg}}</div>
       <br />
       {{end}}
-      <h1 class="container-md">Devices</h1>
+      <h1 class="container-md">Configure</h1>
       <div class="border rounded p-4 container-md bg-white">
-        <a href="/set/devices">Manual Configuration</a>
         {{ if eq (len .Devices) 0 }} No Devices waiting to be configured {{else}}
-        <form action="/set/devices/configure" enctype="multipart/form-data" method="get">
+        <form action="/admin/sandbox/configure" enctype="multipart/form-data" method="get">
           <fieldset>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label class="col-4 text-end">Device:</label>
               <div class="col-6 d-flex gap-1">
                 <select name="ma" onchange="location.assign('?ma=' + this.value)" class="form-select h-auto align-items-center">
+                  <option value="">--New Device--</option>
                   {{range .Devices}}
-                  <option value="{{ .MAC }}" {{if eq .MAC $.Mac}} selected{{end}}>{{ .Name }}</option>
+                  <option value="{{ .MAC }}" {{if eq .MAC $.Device.MAC}} selected{{end}}>{{ .Name }}</option>
                   {{end}}
                 </select>
                 <button class="btn btn-primary h-auto">Configure</button>
@@ -60,12 +60,6 @@
           <label class="col-4 text-end">MAC:</label>
           <div class="col-6">
             <input class="form-control" value="{{.MAC}}" readonly />
-          </div>
-        </div>
-        <div class="d-flex align-items-center gap-1 mb-1">
-          <label class="col-4 text-end">Last updated:</label>
-          <div class="col-6">
-            <input class="form-control" value="{{if .Name}}{{localdatetime .Updated.Unix $.Timezone}}{{end}}" disabled />
           </div>
         </div>
         <div class="d-flex align-items-center gap-1 mb-1">

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -227,7 +227,6 @@
           <fieldset>
             <div class="d-flex justify-content-between h-auto pt-5">
               <h2>Configuration</h2>
-              <a href="?new-configuration=true">Try Auto Configuration (Controllers Only)</a>
             </div>
             <hr />
             <div class="d-flex flex-column gap-1">

--- a/cmd/oceanbench/ts/site-menu.ts
+++ b/cmd/oceanbench/ts/site-menu.ts
@@ -1,6 +1,8 @@
 import { LitElement, html, css, PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 
+export const SandboxSkey: Number = 3;
+
 @customElement('site-menu')
 class SiteMenu extends LitElement {
 
@@ -125,6 +127,10 @@ class SiteMenu extends LitElement {
             r.onreadystatechange = () => {
                 if (r.readyState == XMLHttpRequest.DONE) {
                     console.log("response from set site request: ", r.responseText);
+                    if (Number(selectedKey) == SandboxSkey) {
+                        window.location.assign("/admin/sandbox")
+                        return
+                    }
                     window.location.reload();
                 }
             }

--- a/system/rig_system.go
+++ b/system/rig_system.go
@@ -145,9 +145,9 @@ func WithRigSystemDefaults() func(any) error {
 // NewRigSystem returns a new RigSystem with the given options. It is the callers
 // responsibility to put the components into the datastore.
 //
-// MAC and name refer to the MAC Address and name of the Controller which will be the heart of
-// the RigSystem.
-func NewRigSystem(skey int64, MAC, name string, options ...Option) (*RigSystem, error) {
+// dkey, MAC and name refer to the device key, MAC Address and name of the Controller which will
+// be the heart of the RigSystem.
+func NewRigSystem(skey, dkey int64, MAC, name string, options ...Option) (*RigSystem, error) {
 	if model.MacEncode(MAC) == 0 {
 		return nil, model.ErrInvalidMACAddress
 	}
@@ -155,6 +155,7 @@ func NewRigSystem(skey int64, MAC, name string, options ...Option) (*RigSystem, 
 	sys := &RigSystem{
 		Controller: model.Device{
 			Skey:          skey,
+			Dkey:          dkey,
 			Mac:           model.MacEncode(MAC),
 			Name:          name,
 			Type:          model.DevTypeController,

--- a/system/rig_system_test.go
+++ b/system/rig_system_test.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	testSiteKey = 1
+	testDevKey  = 1098765432
 	strTestMAC  = "00:11:22:33:44:55"
 )
 
@@ -18,6 +19,7 @@ func TestNewRigSystem(t *testing.T) {
 	tests := []struct {
 		name           string
 		skey           int64
+		dkey           int64
 		mac            string
 		ControllerName string
 		options        []system.Option
@@ -27,6 +29,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "Valid input without options",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController1",
 			options:        nil,
@@ -44,6 +47,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "Invalid MAC without options",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            "00:11:22:33",
 			ControllerName: "TestController2",
 			options:        nil,
@@ -53,6 +57,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With AlarmNetworkVar",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController3",
 			options:        []system.Option{system.WithVariables(model.NewAlarmNetworkVar(3))},
@@ -73,6 +78,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With BatteryVoltage Sensor",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController4",
 			options:        []system.Option{system.WithSensors(model.BatteryVoltageSensor(0.0289))},
@@ -92,6 +98,7 @@ func TestNewRigSystem(t *testing.T) {
 		}, {
 			name:           "With AirTemperature Sensor",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController5",
 			options:        []system.Option{system.WithSensors(model.AirTemperatureSensor())},
@@ -112,6 +119,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With Humidity Sensor",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController6",
 			options:        []system.Option{system.WithSensors(model.HumiditySensor())},
@@ -132,6 +140,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With WaterTemperature Sensor",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController7",
 			options:        []system.Option{system.WithSensors(model.WaterTemperatureSensor())},
@@ -152,6 +161,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With AlarmPeriodVar",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController8",
 			options:        []system.Option{system.WithVariables(model.NewAlarmPeriodVar(30 * time.Second))},
@@ -172,6 +182,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With AlarmRecoveryVoltageVar",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController9",
 			options:        []system.Option{system.WithVariables(model.NewAlarmRecoveryVoltageVar(12))},
@@ -192,6 +203,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With Power1Var",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController10",
 			options:        []system.Option{system.WithVariables(model.NewPower1Var(true))},
@@ -212,6 +224,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With Power2Var",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController11",
 			options:        []system.Option{system.WithVariables(model.NewPower2Var(false))},
@@ -232,6 +245,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With PulseWidthVar",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController12",
 			options:        []system.Option{system.WithVariables(model.NewPulseWidthVar(15 * time.Second))},
@@ -252,6 +266,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With AutoRestartVar",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController13",
 			options:        []system.Option{system.WithVariables(model.NewAutoRestartVar(5 * time.Minute))},
@@ -272,6 +287,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With Device1Actuator",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController14",
 			options:        []system.Option{system.WithActuators(model.NewDevice1Actuator())},
@@ -292,6 +308,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With Device2Actuator",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController15",
 			options:        []system.Option{system.WithActuators(model.NewDevice2Actuator())},
@@ -312,6 +329,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With Device3Actuator",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController16",
 			options:        []system.Option{system.WithActuators(model.NewDevice3Actuator())},
@@ -332,6 +350,7 @@ func TestNewRigSystem(t *testing.T) {
 		{
 			name:           "With All Sensors and Variables",
 			skey:           testSiteKey,
+			dkey:           testDevKey,
 			mac:            strTestMAC,
 			ControllerName: "TestController17",
 			options: []system.Option{
@@ -403,7 +422,7 @@ func TestNewRigSystem(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := system.NewRigSystem(tt.skey, tt.mac, tt.ControllerName, tt.options...)
+			got, err := system.NewRigSystem(tt.skey, tt.dkey, tt.mac, tt.ControllerName, tt.options...)
 			if err != tt.wantErr {
 				t.Errorf("unexpected error from NewRigSystem, wanted: %v, got: %v", tt.wantErr, err)
 			}


### PR DESCRIPTION
This change adds a new endpoint /sandbox for the sandbox site which users are automatically redirected to.

This also fixes a few small bugs with the config process, such as loosing the device key upon configuration.

closes #309 