### PR TITLE
Bench: Parse Shutdown Actions

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -221,6 +221,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			ControllerMAC:         model.MacEncode(r.FormValue("controller-mac")),
 			OnActions:             r.FormValue("on-actions"),
 			OffActions:            r.FormValue("off-actions"),
+			ShutdownActions:       r.FormValue("shutdown-actions"),
 			SendMsg:               r.FormValue("report-sensor") == "Chat",
 			UsingVidforward:       r.FormValue("use-vidforward") == "using-vidforward",
 			CheckingHealth:        r.FormValue("check-health") == "checking-health",

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.30.3"
+	version     = "v0.30.4"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This fixes the error where there are no shutdown actions for a broadcast since they just aren't being read.