### PR TITLE
otv: store error in directFailure state

### DIFF
--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -58,11 +58,12 @@ var _ = registerEvent(startFailedEvent{})
 
 func (e startFailedEvent) String() string { return "startFailedEvent" }
 
-type criticalFailureEvent struct{}
+type criticalFailureEvent struct{ string }
 
 var _ = registerEvent(criticalFailureEvent{})
 
 func (e criticalFailureEvent) String() string { return "criticalFailureEvent" }
+func (e criticalFailureEvent) Error() string  { return e.string }
 
 type healthCheckDueEvent struct{}
 

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -235,7 +235,7 @@ func (sm *broadcastStateMachine) handleCriticalFailureEvent(event criticalFailur
 		// will subsequently be in a failure state.
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
 	case *directStarting:
-		sm.transition(newDirectFailure(sm.ctx))
+		sm.transition(newDirectFailure(sm.ctx, event))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -309,6 +310,11 @@ func TestBroadcastCfgToState(t *testing.T) {
 			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
 			want: newDirectStarting(ctx),
 		},
+		{
+			name: "Direct Failure",
+			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false, InFailure: true},
+			want: newDirectFailure(ctx, nil),
+		},
 	}
 
 	for _, tt := range tests {
@@ -446,6 +452,13 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 			s:    &directIdle{broadcastContext: ctx},
 			equal: func(a, b state) bool {
 				return true
+			},
+		},
+		{
+			desc: "directFailure",
+			s:    &directFailure{broadcastContext: ctx, err: errors.New("test error")},
+			equal: func(a, b state) bool {
+				return a.(*directFailure).err.Error() == b.(*directFailure).err.Error()
 			},
 		},
 	}

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.9.0"
+	version            = "v0.9.1"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This allows us to know why we're in the direct failure state in the first place.