### PR TITLE
bench: add live redirect options for mute, autoplay, related 

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -603,38 +603,30 @@ func liveHandler(w http.ResponseWriter, r *http.Request) {
 
 	redirectURL := v.Value
 
-	// Append query parameters to the URL.
 	u, err := url.Parse(redirectURL)
 	if err != nil {
 		http.Error(w, "Invalid livestream URL", http.StatusInternalServerError)
 		return
 	}
-
-	// Ensure query parameters for embedding and additional YouTube options.
 	query := u.Query()
 
-	// Always add rel=0
-	query.Set("rel", "0")
-
-	// Provide embed link if requested.
+	// Append embed, mute and autoplay if present in the request query.
 	if _, ok := r.URL.Query()["embed"]; ok {
 		u.Path = strings.Replace(u.Path, "watch?v=", "embed/", 1)
+		// Always add rel=0 for embedded videos.
+		query.Set("rel", "0")
 	}
-
-	// Append mute and autoplay if present in the request query.
 	if _, ok := r.URL.Query()["mute"]; ok {
 		query.Set("mute", "1")
 	}
-
 	if _, ok := r.URL.Query()["autoplay"]; ok {
 		query.Set("autoplay", "1")
 	}
 
 	u.RawQuery = query.Encode()
-
 	redirectURL = u.String()
 
-	log.Printf("Redirecting to livestream link: %s", redirectURL)
+	log.Printf("redirecting to livestream link: %s", redirectURL)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -35,6 +35,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -602,12 +603,38 @@ func liveHandler(w http.ResponseWriter, r *http.Request) {
 
 	redirectURL := v.Value
 
-	// Provide embed link if requested.
-	if _, ok := r.URL.Query()["embed"]; ok {
-		redirectURL = strings.ReplaceAll(redirectURL, "watch?v=", "embed/")
+	// Append query parameters to the URL.
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		http.Error(w, "Invalid livestream URL", http.StatusInternalServerError)
+		return
 	}
 
-	log.Printf("redirecting to livestream link, link: %s", redirectURL)
+	// Ensure query parameters for embedding and additional YouTube options.
+	query := u.Query()
+
+	// Always add rel=0
+	query.Set("rel", "0")
+
+	// Provide embed link if requested.
+	if _, ok := r.URL.Query()["embed"]; ok {
+		u.Path = strings.Replace(u.Path, "watch?v=", "embed/", 1)
+	}
+
+	// Append mute and autoplay if present in the request query.
+	if _, ok := r.URL.Query()["mute"]; ok {
+		query.Set("mute", "1")
+	}
+
+	if _, ok := r.URL.Query()["autoplay"]; ok {
+		query.Set("autoplay", "1")
+	}
+
+	u.RawQuery = query.Encode()
+
+	redirectURL = u.String()
+
+	log.Printf("Redirecting to livestream link: %s", redirectURL)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -637,16 +637,16 @@ func transformYouTubeURL(rawURL string, r *http.Request) (string, error) {
 		u.RawQuery = "" // Reset query parameters.
 		// Always set rel=0 for embedded videos.
 		newQuery.Set("rel", "0")
+
+		// Conditionally set mute and autoplay if requested.
+		if _, ok := r.URL.Query()["mute"]; ok {
+			newQuery.Set("mute", "1")
+		}
+		if _, ok := r.URL.Query()["autoplay"]; ok {
+			newQuery.Set("autoplay", "1")
+		}
 	} else {
 		newQuery.Set("v", videoID)
-	}
-
-	// Conditionally set mute and autoplay if requested.
-	if _, ok := r.URL.Query()["mute"]; ok {
-		newQuery.Set("mute", "1")
-	}
-	if _, ok := r.URL.Query()["autoplay"]; ok {
-		newQuery.Set("autoplay", "1")
 	}
 
 	u.RawQuery = newQuery.Encode()

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.26.2"
+	version     = "v0.26.3"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This was done to support a more customised experience on AusOceanTV with embedded live streams.