### PR TITLE
Bench: Add search shortcut to monitor page.

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.27.0"
+	version     = "v0.27.1"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/monitor.go
+++ b/cmd/oceanbench/monitor.go
@@ -61,6 +61,7 @@ type sensorData struct {
 	Units  string
 	Scalar string
 	Date   string
+	Pin    string
 }
 
 // monitorDevice holds the relevant information for each device.
@@ -292,6 +293,7 @@ func monitorLoadRoutine(
 		sensorData := sensorData{
 			Name:   sensor.Name,
 			Units:  sensor.Units,
+			Pin:    sensor.Pin,
 			Scalar: fmt.Sprintf("%.2f", value),
 			Date:   time.Unix(scalar.Timestamp, 0).In(fixedTimezone(tz)).Format("Jan 2 15:04:05"),
 		}

--- a/cmd/oceanbench/t/monitor.html
+++ b/cmd/oceanbench/t/monitor.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous" />
     <link href="/s/main.css" rel="stylesheet" type="text/css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <title>CloudBlue | Monitor</title>
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
@@ -51,10 +52,13 @@
             <br />
             {{ else }} Last Reported: {{ localdatetime .LastReportedTimestamp $.Timezone }} {{ end }} {{ if eq .Count 0 }}{{ else }}Throughput: {{ .Throughput }}% {{ .Count }}/{{ .MaxCount }}{{ end }}
           </span>
-          {{ range .Sensors }}
+          {{ $mac := .Device.MAC }} {{ range .Sensors }}
           <hr />
           <span>
-            <span class="monitor-title">{{ .Name }}</span>
+            <div class="d-flex align-items-start">
+              <a href="/search?ma={{ $mac }}&pn={{ .Pin }}"><i class="material-icons">search</i></a>
+              <span class="monitor-title">{{ .Name }}</span>
+            </div>
             <br />
             <span class="signal-date">{{ .Date }}</span>
             <span class="signal-value">{{ .Scalar }} {{ .Units }}</span>


### PR DESCRIPTION
This change allows a user to easily click through to search a given sensor, saving a number of form submissions to achieve the same result otherwise.

![image](https://github.com/user-attachments/assets/4fb7a407-b628-4fed-a0ff-a1bc03498d3e)
