### PR TITLE
update gcloud ignored

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -26,6 +26,7 @@ cmd/oceantv/oceantv
 cmd/oceantv/*~
 cmd/oceantv/#*
 cmd/oceantv/store/*
+cmd/oceantv/youtube-api-credentials.json
 # oceancron
 cmd/oceancron/.git
 cmd/oceancron/.gitignore
@@ -53,3 +54,4 @@ cmd/vidforward/#*
 cmd/ausoceantv/.git
 cmd/ausoceantv/.gitignore
 cmd/ausoceantv/node_modules/
+cmd/ausoceantv/webapp/node_modules/

--- a/cmd/oceantv/.gitignore
+++ b/cmd/oceantv/.gitignore
@@ -1,1 +1,2 @@
 oceantv
+youtube-api-credentials.json


### PR DESCRIPTION
Added node modules in new ausoceantv/webapp folder to the gcloud ignore file as well as the youtube-api-credentials.json file in the oceantv folder which gets copied there from time to time.