### PR TITLE
ausoceantv: create a subscriber on login not checkout

### DIFF
--- a/cmd/ausoceantv/dsclient/dsclient.go
+++ b/cmd/ausoceantv/dsclient/dsclient.go
@@ -47,7 +47,7 @@ func Init(standalone bool, filestorePath string) error {
 		store, err = datastore.NewStore(ctx, "file", "vidgrind", filestorePath)
 	} else {
 		log.Info("running in App Engine mode")
-		store, err = datastore.NewStore(ctx, "cloud", "netreceiver", "")
+		store, err = datastore.NewStore(ctx, "cloud", "vidgrind", "")
 	}
 	return err
 }

--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -58,14 +58,14 @@ const (
 
 // service defines the properties of our web service.
 type service struct {
-	setupMutex    sync.Mutex
-	settingsStore datastore.Store
-	debug         bool
-	standalone    bool
-	development   bool
-	lite          bool
-	storePath     string
-	auth          *gauth.UserAuth
+	setupMutex  sync.Mutex
+	store       datastore.Store
+	debug       bool
+	standalone  bool
+	development bool
+	lite        bool
+	storePath   string
+	auth        *gauth.UserAuth
 }
 
 // svc is an instance of our service.
@@ -195,7 +195,7 @@ func (svc *service) setup(ctx context.Context) {
 	svc.setupMutex.Lock()
 	defer svc.setupMutex.Unlock()
 
-	if svc.settingsStore != nil {
+	if svc.store != nil {
 		return
 	}
 
@@ -203,7 +203,7 @@ func (svc *service) setup(ctx context.Context) {
 	if err != nil {
 		log.Fatalf("could not set up datastore: %v", err)
 	}
-	svc.settingsStore = dsclient.Get()
+	svc.store = dsclient.Get()
 	model.RegisterEntities()
 	log.Info("set up datastore")
 
@@ -226,12 +226,12 @@ func (svc *service) getSubscriptionHandler(c *fiber.Ctx) error {
 		return fmt.Errorf("unable to get profile: %w", err)
 	}
 
-	subscriber, err := model.GetSubscriberByEmail(ctx, svc.settingsStore, p.Email)
+	subscriber, err := model.GetSubscriberByEmail(ctx, svc.store, p.Email)
 	if err != nil {
 		return fmt.Errorf("error getting subscriber by email for: %s: %w", p.Email, err)
 	}
 
-	subscription, err := model.GetSubscription(ctx, svc.settingsStore, subscriber.ID, model.NoFeedID)
+	subscription, err := model.GetSubscription(ctx, svc.store, subscriber.ID, model.NoFeedID)
 	if err != nil {
 		return fmt.Errorf("error getting subscription for id: %d: %w", subscriber.ID, err)
 	}

--- a/cmd/oceanbench/auth.go
+++ b/cmd/oceanbench/auth.go
@@ -71,7 +71,7 @@ func oauthCallbackHandler(w http.ResponseWriter, r *http.Request) {
 	if standalone {
 		return
 	}
-	err := auth.CallbackHandler(backend.NewNetHandler(w, r, auth.NetStore))
+	_, err := auth.CallbackHandler(backend.NewNetHandler(w, r, auth.NetStore))
 	if err != nil {
 		writeError(w, err)
 		return

--- a/model/subscriber.go
+++ b/model/subscriber.go
@@ -87,6 +87,8 @@ func CreateSubscriber(ctx context.Context, store datastore.Store, s *Subscriber)
 		return store.Create(ctx, key, s)
 	}
 
+	s.Created = time.Now()
+
 	// Otherwise generate and use a unique ID.
 	for {
 		s.ID = utils.GenerateInt64ID()


### PR DESCRIPTION
This was reverted so that we have subscriber info from the point of login. This was we can do things based on the _Created_ field etc.

It was originally this way, but it was changed due to issues getting the token right away so it was moved, but David and I agree that it should be here so I have made it so that we can access the profile and token right away.

I also realised that we were using the netreceiver datastore, which will be deprecated, so I have changed it to vidgrind.

The subscriber is still checked at checkout but not created.