### PR TITLE
Set privacy on broadcast completion

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -118,7 +118,8 @@ type BroadcastConfig struct {
 	CID                      string        // ID of associated chat.
 	StreamName               string        // The name of the stream we'll bind to the broadcast.
 	Description              string        // The broadcast description shown below viewing window.
-	Privacy                  string        // Privacy of the broadcast i.e. public, private or unlisted.
+	LivePrivacy              string        // Privacy of the broadcast while live i.e. public, private or unlisted.
+	PostLivePrivacy          string        // Privacy of the broadcast after it has ended i.e. public, private or unlisted.
 	Resolution               string        // Resolution of the stream e.g. 1080p.
 	StartTimestamp           string        // Start time of the broadcast in unix format.
 	Start                    time.Time     // Start time in native go format for easy operations.
@@ -207,7 +208,8 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			ID:                    r.FormValue("broadcast-id"),
 			StreamName:            r.FormValue("stream-name"),
 			Description:           r.FormValue("description"),
-			Privacy:               r.FormValue("privacy"),
+			LivePrivacy:           r.FormValue("live-privacy"),
+			PostLivePrivacy:       r.FormValue("post-live-privacy"),
 			Resolution:            r.FormValue("resolution"),
 			StartTimestamp:        r.FormValue("start-timestamp"),
 			EndTimestamp:          r.FormValue("end-timestamp"),

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.27.1"
+	version     = "v0.28.0"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -86,11 +86,22 @@
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
-              <div class="w-25"></div>
+              <label for="account" class="w-25 text-end">Live Privacy:</label>
               <div class="d-flex align-items-center gap-3 flex-row">
                 {{range .Settings.Privacy}}
                 <div>
-                  <input type="radio" name="privacy" value="{{.}}" id="{{.}}-radio" {{if eq . $.CurrentBroadcast.Privacy}}checked{{end}} />
+                  <input type="radio" name="live-privacy" value="{{.}}" id="{{.}}-radio" {{if eq . $.CurrentBroadcast.LivePrivacy}}checked{{end}} />
+                  <label class="text-capitalize" for="{{.}}-radio">{{.}}</label>
+                </div>
+                {{end}}
+              </div>
+            </div>
+            <div class="d-flex align-items-center gap-1 mb-1">
+              <label for="account" class="w-25 text-end">Post Live Privacy:</label>
+              <div class="d-flex align-items-center gap-3 flex-row">
+                {{range .Settings.Privacy}}
+                <div>
+                  <input type="radio" name="post-live-privacy" value="{{.}}" id="{{.}}-radio" {{if eq . $.CurrentBroadcast.PostLivePrivacy}}checked{{end}} />
                   <label class="text-capitalize" for="{{.}}-radio">{{.}}</label>
                 </div>
                 {{end}}

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -95,7 +95,8 @@ type BroadcastConfig struct {
 	CID                      string        // ID of associated chat.
 	StreamName               string        // The name of the stream we'll bind to the broadcast.
 	Description              string        // The broadcast description shown below viewing window.
-	Privacy                  string        // Privacy of the broadcast i.e. public, private or unlisted.
+	LivePrivacy              string        // Privacy of the broadcast whilst live i.e. public, private or unlisted.
+	PostLivePrivacy          string        // Privacy of the broadcast after it has ended i.e. public, private or unlisted.
 	Resolution               string        // Resolution of the stream e.g. 1080p.
 	StartTimestamp           string        // Start time of the broadcast in unix format.
 	Start                    time.Time     // Start time in native go format for easy operations.
@@ -426,6 +427,13 @@ func stopBroadcast(ctx context.Context, cfg *BroadcastConfig, store datastore.St
 	err = saveBroadcast(ctx, cfg, store, log)
 	if err != nil {
 		return fmt.Errorf("save broadcast error: %w", err)
+	}
+
+	// Change privacy to post live privacy.
+	// This will also set the privacy of the video after the broadcast has ended.
+	err = svc.SetBroadcastPrivacy(ctx, cfg.ID, cfg.PostLivePrivacy)
+	if err != nil {
+		return fmt.Errorf("could not update broadcast privacy: %w", err)
 	}
 
 	return nil

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -125,7 +125,7 @@ func (m *OceanBroadcastManager) CreateBroadcast(
 		cfg.Name+" "+dateStr,
 		cfg.Description,
 		cfg.StreamName,
-		cfg.Privacy,
+		cfg.LivePrivacy,
 		cfg.Resolution,
 		timeCreated,
 		cfg.End,
@@ -356,10 +356,11 @@ func (m *OceanBroadcastManager) SetupSecondary(ctx Ctx, cfg *Cfg, store Store) e
 		// configuration, except for a few of the fields.
 		_cfg.Name = secondaryName
 		_cfg.StreamName = secondaryName
-		_cfg.Privacy = "unlisted" // We don't want the secondary broadcast to be easily discovered by youtube watchers.
-		_cfg.OnActions = ""       // We don't need it to have any control of the camera hardware.
-		_cfg.OffActions = ""      // Ditto.
-		_cfg.SendMsg = true       // It would be handy to have sensors stored in the store broadcasts too.
+		_cfg.LivePrivacy = "unlisted"     // We don't want the secondary broadcast to be easily discovered by youtube watchers.
+		_cfg.PostLivePrivacy = "unlisted" // This will be public eventually, but not while the software is young.
+		_cfg.OnActions = ""               // We don't need it to have any control of the camera hardware.
+		_cfg.OffActions = ""              // Ditto.
+		_cfg.SendMsg = true               // It would be handy to have sensors stored in the store broadcasts too.
 		_cfg.Start = cfg.Start
 		_cfg.End = cfg.End
 		_cfg.Resolution = cfg.Resolution

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -280,10 +280,11 @@ func (d *dummyService) BroadcastStatus(ctx Ctx, id string) (string, error) { ret
 func (d *dummyService) BroadcastScheduledStartTime(ctx Ctx, id string) (time.Time, error) {
 	return d.start, nil
 }
-func (d *dummyService) BroadcastHealth(ctx Ctx, id string) (string, error) { return "", nil }
-func (d *dummyService) RTMPKey(ctx Ctx, streamName string) (string, error) { return "", nil }
-func (d *dummyService) CompleteBroadcast(ctx Ctx, id string) error         { return nil }
-func (d *dummyService) PostChatMessage(id, msg string) error               { return nil }
+func (d *dummyService) BroadcastHealth(ctx Ctx, id string) (string, error)    { return "", nil }
+func (d *dummyService) RTMPKey(ctx Ctx, streamName string) (string, error)    { return "", nil }
+func (d *dummyService) CompleteBroadcast(ctx Ctx, id string) error            { return nil }
+func (d *dummyService) PostChatMessage(id, msg string) error                  { return nil }
+func (d *dummyService) SetBroadcastPrivacy(ctx Ctx, id, privacy string) error { return nil }
 
 type dummyForwardingService struct{}
 

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.6.0"
+	version            = "v0.7.0"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This will allow us to broadcast live with unlisted privacy, but then on completion, set to public. This means we can restrict live viewing to the AusOceanTV platform, but still have past broadcasts on the YouTube channel.