### PR TITLE
otv: update battery voltage pin

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -152,6 +152,7 @@ type BroadcastConfig struct {
 	HardwareStateData        []byte        // Hardware states will be marshalled and their data stored here.
 	Account                  string        // The YouTube account email that this broadcast is associated with.
 	InFailure                bool          // True if the broadcast is in a failure state.
+	BatteryVoltagePin        string        // The pin that the battery voltage is read from.
 	RecoveringVoltage        bool          // True if the broadcast is currently recovering voltage.
 	RequiredStreamingVoltage float64       // The required battery voltage for the camera to stream.
 	VoltageRecoveryTimeout   int           // Max allowable hours for voltage recovery before failure.

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -247,6 +247,10 @@
               </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
+              <label for="battery-voltage-pin" class="advanced w-25 text-end">Battery Voltage Pin:</label>
+              <input class="advanced w-50 form-control" type="input" name="battery-voltage-pin" value="{{.CurrentBroadcast.BatteryVoltagePin}}" />
+            </div>
+            <div class="d-flex align-items-center gap-1 mb-1">
               <label for="required-streaming-voltage" class="advanced w-25 text-end">Required Streaming Voltage:</label>
               <input class="advanced w-50 form-control" type="input" name="required-streaming-voltage" value="{{.CurrentBroadcast.RequiredStreamingVoltage}}" />
             </div>

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -129,6 +129,7 @@ type BroadcastConfig struct {
 	HardwareStateData        []byte        // Hardware states will be marshalled and their data stored here.
 	Account                  string        // The YouTube account email that this broadcast is associated with.
 	InFailure                bool          // True if the broadcast is in a failure state.
+	BatteryVoltagePin        string        // The pin that the battery voltage is read from.
 	RecoveringVoltage        bool          // True if the broadcast is currently recovering voltage.
 	RequiredStreamingVoltage float64       // The required battery voltage for the camera to stream.
 	VoltageRecoveryTimeout   int           // Max allowable hours for voltage recovery before failure.

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -778,7 +778,11 @@ func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error)
 	}
 
 	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
-	const batteryVoltagePin = "A0"
+	batteryVoltagePin := ctx.cfg.BatteryVoltagePin
+	if batteryVoltagePin == "" {
+		const defaultBatteryVoltagePin = "A4"
+		batteryVoltagePin = defaultBatteryVoltagePin
+	}
 	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.cfg.ControllerMAC, batteryVoltagePin)
 	if err != nil {
 		return 0, fmt.Errorf("could not get battery voltage sensor: %v", err)

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.7.5"
+	version            = "v0.7.6"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
Make battery voltage pin configurable and default to the ESP32 A4 pin when it's not defined in the broadcast config.