### PR TITLE
bench: only add broadcast cron when doesn't exist

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.8.5"
+	version            = "v0.8.6"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This change makes sure we only create the broadcastCheck cron if it doesn't exist already. This ensures that if we've modified the broadcast check cron to hit the testing endpoint we don't overwrite that whenever we save the broadcast config.