### PR TITLE
Bench: Add battery voltage for esp32

### DIFF
--- a/model/factories.go
+++ b/model/factories.go
@@ -101,6 +101,20 @@ func WaterTemperatureSensor() *SensorV2 {
 	)
 }
 
+// ESP32BatterySensor returns a Battery Voltage sensor for an ESP32 with
+// the given scale factor.
+func ESP32BatterySensor(scaleFactor float64) *SensorV2 {
+	return sensorShim(
+		"Battery Voltage",
+		pinESP32BatteryVoltage,
+		nmea.DCVoltage,
+		funcScale,
+		unitVoltage,
+		formRound1,
+		Arg(scaleFactor),
+	)
+}
+
 // ESP32Power1Sensor returns a Power 1 Voltage sensor for an ESP32 with
 // the given scale factor.
 func ESP32Power1Sensor(scaleFactor float64) *SensorV2 {

--- a/system/rig_system.go
+++ b/system/rig_system.go
@@ -133,6 +133,7 @@ func WithRigSystemDefaults() func(any) error {
 			model.AirTemperatureSensor(),
 			model.HumiditySensor(),
 			model.WaterTemperatureSensor(),
+			model.ESP32BatterySensor(defaultVoltageScaleFactor),
 			model.ESP32Power1Sensor(defaultVoltageScaleFactor),
 			model.ESP32Power2Sensor(defaultVoltageScaleFactor),
 			model.ESP32Power3Sensor(defaultVoltageScaleFactor),


### PR DESCRIPTION
This change adds the battery voltage sensor for the ESP32 which will be added by default to the config