### PR TITLE
AOTV: Add logAndReturnError function (#474)

### DIFF
--- a/cmd/ausoceantv/auth.go
+++ b/cmd/ausoceantv/auth.go
@@ -60,7 +60,7 @@ func (svc *service) callbackHandler(c *fiber.Ctx) error {
 		log.Warn(err)
 		return c.Redirect("/", fiber.StatusFound)
 	} else if err != nil {
-		return fmt.Errorf("error handling callback: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error handling callback: %v", err))
 	}
 
 	// Create a new subscriber if one does not exist.
@@ -70,10 +70,10 @@ func (svc *service) callbackHandler(c *fiber.Ctx) error {
 		subscriber := &model.Subscriber{GivenName: p.GivenName, FamilyName: p.FamilyName, Email: p.Email}
 		err := model.CreateSubscriber(ctx, svc.store, subscriber)
 		if err != nil {
-			return fmt.Errorf("unable to create susbcriber %v: %w", subscriber, err)
+			return logAndReturnError(c, fmt.Sprintf("unable to create susbcriber %v: %v", subscriber, err))
 		}
 	} else if err != nil {
-		return fmt.Errorf("failed getting subscriber by email: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("failed getting subscriber by email: %v", err))
 	}
 
 	return nil
@@ -83,13 +83,13 @@ func (svc *service) callbackHandler(c *fiber.Ctx) error {
 func (svc *service) profileHandler(c *fiber.Ctx) error {
 	p, err := svc.auth.GetProfile(backend.NewFiberHandler(c))
 	if errors.Is(err, gauth.SessionNotFound) || errors.Is(err, gauth.TokenNotFound) {
-		return fiber.NewError(fiber.StatusUnauthorized, fmt.Sprintf("error getting profile: %v", err))
+		return logAndReturnError(c, fmt.Sprintf("error getting profile: %v", err), withStatus(fiber.StatusUnauthorized))
 	} else if err != nil {
-		return fmt.Errorf("unable to get profile: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to get profile: %v", err))
 	}
 	bytes, err := json.Marshal(p)
 	if err != nil {
-		return fmt.Errorf("unable to marshal profile: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to marshal profile: %v", err))
 	}
 	c.Write(bytes)
 	return nil

--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -227,14 +227,14 @@ func (svc *service) getSubscriptionHandler(c *fiber.Ctx) error {
 	ctx := context.Background()
 	p, err := svc.auth.GetProfile(backend.NewFiberHandler(c))
 	if errors.Is(err, gauth.SessionNotFound) || errors.Is(err, gauth.TokenNotFound) {
-		return fiber.NewError(fiber.StatusUnauthorized, fmt.Sprintf("error getting profile: %v", err))
+		return logAndReturnError(c, fmt.Sprintf("error getting profile: %v", err), withStatus(fiber.StatusUnauthorized))
 	} else if err != nil {
-		return fmt.Errorf("unable to get profile: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to get profile: %v", err))
 	}
 
 	subscriber, err := model.GetSubscriberByEmail(ctx, svc.store, p.Email)
 	if err != nil {
-		return fmt.Errorf("error getting subscriber by email for: %s: %w", p.Email, err)
+		return logAndReturnError(c, fmt.Sprintf("error getting subscriber by email for: %s: %v", p.Email, err))
 	}
 
 	subscription, err := model.GetSubscription(ctx, svc.store, subscriber.ID, model.NoFeedID)
@@ -242,10 +242,8 @@ func (svc *service) getSubscriptionHandler(c *fiber.Ctx) error {
 		return c.JSON(nil)
 	}
 	if err != nil {
-		return fmt.Errorf("error getting subscription for id: %d: %w", subscriber.ID, err)
+		return logAndReturnError(c, fmt.Sprintf("error getting subscription for id: %d: %v", subscriber.ID, err))
 	}
-
-	log.Infof("got subscription: %+v", subscription)
 
 	// Check that the current time is prior to the end date of the subscription.
 	// ie. the subscription hasn't expired and is still valid.
@@ -261,20 +259,14 @@ func (svc *service) checkSurveyHandler(c *fiber.Ctx) error {
 	ctx := context.Background()
 	p, err := svc.auth.GetProfile(backend.NewFiberHandler(c))
 	if errors.Is(err, gauth.SessionNotFound) || errors.Is(err, gauth.TokenNotFound) {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": fmt.Sprintf("error getting profile: %v", err),
-		})
+		return logAndReturnError(c, fmt.Sprintf("error getting profile: %v", err), withStatus(fiber.StatusUnauthorized))
 	} else if err != nil {
-		log.Error("unable to get profile:", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Internal Server Error",
-		})
+		return logAndReturnError(c, fmt.Sprintf("unable to get profile: %v", err))
 	}
 
 	subscriber, err := model.GetSubscriberByEmail(ctx, svc.store, p.Email)
 	if err != nil {
-		log.Error("error retrieving subscriber:", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Internal Server Error"})
+		return logAndReturnError(c, fmt.Sprintf("error retrieving subscriber: %v", err))
 	}
 
 	// Check if the subscriber was created more than a day ago.
@@ -287,10 +279,7 @@ func (svc *service) checkSurveyHandler(c *fiber.Ctx) error {
 	var demographicData map[string]interface{}
 	if subscriber.DemographicInfo != "" {
 		if err := json.Unmarshal([]byte(subscriber.DemographicInfo), &demographicData); err != nil {
-			log.Error("failed to parse demographic info JSON for subscriber", subscriber.ID, ":", err)
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-				"error": "Internal Server Error",
-			})
+			return logAndReturnError(c, fmt.Sprintf("failed to parse demographic info JSON for subscriber %d: %v", subscriber.ID, err))
 		}
 
 		if interest, hasInterest := demographicData["interest"]; hasInterest {
@@ -312,15 +301,15 @@ func (s *service) handleSurveyFormSubmission(c *fiber.Ctx) error {
 	// Authenticate the user and fetch their profile.
 	p, err := svc.auth.GetProfile(backend.NewFiberHandler(c))
 	if errors.Is(err, gauth.SessionNotFound) || errors.Is(err, gauth.TokenNotFound) {
-		return fiber.NewError(fiber.StatusUnauthorized, "user not authenticated")
+		return logAndReturnError(c, "user not authenticated", withStatus(fiber.StatusUnauthorized))
 	} else if err != nil {
-		return fmt.Errorf("unable to get profile: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to get profile: %v", err))
 	}
 
 	// Fetch the subscriber by email from the datastore.
 	subscriber, err := model.GetSubscriberByEmail(ctx, svc.store, p.Email)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "subscriber not found"})
+		return logAndReturnError(c, "subscriber not found")
 	}
 
 	// Extract form values from request body.
@@ -336,14 +325,49 @@ func (s *service) handleSurveyFormSubmission(c *fiber.Ctx) error {
 	// Encode demographic info as JSON and store it in Subscriber.
 	demographicJSON, err := json.Marshal(demographicInfo)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to encode demographic info"})
+		return logAndReturnError(c, "failed to encode demographic info")
 	}
 	subscriber.DemographicInfo = string(demographicJSON)
 
 	// Save updated subscriber to datastore.
 	if err := model.UpdateSubscriber(ctx, s.store, subscriber); err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to update subscriber"})
+		return logAndReturnError(c, "failed to update subscriber")
 	}
 
 	return c.JSON(fiber.Map{"message": "demographic info successfully updated"})
+}
+
+type loggingErrorOption func(c *fiber.Ctx, msg *string) error
+
+// withStatus sets the status of the response.
+func withStatus(status int) loggingErrorOption {
+	return func(c *fiber.Ctx, msg *string) error {
+		c.Status(status)
+		return nil
+	}
+}
+
+// withUserMessage updates the message that will be sent to the frontend,
+// this is intended for user readable messages.
+func withUserMessage(userMsg string) loggingErrorOption {
+	return func(c *fiber.Ctx, msg *string) error {
+		*msg = userMsg
+		return nil
+	}
+}
+
+// logAndReturnError logs the passed message as an error, and if no options are passed,
+// will return the same error to the frontend as a JSON formatted error string.
+//
+// The response code defaults to internal server error (500).
+func logAndReturnError(c *fiber.Ctx, message string, opts ...loggingErrorOption) error {
+	log.Error(message)
+	c.Status(fiber.StatusInternalServerError)
+	for i, opt := range opts {
+		err := opt(c, &message)
+		if err != nil {
+			log.Errorf("error applying opt[%d]: %v", i, err)
+		}
+	}
+	return c.JSON(fiber.Map{"message": message})
 }

--- a/cmd/ausoceantv/stripe.go
+++ b/cmd/ausoceantv/stripe.go
@@ -94,8 +94,7 @@ func (svc *service) handleStripeWebhook(c *fiber.Ctx) error {
 	event := stripe.Event{}
 
 	if err := json.Unmarshal(c.Body(), &event); err != nil {
-		log.Errorf("Failed to parse webhook body json: %w", err.Error())
-		return err
+		return logAndReturnError(c, fmt.Sprintf("failed to parse webhook body json: %v", err.Error()))
 	}
 
 	switch event.Type {
@@ -103,33 +102,30 @@ func (svc *service) handleStripeWebhook(c *fiber.Ctx) error {
 		var pi stripe.PaymentIntent
 		err := json.Unmarshal(event.Data.Raw, &pi)
 		if err != nil {
-			log.Errorf("Error parsing webhook JSON: %w", err)
-			return err
+			return logAndReturnError(c, fmt.Sprintf("error parsing webhook JSON: %v", err))
 		}
-		return svc.handleSuccessfulPaymentIntent(pi)
+		return svc.handleSuccessfulPaymentIntent(c, pi)
 	case stripe.EventTypeInvoicePaymentSucceeded:
 		var invoice stripe.Invoice
 		err := json.Unmarshal(event.Data.Raw, &invoice)
 		if err != nil {
-			log.Errorf("Error parsing webhook JSON: %w", err)
-			return err
+			return logAndReturnError(c, fmt.Sprintf("error parsing webhook JSON: %v", err))
 		}
-		return svc.handleInvoicePaymentSuccess(invoice)
+		return svc.handleInvoicePaymentSuccess(c, invoice)
 	default:
-		return errors.New("unsupported event type")
+		return logAndReturnError(c, "unsupported event type")
 	}
 }
 
-func (svc *service) handleSuccessfulPaymentIntent(pi stripe.PaymentIntent) error {
+func (svc *service) handleSuccessfulPaymentIntent(c *fiber.Ctx, pi stripe.PaymentIntent) error {
 	ctx := context.Background()
 	customer, err := svc.getCustomer(&model.Subscriber{PaymentInfo: pi.Customer.ID})
 	if err != nil {
-		return fmt.Errorf("error getting customer: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error getting customer: %v", err))
 	}
 	sub, err := model.GetSubscriberByEmail(ctx, svc.store, customer.Email)
 	if err != nil {
-		log.Errorf("failed to get subscriber for email: %s, err: %v", pi.Customer.Email, err)
-		return fmt.Errorf("failed to get subscriber for email: %s, err: %w", pi.Customer.Email, err)
+		return logAndReturnError(c, fmt.Sprintf("failed to get subscriber for email: %s, err: %v", pi.Customer.Email, err))
 	}
 
 	if pi.Invoice != nil {
@@ -144,19 +140,19 @@ func (svc *service) handleSuccessfulPaymentIntent(pi stripe.PaymentIntent) error
 	)
 }
 
-func (svc *service) handleInvoicePaymentSuccess(invoice stripe.Invoice) error {
+func (svc *service) handleInvoicePaymentSuccess(c *fiber.Ctx, invoice stripe.Invoice) error {
 	ctx := context.Background()
 	customer, err := svc.getCustomer(&model.Subscriber{PaymentInfo: invoice.Customer.ID})
 	if err != nil {
-		return fmt.Errorf("error getting customer: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error getting customer: %v", err))
 	}
 	subber, err := model.GetSubscriberByEmail(ctx, svc.store, customer.Email)
 	if err != nil {
-		return fmt.Errorf("failed to get subscriber for email: %s, err: %w", invoice.Customer.Email, err)
+		return logAndReturnError(c, fmt.Sprintf("failed to get subscriber for email: %s, err: %v", invoice.Customer.Email, err))
 	}
 	sub, err := subscription.Get(invoice.Subscription.ID, nil)
 	if err != nil {
-		return fmt.Errorf("error getting subscription from stripe: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error getting subscription from stripe: %v", err))
 	}
 
 	start := sub.CurrentPeriodStart
@@ -173,7 +169,7 @@ func (svc *service) handleInvoicePaymentSuccess(invoice stripe.Invoice) error {
 		)
 	}
 	if err != nil {
-		return fmt.Errorf("unable to get current subscription: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to get current subscription: %v", err))
 	}
 
 	curr.Start = time.Unix(start, 0)
@@ -188,33 +184,29 @@ func (svc *service) handleCreatePaymentIntent(c *fiber.Ctx) error {
 	if errors.Is(err, gauth.SessionNotFound) || errors.Is(err, gauth.TokenNotFound) {
 		return fiber.NewError(fiber.StatusUnauthorized, fmt.Sprintf("error getting profile: %v", err))
 	} else if err != nil {
-		return fmt.Errorf("unable to get profile: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to get profile: %v", err))
 	}
 
 	ctx := context.Background()
 
 	subscriber, err := model.GetSubscriberByEmail(ctx, svc.store, p.Email)
 	if err != nil {
-		return fmt.Errorf("failed getting subscriber, try logging in again: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("failed getting subscriber, try logging in again: %v", err))
 	}
 
 	customer, err := svc.getCustomer(subscriber)
 	if err != nil {
-		return fmt.Errorf("error getting customer ID: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error getting customer ID: %v", err))
 	}
 
 	priceID := c.FormValue("priceID")
 	if priceID == "" {
-		err := c.SendStatus(fiber.StatusBadRequest)
-		if err != nil {
-			return fmt.Errorf("error sending status: %d, err: %w", fiber.StatusBadRequest, err)
-		}
-		return ErrNoProductSelected
+		return logAndReturnError(c, ErrNoProductSelected.Error(), withStatus(fiber.StatusBadRequest))
 	}
 
 	price, err := getPrice(priceID)
 	if err != nil {
-		return fmt.Errorf("error getting price: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error getting price: %v", err))
 	}
 
 	// If the price is recurring the selected product is a subscription and needs
@@ -256,8 +248,7 @@ func (svc *service) createPaymentIntent(c *fiber.Ctx, cid string, price *stripe.
 	// NOTE: DO NOT LOG PAYMENT INTENT.
 	pi, err = paymentintent.New(params)
 	if err != nil {
-		log.Errorf("error creating new Stripe payment intent: %v", err)
-		return fmt.Errorf("could not create payment intent: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error creating new Stripe payment intent: %v", err))
 	}
 
 	return c.JSON(clientSecretResponse{pi.ClientSecret})
@@ -278,7 +269,7 @@ func (svc *service) createSubscriptionIntent(c *fiber.Ctx, cid, pid string) erro
 	subParams.AddExpand("latest_invoice.payment_intent")
 	s, err := subscription.New(subParams)
 	if err != nil {
-		return fmt.Errorf("unable to create new stripe subscription: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to create new stripe subscription: %v", err))
 	}
 
 	return c.JSON(
@@ -366,17 +357,17 @@ func (svc *service) cancelSubscription(c *fiber.Ctx) error {
 	if errors.Is(err, gauth.SessionNotFound) || errors.Is(err, gauth.TokenNotFound) {
 		return fiber.NewError(fiber.StatusUnauthorized, fmt.Sprintf("error getting profile: %v", err))
 	} else if err != nil {
-		return fmt.Errorf("unable to get profile: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("unable to get profile: %v", err))
 	}
 
 	subscriber, err := model.GetSubscriberByEmail(ctx, svc.store, p.Email)
 	if err != nil {
-		return fmt.Errorf("error getting subscriber by email for: %s: %w", p.Email, err)
+		return logAndReturnError(c, fmt.Sprintf("error getting subscriber by email for: %s: %v", p.Email, err))
 	}
 
 	sub, err := model.GetSubscription(ctx, svc.store, subscriber.ID, 0)
 	if err != nil {
-		return fmt.Errorf("error getting subscription for id: %d: %w", subscriber.ID, err)
+		return logAndReturnError(c, fmt.Sprintf("error getting subscription for id: %d: %v", subscriber.ID, err))
 	}
 
 	// Since the day pass is not a renewing subscription, we shouldn't need to cancel it with stripe.
@@ -384,7 +375,7 @@ func (svc *service) cancelSubscription(c *fiber.Ctx) error {
 		subParams := &stripe.SubscriptionParams{CancelAtPeriodEnd: stripe.Bool(true)}
 		_, err = subscription.Update(sub.StripeSubscriptionID, subParams)
 		if err != nil {
-			return fmt.Errorf("failed to cancel subscription: %w", err)
+			return logAndReturnError(c, fmt.Sprintf("failed to cancel subscription: %v", err))
 		}
 	}
 
@@ -401,10 +392,8 @@ func (svc *service) handleGetPrice(c *fiber.Ctx) error {
 
 	price, err := getPrice(pid)
 	if err != nil {
-		return fmt.Errorf("error getting price: %w", err)
+		return logAndReturnError(c, fmt.Sprintf("error getting price: %v", err))
 	}
-
-	log.Infof("price: %+v", price)
 
 	return c.JSON(price)
 }
@@ -419,7 +408,7 @@ func (svc *service) handleGetProduct(c *fiber.Ctx) error {
 	params := &stripe.ProductParams{}
 	product, err := product.Get(pid, params)
 	if err != nil {
-		return fmt.Errorf("error getting product for id: %s, err: %w", pid, err)
+		return logAndReturnError(c, fmt.Sprintf("error getting product for id: %s, err: %v", pid, err))
 	}
 
 	return c.JSON(product)

--- a/cmd/ausoceantv/webapp/src/survey-check.ts
+++ b/cmd/ausoceantv/webapp/src/survey-check.ts
@@ -2,6 +2,10 @@
 async function checkSurveyRedirect() {
   try {
     const response = await fetch("/api/v1/survey/check", { credentials: "include" });
+    if (!response.ok) {
+      const error = await response.json();
+      throw response.statusText + ": " + error.message;
+    }
     const result = await response.json();
     if (result.redirect) {
       window.location.href = result.redirect;

--- a/cmd/ausoceantv/webapp/src/survey.ts
+++ b/cmd/ausoceantv/webapp/src/survey.ts
@@ -14,7 +14,7 @@ async function handleFormSubmit(event: Event): Promise<void> {
 
     if (!response.ok) {
       const error = await response.json();
-      alert(`Error: ${error.error}`);
+      throw response.statusText + ": " + error.message;
     } else {
       window.location.href = "/watch.html"; // Redirect to home page.
     }
@@ -36,4 +36,3 @@ function initFormHandler(): void {
 
 // Initialize the form submission handler when the document is ready.
 document.addEventListener("DOMContentLoaded", initFormHandler);
-  

--- a/cmd/ausoceantv/webapp/src/web-components/authenticator.ts
+++ b/cmd/ausoceantv/webapp/src/web-components/authenticator.ts
@@ -15,9 +15,10 @@ export class Authenticator extends TailwindElement() {
     super.connectedCallback();
 
     await fetch("/api/v1/auth/profile")
-      .then((resp) => {
-        if (resp.status != 200) {
-          throw resp.status;
+      .then(async (resp) => {
+        if (!resp.ok) {
+          const error = await resp.json();
+          throw resp.statusText + ": " + error.message;
         }
         return resp.json();
       })
@@ -27,11 +28,7 @@ export class Authenticator extends TailwindElement() {
         this.user.email = resp.Email;
       })
       .catch((err) => {
-        if (err == 401) {
-          console.log("No session found");
-        } else {
-          console.log("Error fetching profile:", err);
-        }
+        console.warn("Error fetching profile:", err);
 
         // Send Non-Authenticated users to the index page.
         if (window.location.pathname != "/") {

--- a/cmd/ausoceantv/webapp/src/web-components/profile-details.ts
+++ b/cmd/ausoceantv/webapp/src/web-components/profile-details.ts
@@ -34,9 +34,9 @@ export class ProfileDetails extends TailwindElement() {
     console.log("getting subscription");
     await fetch("/api/v1/get/subscription")
       .then(async (resp) => {
-        if (resp.status != 200) {
-          const errorText = await resp.text();
-          throw errorText;
+        if (!resp.ok) {
+          const error = await resp.json();
+          throw resp.statusText + ": " + error.message;
         }
         return resp.json();
       })
@@ -114,7 +114,7 @@ export class ProfileDetails extends TailwindElement() {
   async handleCancel() {
     await fetch("api/v1/stripe/cancel", { method: "POST" }).then(async (resp) => {
       this.msg = await resp.text();
-      if (resp.status >= 200 && resp.status < 300) {
+      if (resp.ok) {
         this.msgColour = textGreen;
       } else {
         this.msgColour = textRed;


### PR DESCRIPTION
This change adds a simple helper function which can log an error, as well as return an error using properly formatted JSON.

Callers can set a different value to be returned to the frontend, as well as specifying the response code through functional options.

This change may introduce more logging than previously, we may have to replace some calls to just return errors, or even have another functional option to set the log level.

requires #471 
closes #474