### PR TITLE
Bench: Auto Generate default actions (#514)

### DIFF
--- a/cmd/oceanbench/s/broadcast.js
+++ b/cmd/oceanbench/s/broadcast.js
@@ -1,6 +1,9 @@
 var advancedOpts;
 var adv = false;
 
+let camSelect, conSelect
+let prevCamOn, prevCamShutdown, prevCamOff, prevConOn, prevConOff, prevURL
+
 document.addEventListener('DOMContentLoaded', function() {
   document.getElementById('time-zone').value = getTimezone();
   const startTimestamp = document.getElementById('start-timestamp').value;
@@ -40,7 +43,62 @@ document.addEventListener('DOMContentLoaded', function() {
   for (opt of advancedOpts) {
     adv ? document.getElementById("adv-options-toggle").checked = true : opt.style.display = "none";
   }
+
+  camSelect = document.getElementById("camera-select")
+  conSelect = document.getElementById("controller-select")
 });
+
+function generateActions(e) {
+  let onActs = document.getElementById("on-actions")
+  let shutdownActs = document.getElementById("shutdown-actions")
+  let offActs = document.getElementById("off-actions")
+  let rtmpVar = document.getElementById("rtmp-var")
+
+  let con = conSelect.options[conSelect.selectedIndex].value
+  let cam = camSelect.options[camSelect.selectedIndex].value
+
+  console.log("controller:", con)
+  console.log("camera:", cam)
+
+  let conOn = con.toLowerCase().replaceAll(":", "") + ".Power2=true"
+  let conOff = con.toLowerCase().replaceAll(":", "") + ".Power2=false"
+  let camOn = cam.toLowerCase().replaceAll(":", "") + ".mode=normal"
+  let camShutdown = cam.toLowerCase().replaceAll(":", "") + ".mode=shutdown"
+  let camOff = cam.toLowerCase().replaceAll(":", "") + ".mode=paused"
+  let url = cam.toLowerCase().replaceAll(":", "") + ".RTMPURL"
+
+  if (prevConOn != null && con != "Select") {
+    console.log("previous con")
+      onActs.value.replaceAll(prevConOn, conOn)
+      prevConOn = conOn
+      offActs.value.replaceAll(prevConOff, conOff)
+      prevConOff = conOff
+  } else if (con != "Select") {
+      onActs.value += conOn + ","
+      prevConOn = conOn
+      offActs.value += conOff + ","
+      prevConOff = conOff
+  }
+  if (prevCamOn != null && cam != "Select") {
+    onActs.value.replaceAll(prevCamOn, camOn)
+    prevCamOn = camOn
+    shutdownActs.value.replaceAll(prevCamShutdown, camShutdown)
+    prevCamShutdown = camShutdown
+    offActs.value.replaceAll(prevCamOff, camOff)
+    prevCamOff = camOff
+    rtmpVar.value.replaceAll(prevURL, url)
+    prevURL = url
+  } else if (cam != "Select") {
+    onActs.value += camOn + ","
+    prevCamOn = camOn
+    shutdownActs.value += camShutdown + ","
+    prevCamShutdown = camShutdown
+    offActs.value += camOff + ","
+    prevCamOff = camOff
+    rtmpVar.value += url
+    prevURL = url
+  }
+}
 
 function handleSiteChange(event) {
     // Make a request to change site.

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -156,7 +156,7 @@
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="camera-mac" class="w-25 text-end">Camera:</label>
               <div class="w-50 d-flex align-items-center justify-content-between">
-                <select name="camera-mac" class="form-select w-50">
+                <select id="camera-select" name="camera-mac" class="form-select w-50">
                   {{if not .CurrentBroadcast.CameraMac}}
                   <option>Select</option>
                   {{end}} {{range .Cameras}}
@@ -166,7 +166,7 @@
                 <div class="d-flex gap-3 flex-row">
                   {{range .Settings.Resolution}}
                   <div>
-                    <input type="radio" name="resolution" value="{{.}}" {{if eq . $.CurrentBroadcast.Resolution}}checked{{end}} />
+                    <input type="radio" name="resolution" value="{{.}}" checked />
                     {{.}}
                   </div>
                   {{end}}
@@ -175,29 +175,32 @@
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="controller-mac" class="w-25 text-end">Controller:</label>
-              <select name="controller-mac" class="form-select w-50">
-                {{if not .CurrentBroadcast.ControllerMAC}}
-                <option>Select</option>
-                {{end}} {{range .Controllers}}
-                <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.ControllerMAC }}selected{{end}}>{{.Name}}</option>
-                {{ end }}
-              </select>
+              <div class="w-50 d-flex align-items-center justify-content-between">
+                <select id="controller-select" name="controller-mac" class="form-select w-50">
+                  {{if not .CurrentBroadcast.ControllerMAC}}
+                  <option>Select</option>
+                  {{end}} {{range .Controllers}}
+                  <option value="{{.MAC}}" {{if eq .Mac $.CurrentBroadcast.ControllerMAC }}selected{{end}}>{{.Name}}</option>
+                  {{ end }}
+                </select>
+                <button type="button" onclick="generateActions()" class="btn btn-primary">Generate Actions</button>
+              </div>
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="on-actions" class="w-25 text-end">On Actions:</label>
-              <input type="input" name="on-actions" class="form-control w-50" value="{{.CurrentBroadcast.OnActions}}" class="actions" />
+              <input id="on-actions" type="input" name="on-actions" class="form-control w-50" value="{{.CurrentBroadcast.OnActions}}" class="actions" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="shutdown-actions" class="w-25 text-end">Shutdown Actions:</label>
-              <input type="input" name="shutdown-actions" class="form-control w-50" value="{{.CurrentBroadcast.ShutdownActions}}" class="actions" />
+              <input id="shutdown-actions" type="input" name="shutdown-actions" class="form-control w-50" value="{{.CurrentBroadcast.ShutdownActions}}" class="actions" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="off-actions" class="w-25 text-end">Off Actions:</label>
-              <input type="input" name="off-actions" class="form-control w-50" value="{{.CurrentBroadcast.OffActions}}" class="actions" />
+              <input id="off-actions" type="input" name="off-actions" class="form-control w-50" value="{{.CurrentBroadcast.OffActions}}" class="actions" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label for="rtmp-key-var" class="w-25 text-end">RTMP URL Variable:</label>
-              <input type="input" name="rtmp-key-var" class="w-50 form-control" value="{{.CurrentBroadcast.RTMPVar}}" />
+              <input id="rtmp-var" type="input" name="rtmp-key-var" class="w-50 form-control" value="{{.CurrentBroadcast.RTMPVar}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
               <label class="advanced w-25 text-end">RTMP Key:</label>


### PR DESCRIPTION
This change adds a button which will auto-generate the default actions for a controller and a camera, which are typically the only variables used. This reduces the chance of an error, whilst also decreasing the time to setup a broadcast.

This change also sets the default resolution to 1080p

NOTE: Neither of these fixes are pretty, but they are simple to implement and will hopefully save a lot of time.

![image](https://github.com/user-attachments/assets/56883005-bb8f-4b7f-8977-684db68a1489)
