### PR TITLE
cmd/ausoceantv: if there is no refresh token, prompt consent

### DIFF
--- a/cmd/ausoceantv/main.go
+++ b/cmd/ausoceantv/main.go
@@ -1,6 +1,8 @@
 /*
 AUTHORS
   Alan Noble <alan@ausocean.org>
+  David Sutton <david@ausocean.org>
+  Trek Hopton <trek@ausocean.org>
 
 LICENSE
   Copyright (C) 2024 the Australian Ocean Lab (AusOcean)
@@ -55,7 +57,7 @@ const (
 	projectID     = "ausoceantv"
 	oauthClientID = "1005382600755-7st09cc91eqcqveviinitqo091dtcmf0.apps.googleusercontent.com"
 	oauthMaxAge   = 60 * 60 * 24 * 7 // 7 days.
-	version       = "v0.5.7"
+	version       = "v0.5.8"
 )
 
 // service defines the properties of our web service.

--- a/gauth/userauth.go
+++ b/gauth/userauth.go
@@ -227,7 +227,7 @@ func (ua *UserAuth) LoginHandler(h backend.Handler) error {
 		hasRefreshToken = true
 	}
 
-	// Build auth URL
+	// Build auth URL.
 	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
 	if !hasRefreshToken {
 		opts = append(opts, oauth2.SetAuthURLParam("prompt", "consent"))

--- a/gauth/userauth.go
+++ b/gauth/userauth.go
@@ -220,11 +220,13 @@ func (ua *UserAuth) LoginHandler(h backend.Handler) error {
 	}
 
 	// Check for refresh token in the user's main session.
-	mainSession, _ := h.LoadSession(ua.SessionID)
-	tok := &oauth2.Token{}
 	hasRefreshToken := false
-	if err := mainSession.Get(oauthTokenSessionKey, &tok); err == nil && tok != nil && tok.RefreshToken != "" {
-		hasRefreshToken = true
+	mainSession, err := h.LoadSession(ua.SessionID)
+	if err == nil {
+		tok := &oauth2.Token{}
+		if err := mainSession.Get(oauthTokenSessionKey, &tok); err == nil && tok != nil && tok.RefreshToken != "" {
+			hasRefreshToken = true
+		}
 	}
 
 	// Build auth URL.


### PR DESCRIPTION
There's no way of getting another refresh token if it's gone for some reason (user clears cookies), so we need to check and prompt for consent if it's missing to get another refresh token. Unless we decide we want to store the refresh tokens in our DB.