### PR TITLE
Bench better broadcast testing

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.30.2"
+	version     = "v0.30.3"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/rollup.config.js
+++ b/cmd/oceanbench/rollup.config.js
@@ -49,5 +49,21 @@ export default [
       resolve(),
       typescript()
     ]
+  },
+  {
+    input: 'ts/cron-settings.ts',
+    output: {
+      file: 's/lit/cron-settings.js',
+      format: 'iife',
+      name: 'cronSettings',
+      globals: {
+        lit: 'lit',
+        'lit/decorators.js': 'decorators_js'
+      }
+    },
+    plugins: [
+      resolve(),
+      typescript()
+    ]
   }
 ];

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -662,7 +662,7 @@ func editCronsHandler(w http.ResponseWriter, r *http.Request) {
 	task := r.FormValue("task")
 
 	if id == "" {
-		writeCrons(w, r, errInvalidID.Error())
+		writeError(w, errInvalidID)
 		return
 	}
 
@@ -685,28 +685,28 @@ func editCronsHandler(w http.ResponseWriter, r *http.Request) {
 
 	site, err := model.GetSite(ctx, settingsStore, skey)
 	if err != nil {
-		writeCrons(w, r, fmt.Sprintf("could not get site: %v", err))
+		writeError(w, fmt.Errorf("could not get site: %v", err))
 		return
 	}
 
 	c := model.Cron{Skey: skey, ID: id, Action: ca, Var: cv, Data: cd, Enabled: ce != ""}
 	err = c.ParseTime(ct, site.Timezone)
 	if err != nil {
-		writeCrons(w, r, fmt.Sprintf("could not parse time: %v", err))
+		writeError(w, fmt.Errorf("could not parse time: %v", err))
 		return
 	}
 
 	err = model.PutCron(ctx, settingsStore, &c)
 	if err != nil {
-		writeCrons(w, r, fmt.Sprintf("could not put cron in datastore: %v", err))
+		writeError(w, fmt.Errorf("could not put cron in datastore: %v", err))
 		return
 	}
 
 	err = cronScheduler.Set(&c)
 	if err != nil {
-		writeCrons(w, r, fmt.Sprintf("could not schedule cron: %v", err))
+		writeError(w, fmt.Errorf("could not schedule cron: %v", err))
 		return
 	}
 
-	writeCrons(w, r, "")
+	return
 }

--- a/cmd/oceanbench/t/set/cron.html
+++ b/cmd/oceanbench/t/set/cron.html
@@ -33,10 +33,7 @@
       {{ end }}
       <h1 class="container-md">Crons</h1>
       <div class="table border rounded p-4 container-md bg-white" id="crons">
-        {{ range $c := .Crons }}
-        <cron-settings id="{{.ID}}" time="{{ .FormatTime $.Timezone }}" action="{{.Action}}" value="{{.Data}}" enabled="{{.Enabled}}" var="{{.Var}}"></cron-settings>
-        {{ end }}
-        <!-- <div class="tr">
+        <div style="display: grid; grid-template-columns: 8% 20% 8% 8% 20% 16% 10%; gap: 10px">
           <span class="td select"></span>
           <span class="td std">ID</span>
           <span class="td half">Time</span>
@@ -46,46 +43,9 @@
           <span class="td half">Enabled</span>
         </div>
         {{ range $c := .Crons }}
-        <form class="tr" id="{{ .ID }}" enctype="multipart/form-data" action="/set/crons/edit" method="post" novalidate>
-          <span class="td select"><img src="/s/delete.png" onclick="deleteCron('{{ .ID }}');" /></span>
-          <span class="td std"><input type="text" name="ci" class="" value="{{ .ID }}" readonly /></span>
-          <span class="td half"><input type="text" name="ct" value="{{ .FormatTime $.Timezone }}" class="half" onchange="updateCron(this);" /></span>
-          <span class="td half">
-            <select name="ca" class="half" onchange="updateCron(this);">
-              {{ range $.Actions }}
-              <option value="{{ . }}" {{ if eq . $c.Action }}selected{{ end }}>{{ . }}</option>
-              {{ end }}
-            </select>
-          </span>
-          <span class="td std">
-            <select type="text" name="cv" class="std" onchange="updateCron(this);">
-              <option selected value="{{ .Var }}"></option>
-            </select>
-          </span>
-          <span class="td std"><input type="text" name="cd" value="{{ .Data }}" class="std" onchange="updateCron(this);" /></span>
-          <span class="td half"><input type="checkbox" name="ce" {{ if .Enabled }}checked{{ end }} onchange="updateCron(this);" /></span>
-        </form>
+        <cron-settings class="w-100" id="{{.ID}}" time="{{ .FormatTime $.Timezone }}" action="{{.Action}}" value="{{.Data}}" {{if .Enabled}}enabled{{end}} var="{{.Var}}"></cron-settings>
         {{ end }}
-        <form class="tr" id="_newcron" enctype="multipart/form-data" action="/set/crons/edit" method="post" novalidate>
-          <span class="td select"><img src="/s/add.png" onclick="addCron();" /></span>
-          <span class="td std"><input type="text" name="ci" class="std" /></span>
-          <span class="td half"><input type="text" name="ct" class="half" /></span>
-          <span class="td half">
-            <select name="ca" class="half">
-              {{ range $.Actions }}
-              <option value="{{ . }}">{{ . }}</option>
-              {{ end }}
-            </select>
-          </span>
-          <span class="td std">
-            <select id="var-select" type="text" name="cv" class="std">
-              <option>-- Select Var --</option>
-            </select>
-          </span>
-          <span class="td std"><input type="text" name="cd" class="std" /></span>
-          <span class="td half"><input type="checkbox" name="ce" /></span>
-          <input type="hidden" name="task" value="Add" />
-        </form> -->
+        <cron-settings class="w-100" new-cron></cron-settings>
       </div>
     </section>
     {{ .Footer }}

--- a/cmd/oceanbench/t/set/cron.html
+++ b/cmd/oceanbench/t/set/cron.html
@@ -9,6 +9,7 @@
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
     <script type="text/javascript" src="/s/cron.js"></script>
+    <script type="module" src="/s/lit/cron-settings.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -32,7 +33,10 @@
       {{ end }}
       <h1 class="container-md">Crons</h1>
       <div class="table border rounded p-4 container-md bg-white" id="crons">
-        <div class="tr">
+        {{ range $c := .Crons }}
+        <cron-settings id="{{.ID}}" time="{{ .FormatTime $.Timezone }}" action="{{.Action}}" value="{{.Data}}" enabled="{{.Enabled}}" var="{{.Var}}"></cron-settings>
+        {{ end }}
+        <!-- <div class="tr">
           <span class="td select"></span>
           <span class="td std">ID</span>
           <span class="td half">Time</span>
@@ -81,7 +85,7 @@
           <span class="td std"><input type="text" name="cd" class="std" /></span>
           <span class="td half"><input type="checkbox" name="ce" /></span>
           <input type="hidden" name="task" value="Add" />
-        </form>
+        </form> -->
       </div>
     </section>
     {{ .Footer }}

--- a/cmd/oceanbench/ts/cron-settings.ts
+++ b/cmd/oceanbench/ts/cron-settings.ts
@@ -1,0 +1,179 @@
+import { LitElement, html, css } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+interface SiteVar {
+  Skey: number;
+  Scope: string;
+  Name: string;
+  Value: string;
+  Updated: string;
+}
+
+interface SiteDevice {
+  Skey: number;
+  Dkey: number;
+  Mac: number;
+  Name: string;
+  Inputs: string;
+  Outputs: string;
+  Wifi: string;
+  MonitorPeriod: number;
+  ActPeriod: number;
+  Type: string;
+  Version: string;
+  Protocol: string;
+  Status: number;
+  Latitude: number;
+  Longitude: number;
+  Enabled: boolean;
+  Updated: string;
+}
+
+const prodEndpoint = "https://oceantv.appspot.com/checkbroadcasts";
+const devEndpoint = "https://dev-dot-oceantv.ts.r.appspot.com/checkbroadcasts";
+
+@customElement("cron-settings")
+export class CronSettings extends LitElement {
+  @property({ type: String, attribute: "id" }) ID = "";
+  @property({ type: String, attribute: "time" }) Time = "";
+  @property({ type: String, attribute: "action" }) Action = "";
+  @property({ type: String, attribute: "var" }) Variable = "";
+  @property({ type: String, attribute: "value" }) Value = "";
+  @property({ type: Boolean, attribute: "enabled" }) Enabled = false;
+
+  @state() buttonText = "Save";
+
+  siteVars: SiteVar[] = [];
+  devMap: Map<string, SiteDevice> = new Map();
+
+  static styles = css`
+    .row {
+      display: flex;
+      flex-direction: row;
+      gap: 10px;
+    }
+
+    @keyframes pulse {
+          0% {
+            opacity: 1;
+          }
+          50% {
+            opacity: 0.5;
+          }
+          100% {
+            opacity: 1;
+          }
+  `;
+
+  async connectedCallback() {
+    super.connectedCallback();
+    fetch("/api/get/vars/site")
+      .then(async (resp) => {
+        if (resp.ok) {
+          return resp.json();
+        }
+        throw await resp.text();
+      })
+      .then((data) => {
+        this.siteVars = data;
+        this.requestUpdate();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+
+    fetch("/api/get/devices/site")
+      .then(async (resp) => {
+        if (resp.ok) {
+          return resp.json();
+        }
+        throw await resp.text();
+      })
+      .then((data) => {
+        this.devMap = new Map(data.map((d: SiteDevice) => [d.Mac.toString(16), d]));
+        this.requestUpdate();
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  override render() {
+    return html`
+      <div class="row">
+        <button @click="${this.submitCron}">${this.buttonText}</button>
+        <input type="text" value="${this.ID}" />
+        <input type="text" value="${this.Time}" />
+        <select @input="${this.updateAction}">
+          <option ?selected="${this.Action == "set"}">set</option>
+          <option ?selected="${this.Action == "del"}">del</option>
+          <option ?selected="${this.Action == "call"}">call</option>
+          <option ?selected="${this.Action == "rpc"}">rpc</option>
+          <option ?selected="${this.Action == "email"}">email</option>
+        </select>
+        ${this.varDropdown()}
+        <input type="text" value="${this.Value}" />
+        <input type="checkbox" ?checked=${this.Enabled} />
+      </div>
+    `;
+  }
+
+  updateAction(e: Event) {
+    let actionSelect = e.target as HTMLSelectElement;
+    this.Action = actionSelect.options[actionSelect.selectedIndex].text;
+    this.requestUpdate();
+  }
+
+  varDropdown() {
+    switch (this.Action) {
+      case "rpc":
+        console.log("variable:", this.Variable);
+        return html`
+          <select @change="${this.checkEndpoint}">
+            <option value="other">other</option>
+            <option value="https://oceantv.appspot.com/checkbroadcasts" ?selected="${this.Variable == prodEndpoint}">Production</option>
+            <option value="https://dev-dot-oceantv.ts.r.appspot.com/checkbroadcasts" ?selected="${this.Variable == devEndpoint}">Testing (Dev)</option>
+          </select>
+          <input type="text" id="other-input" ?hidden="${this.Variable === prodEndpoint || this.Variable === devEndpoint}" value="${this.Variable}" />
+        `;
+      case "set":
+        if (this.devMap.size == 0 || this.siteVars.length == 0) {
+          return html`
+            <input type="text" style="animation: pulse 1s infinite;" readonly value="loading..." />
+          `;
+        }
+        console.log("devmap:", this.devMap);
+        return html`
+          <select>
+            ${this.siteVars.map((v) => {
+              let parts = v.Name.split(".");
+              let dev = this.devMap.get(parts[0]);
+
+              return html`
+                <option value="${v.Name}" ?selected="${this.Variable === v.Name}">${dev?.Name + "." + parts[1]}</option>
+              `;
+            })}
+          </select>
+        `;
+      default:
+        return html`
+          <input type="text" .value="${this.Variable}" />
+        `;
+    }
+  }
+
+  checkEndpoint(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.Variable = select.value;
+    if (this.Variable === "other") {
+      this.Variable = (this.shadowRoot?.querySelector("#other-input") as HTMLInputElement).value;
+    }
+    this.requestUpdate();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "cron-settings": CronSettings;
+  }
+}

--- a/cmd/oceanbench/ts/cron-settings.ts
+++ b/cmd/oceanbench/ts/cron-settings.ts
@@ -40,16 +40,19 @@ export class CronSettings extends LitElement {
   @property({ type: String, attribute: "var" }) Variable = "";
   @property({ type: String, attribute: "value" }) Value = "";
   @property({ type: Boolean, attribute: "enabled" }) Enabled = false;
+  @property({ type: Boolean, attribute: "new-cron" }) newCron = false;
 
   @state() buttonText = "Save";
+  @state() dropdownOption = "";
 
   siteVars: SiteVar[] = [];
   devMap: Map<string, SiteDevice> = new Map();
 
   static styles = css`
     .row {
-      display: flex;
-      flex-direction: row;
+        width: 100%;
+      display: inline-grid;
+      grid-template-columns: 8% 20% 8% 8% 20% 16% 10%;
       gap: 10px;
     }
 
@@ -67,6 +70,11 @@ export class CronSettings extends LitElement {
 
   async connectedCallback() {
     super.connectedCallback();
+    this.getVars();
+    this.getDevices();
+  }
+
+  getVars() {
     fetch("/api/get/vars/site")
       .then(async (resp) => {
         if (resp.ok) {
@@ -81,7 +89,9 @@ export class CronSettings extends LitElement {
       .catch((err) => {
         console.error(err);
       });
+  }
 
+  getDevices() {
     fetch("/api/get/devices/site")
       .then(async (resp) => {
         if (resp.ok) {
@@ -102,8 +112,8 @@ export class CronSettings extends LitElement {
     return html`
       <div class="row">
         <button @click="${this.submitCron}">${this.buttonText}</button>
-        <input type="text" value="${this.ID}" />
-        <input type="text" value="${this.Time}" />
+        <input @change="${this.updateID}" type="text" value="${this.ID}" />
+        <input @change="${this.updateTime}" type="text" value="${this.Time}" />
         <select @input="${this.updateAction}">
           <option ?selected="${this.Action == "set"}">set</option>
           <option ?selected="${this.Action == "del"}">del</option>
@@ -112,10 +122,49 @@ export class CronSettings extends LitElement {
           <option ?selected="${this.Action == "email"}">email</option>
         </select>
         ${this.varDropdown()}
-        <input type="text" value="${this.Value}" />
-        <input type="checkbox" ?checked=${this.Enabled} />
+        <input @change="${this.updateValue}" type="text" value="${this.Value}" />
+        <input @change="${this.updateEnabled}" type="checkbox" ?checked=${this.Enabled} style="max-height: 16px;" />
       </div>
     `;
+  }
+
+  submitCron() {
+    let formData = new FormData();
+    formData.append("ci", this.ID);
+    formData.append("ct", this.Time);
+    formData.append("ca", this.Action);
+    formData.append("cv", this.Variable);
+    formData.append("cd", this.Value);
+    formData.append("ce", this.Enabled ? "true" : "");
+
+    // Create a new cron input.
+    if (this.newCron) {
+      let nextCron = new CronSettings();
+      nextCron.newCron = true;
+      this.parentElement?.appendChild(nextCron);
+      this.newCron = false;
+    }
+
+    fetch("/set/crons/edit", { method: "POST", body: formData })
+      .then((resp) => {
+        if (resp.ok) {
+          this.buttonText = "Saved!";
+          this.requestUpdate();
+          setTimeout(() => {
+            this.buttonText = "Save";
+            this.requestUpdate();
+          }, 1000);
+        }
+      })
+      .catch((err) => {
+        console.log("Got error:", err);
+      });
+  }
+
+  updateID(e: Event) {
+    let idInput = e.target as HTMLInputElement;
+    this.ID = idInput.value;
+    this.requestUpdate();
   }
 
   updateAction(e: Event) {
@@ -124,17 +173,37 @@ export class CronSettings extends LitElement {
     this.requestUpdate();
   }
 
+  updateTime(e: Event) {
+    let timeInput = e.target as HTMLInputElement;
+    this.Time = timeInput.value;
+    this.requestUpdate();
+  }
+
+  updateValue(e: Event) {
+    let valueInput = e.target as HTMLInputElement;
+    this.Value = valueInput.value;
+    this.requestUpdate();
+  }
+
+  updateEnabled(e: Event) {
+    let enabledInput = e.target as HTMLInputElement;
+    this.Enabled = enabledInput.checked;
+    this.requestUpdate();
+  }
+
   varDropdown() {
     switch (this.Action) {
       case "rpc":
         console.log("variable:", this.Variable);
         return html`
-          <select @change="${this.checkEndpoint}">
-            <option value="other">other</option>
-            <option value="https://oceantv.appspot.com/checkbroadcasts" ?selected="${this.Variable == prodEndpoint}">Production</option>
-            <option value="https://dev-dot-oceantv.ts.r.appspot.com/checkbroadcasts" ?selected="${this.Variable == devEndpoint}">Testing (Dev)</option>
-          </select>
-          <input type="text" id="other-input" ?hidden="${this.Variable === prodEndpoint || this.Variable === devEndpoint}" value="${this.Variable}" />
+          <div>
+            <select @change="${this.updateEndpoint}" style="width: 100%">
+              <option value="other">other</option>
+              <option value="https://oceantv.appspot.com/checkbroadcasts" ?selected="${this.Variable == prodEndpoint}">Production</option>
+              <option value="https://dev-dot-oceantv.ts.r.appspot.com/checkbroadcasts" ?selected="${this.Variable == devEndpoint}">Testing (Dev)</option>
+            </select>
+            <input @change="${this.updateEndpoint}" type="text" id="endpoint-input" value="${this.Variable}" />
+          </div>
         `;
       case "set":
         if (this.devMap.size == 0 || this.siteVars.length == 0) {
@@ -144,7 +213,8 @@ export class CronSettings extends LitElement {
         }
         console.log("devmap:", this.devMap);
         return html`
-          <select>
+          <select @change="${this.updateVariable}">
+            <option value="">-- Select a Variable --</option>
             ${this.siteVars.map((v) => {
               let parts = v.Name.split(".");
               let dev = this.devMap.get(parts[0]);
@@ -162,12 +232,22 @@ export class CronSettings extends LitElement {
     }
   }
 
-  checkEndpoint(e: Event) {
+  updateEndpoint(e: Event) {
     const select = e.target as HTMLSelectElement;
     this.Variable = select.value;
     if (this.Variable === "other") {
-      this.Variable = (this.shadowRoot?.querySelector("#other-input") as HTMLInputElement).value;
+      let input = this.shadowRoot?.querySelector("#other-input") as HTMLInputElement;
+      if (!input) {
+        return;
+      }
+      this.Variable = input.value;
     }
+    this.requestUpdate();
+  }
+
+  updateVariable(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.Variable = select.value;
     this.requestUpdate();
   }
 }


### PR DESCRIPTION
This change updates the cron page to make it much easier to set a different endpoint for an rpc cron.

To make the cron stay, the broadcast save method needs to be changed so that it checks before just blindly putting a cron.

![image](https://github.com/user-attachments/assets/203de5e0-053c-404c-a93c-f92badebf416)
