### PR TITLE
Notify: Add new HTMLEmailer interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.4
 
 require (
 	bou.ke/monkey v1.0.2
+	cloud.google.com/go/datastore v1.11.0
 	cloud.google.com/go/storage v1.30.1
 	github.com/Comcast/gots/v2 v2.2.1
 	github.com/Knetic/govaluate v3.0.0+incompatible
@@ -33,7 +34,6 @@ require (
 	cloud.google.com/go v0.110.0 // indirect
 	cloud.google.com/go/compute v1.19.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
-	cloud.google.com/go/datastore v1.11.0 // indirect
 	cloud.google.com/go/iam v0.13.0 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
The new HTMLEmailer interface is for types which can send emails using formatted HTML.

This change implements a simple method for a MailjetNotifier.

This is a really basic change that should allow us to send basic emails to ausoceantv users, but we may want to explore how we can use the mailjet platform for more refined and complex emails. Especially since email html != web html.

We could also just add the type of email as an option to the existing send method, since there is a lot of overlap in the code, but I'm not sure that its a good abstraction. I think that having the seperate interface can be useful for other services as well, since the notifier up until now has been very clearly designed for purpose (being site and broadcast notifications), without much generality in mind. I think that starting a fresh interface can somewhat improve the experience for developers of AusOceanTV