### PR TITLE
gauth: Handle errors in callback url (#462)

### DIFF
--- a/cmd/ausoceantv/auth.go
+++ b/cmd/ausoceantv/auth.go
@@ -32,6 +32,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/log"
 
 	"github.com/ausocean/cloud/backend"
 	"github.com/ausocean/cloud/gauth"
@@ -55,7 +56,10 @@ func (svc *service) logoutHandler(c *fiber.Ctx) error {
 // callbackHandler handles callbacks from google's oauth2 flow.
 func (svc *service) callbackHandler(c *fiber.Ctx) error {
 	p, err := svc.auth.CallbackHandler(backend.NewFiberHandler(c))
-	if err != nil {
+	if errors.Is(err, &gauth.ErrOauth2RedirectError{}) {
+		log.Warn(err)
+		return c.Redirect("/", fiber.StatusFound)
+	} else if err != nil {
 		return fmt.Errorf("error handling callback: %w", err)
 	}
 

--- a/cmd/oceanbench/auth.go
+++ b/cmd/oceanbench/auth.go
@@ -26,6 +26,8 @@ LICENSE
 package main
 
 import (
+	"errors"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -72,7 +74,12 @@ func oauthCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, err := auth.CallbackHandler(backend.NewNetHandler(w, r, auth.NetStore))
-	if err != nil {
+	log.Println("errors is:", errors.Is(err, &gauth.ErrOauth2RedirectError{}))
+	if errors.Is(err, &gauth.ErrOauth2RedirectError{}) {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	} else if err != nil {
+		log.Println("got error:", err)
 		writeError(w, err)
 		return
 	}


### PR DESCRIPTION
This change handles errors passed to the callback and wraps them with an error so they can be more easily parsed and handled properly by the server.

closes #462 