### PR TITLE
ausoceantv: increase readbuffersize for http headers

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -118,7 +118,7 @@ func main() {
 	flag.Parse()
 
 	// Create app.
-	app := fiber.New(fiber.Config{ErrorHandler: api.ErrorHandler})
+	app := fiber.New(fiber.Config{ErrorHandler: api.ErrorHandler, ReadBufferSize: 8192})
 
 	// Encrypt cookies.
 	// NOTE: This must be done before any middleware which uses cookies.


### PR DESCRIPTION
This was done because logging out and other requests would cause an error, header fields too large.