### PR TITLE
otv: add custom marshalling for nested hardware states

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.7.7"
+	version            = "v0.7.8"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
Because the nested states use substates of interface state, we need to add custom marshaling/unmarshaling to deal with this.