### PR TITLE
otv: check there's no YouTube broadcast if not enabled

### DIFF
--- a/cmd/oceantv/broadcast/youtube.go
+++ b/cmd/oceantv/broadcast/youtube.go
@@ -55,6 +55,7 @@ import (
 const (
 	StatusComplete = "complete"
 	StatusRevoked  = "revoked"
+	StatusLive     = "live"
 )
 
 // Misc constants.

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -44,6 +44,7 @@ const (
 	broadcastNetwork       notify.Kind = "broadcast-network"       // Problems related to bad bandwidth, generally indicated by bad health events.
 	broadcastSoftware      notify.Kind = "broadcast-software"      // Problems related to the functioning of our broadcast software.
 	broadcastConfiguration notify.Kind = "broadcast-configuration" // Problems related to the configuration of the broadcast.
+	broadcastService       notify.Kind = "broadcast-service"       // Problems related to the broadcast service e.g. YouTube API issues.
 )
 
 var errNoGlobalNotifier = errors.New("global notifier is nil")

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.8.5"
+	version            = "v0.8.6"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
Occasionally we were getting into a situation where a broadcast would be disabled but the YouTube broadcast object would still be broadcasting. This ensures this doesn't happen by checking that there are no live broadcast YouTube objects associated.