### PR TITLE
otv: enable state/event based webhooks

### DIFF
--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -34,6 +34,12 @@ var _ = registerEvent(finishEvent{})
 
 func (e finishEvent) String() string { return "finishEvent" }
 
+type finishedEvent struct{}
+
+var _ = registerEvent(finishedEvent{})
+
+func (e finishedEvent) String() string { return "finishedEvent" }
+
 type startEvent struct{}
 
 var _ = registerEvent(startEvent{})

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -39,7 +39,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "vidforwardSecondaryLive with time after End",
 			initialState:   newVidforwardSecondaryLive(bCtx),
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
-			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
 			cfg: &BroadcastConfig{
 				Start: now,
@@ -50,7 +50,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "directLive with time after End",
 			initialState:   newDirectLive(bCtx),
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
-			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
 			cfg: &BroadcastConfig{
 				Start: now,
@@ -83,7 +83,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "directLiveUnhealthy with time after End",
 			initialState:   newDirectLiveUnhealthy(bCtx),
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
-			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
 			cfg: &BroadcastConfig{
 				Start: now,
@@ -394,7 +394,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "vidforwardSecondaryLive before start",
 			initialState:   newVidforwardSecondaryLive(bCtx),
 			event:          timeEvent{now.Add(5 * time.Minute)},
-			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
 			cfg: &BroadcastConfig{
 				Start: now.Add(10 * time.Minute),
@@ -405,7 +405,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "directLive before start",
 			initialState:   newDirectLive(bCtx),
 			event:          timeEvent{now.Add(5 * time.Minute)},
-			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
 			cfg: &BroadcastConfig{
 				Start: now.Add(10 * time.Minute),
@@ -438,7 +438,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "directLiveUnhealthy before start",
 			initialState:   newDirectLiveUnhealthy(bCtx),
 			event:          timeEvent{now.Add(5 * time.Minute)},
-			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
 			cfg: &BroadcastConfig{
 				Start: now.Add(10 * time.Minute),
@@ -525,7 +525,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			desc:           "directStarting timed out",
 			initialState:   &directStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now)},
 			event:          timeEvent{now.Add(11 * time.Minute)},
-			expectedEvents: []event{timeEvent{}, startFailedEvent{}, hardwareStopRequestEvent{}},
+			expectedEvents: []event{timeEvent{}, startFailedEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
 			cfg:            &BroadcastConfig{},
 		},
@@ -1376,6 +1376,7 @@ func TestHandleCameraConfiguration(t *testing.T) {
 				startEvent{},
 				hardwareStartRequestEvent{},
 				invalidConfigurationEvent{},
+				finishedEvent{},
 				hardwareStopRequestEvent{},
 			},
 			expectedLogs: []string{
@@ -1611,7 +1612,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 						hardwareStartRequestEvent{},
 						lowVoltageEvent{},
 					}, timeEvents(241)...), // Time events to account for charging time.
-				[]event{hardwareStartFailedEvent{}, startFailedEvent{}, hardwareStopRequestEvent{}}...,
+				[]event{hardwareStartFailedEvent{}, startFailedEvent{}, finishedEvent{}, hardwareStopRequestEvent{}}...,
 			),
 			expectedLogs:   []string{},
 			expectedNotify: map[int64]map[notify.Kind][]string{},
@@ -1642,7 +1643,9 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 				hardwareStartRequestEvent{},
 				controllerFailureEvent{},
 				criticalFailureEvent{},
+				finishedEvent{},
 				hardwareStopRequestEvent{},
+				finishedEvent{},
 				hardwareStopRequestEvent{},
 			},
 			expectedLogs:   []string{},

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -30,7 +30,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -199,18 +198,6 @@ func (m *OceanBroadcastManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, sv
 		err := svc.CompleteBroadcast(ctx, cfg.ID)
 		if err != nil {
 			return fmt.Errorf("could not complete broadcast: %w", err)
-		}
-
-		if cfg.RegisterOpenFish {
-			// Register stream with openfish so we can annotate the video.
-			cs, err := strconv.Atoi(cfg.OpenFishCaptureSource)
-			if err != nil {
-				return fmt.Errorf("bad capturesource ID: %w", err)
-			}
-			err = ofsvc.RegisterStream(cfg.SID, cs, cfg.Start, cfg.End)
-			if err != nil {
-				return fmt.Errorf("register stream with openfish error: %w", err)
-			}
 		}
 	}
 

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -358,7 +358,12 @@ func newVidforwardSecondaryLive(ctx *broadcastContext) *vidforwardSecondaryLive 
 	return &vidforwardSecondaryLive{broadcastContext: ctx}
 }
 func (s *vidforwardSecondaryLive) exit() {
-	try(s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc), "could not stop broadcast exiting secondary live", s.log)
+	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
+	if err != nil {
+		s.log("could not stop broadcast on exit: %v", err)
+		return
+	}
+	s.bus.publish(finishedEvent{})
 }
 
 type vidforwardSecondaryLiveUnhealthy struct {
@@ -478,7 +483,12 @@ type directIdle struct {
 
 func newDirectIdle(ctx *broadcastContext) *directIdle { return &directIdle{broadcastContext: ctx} }
 func (s *directIdle) enter() {
-	try(s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc), "could not stop broadcast on direct idle entry", s.log)
+	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
+	if err != nil {
+		s.log("could not stop broadcast on entry: %v", err)
+	} else {
+		s.bus.publish(finishedEvent{})
+	}
 	s.bus.publish(hardwareStopRequestEvent{})
 }
 
@@ -491,7 +501,12 @@ func newDirectFailure(ctx *broadcastContext) *directFailure {
 	return &directFailure{broadcastContext: ctx}
 }
 func (s *directFailure) enter() {
-	try(s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc), "could not stop broadcast on direct failure entry", s.log)
+	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
+	if err != nil {
+		s.log("could not stop broadcast on entry: %v", err)
+	} else {
+		s.bus.publish(finishedEvent{})
+	}
 	s.bus.publish(hardwareStopRequestEvent{})
 }
 


### PR DESCRIPTION
This change provides the option to add event or state based webhooks (or any other sort of hook for that matter). This is is motivated by the desire for services such as AusOceanTV and OpenFish to have an awareness of broadcast events and states.

We have done this by using options to an oceantv service, which then propagates these hooks to the state machine.

closes #526