### PR TITLE
OTV: Don't notify with no shutdown actions

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -562,7 +562,12 @@ func (s *hardwareStopping) handleTimeEvent(t timeEvent) {
 func (s *hardwareStopping) handleHardwareShutdownFailedEvent(event hardwareShutdownFailedEvent) {
 	switch s.Substate.(type) {
 	case *hardwareShuttingDown:
-		s.logAndNotify(broadcastHardware, "shutdown failed during hardware stop, skipping to power off: %v", event.Error())
+		// Don't notify if there were no shutdown actions.
+		if errors.Is(event, errNoShutdownActions) {
+			s.log("no shutdowns to perform, transitioning to powering off")
+		} else {
+			s.logAndNotify(broadcastHardware, "shutdown failed during hardware stop, skipping to power off: %v", event.Error())
+		}
 		s.transition()
 	default:
 		// Ignore.

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.8.5"
+	version            = "v0.8.6"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This change stops a notification if the reason that the shutdown failed was due to there being no shutdown actions provided. This was done so that if cameras are not configured correctly to shutdown that we won't get notified every time that it turns off if we don't set any shutdown actions.

closes #529 