### PR TITLE
AOTV: Update stripe subscription to cancel (#420)

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -238,6 +238,9 @@ func (svc *service) getSubscriptionHandler(c *fiber.Ctx) error {
 	}
 
 	subscription, err := model.GetSubscription(ctx, svc.store, subscriber.ID, model.NoFeedID)
+	if errors.Is(err, datastore.ErrNoSuchEntity) {
+		return c.JSON(nil)
+	}
 	if err != nil {
 		return fmt.Errorf("error getting subscription for id: %d: %w", subscriber.ID, err)
 	}


### PR DESCRIPTION
This change update the subscription on the stripe server to make sure that we are in sync when cancelling to avoid users getting charged when it seemed like they had cancelled the subscription.

This change also adds a few checks and conditional rendering in the profile-details element to make it easier to see the state of the subscription.