### PR TITLE
AOTV: Don't create stripe customer in lite mode

### DIFF
--- a/cmd/ausoceantv/auth.go
+++ b/cmd/ausoceantv/auth.go
@@ -72,9 +72,11 @@ func (svc *service) callbackHandler(c *fiber.Ctx) error {
 		if err != nil {
 			return logAndReturnError(c, fmt.Sprintf("unable to create susbcriber %v: %v", subscriber, err))
 		}
-		_, err = svc.getCustomer(subscriber)
-		if err != nil {
-			return logAndReturnError(c, fmt.Sprintf("unable to create stripe customer: %v", err))
+		if !svc.lite {
+			_, err = svc.getCustomer(subscriber)
+			if err != nil {
+				return logAndReturnError(c, fmt.Sprintf("unable to create stripe customer: %v", err))
+			}
 		}
 	} else if err != nil {
 		return logAndReturnError(c, fmt.Sprintf("failed getting subscriber by email: %v", err))


### PR DESCRIPTION
We can't create a stripe customer in lite mode since we don't have production keys.