### PR TITLE
otv: improve error event handling

### DIFF
--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -1,15 +1,26 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"context"
 
 	"github.com/ausocean/cloud/cmd/oceantv/registry"
+	"github.com/ausocean/cloud/notify"
 )
 
 type event interface{ fmt.Stringer }
+
+type errorEvent interface {
+	event
+	error
+	registry.Newable
+	Kind() notify.Kind
+}
 
 // registerEvent registers an event in the registry.
 // It returns a struct{} to allow us to register the event in a var declaration in
@@ -52,18 +63,63 @@ var _ = registerEvent(startedEvent{})
 
 func (e startedEvent) String() string { return "startedEvent" }
 
-type startFailedEvent struct{}
+type startFailedEvent struct{ error }
 
 var _ = registerEvent(startFailedEvent{})
 
 func (e startFailedEvent) String() string { return "startFailedEvent" }
+func (e startFailedEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
 
-type criticalFailureEvent struct{ string }
+// Kind implements the errorEvent interface.
+func (e startFailedEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastGeneric
+}
+
+// criticalFailureEvent is really a non recoverable start failure event.
+type criticalFailureEvent struct{ error }
 
 var _ = registerEvent(criticalFailureEvent{})
 
 func (e criticalFailureEvent) String() string { return "criticalFailureEvent" }
-func (e criticalFailureEvent) Error() string  { return e.string }
+func (e criticalFailureEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e criticalFailureEvent) New(args ...any) (any, error) {
+	var err error = nil
+	if len(args) != 0 {
+		err = args[0].(error)
+	}
+	return criticalFailureEvent{err}, nil
+}
+
+// Kind implements the errorEvent interface.
+func (e criticalFailureEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastGeneric
+}
 
 type healthCheckDueEvent struct{}
 
@@ -113,19 +169,65 @@ var _ = registerEvent(hardwareResetRequestEvent{})
 
 func (e hardwareResetRequestEvent) String() string { return "hardwareResetRequestEvent" }
 
-type hardwareStartFailedEvent struct{ string }
+type hardwareStartFailedEvent struct{ error }
 
 var _ = registerEvent(hardwareStartFailedEvent{})
 
 func (e hardwareStartFailedEvent) String() string { return "hardwareStartFailedEvent" }
-func (e hardwareStartFailedEvent) Error() string  { return e.string }
+func (e hardwareStartFailedEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e hardwareStartFailedEvent) New(args ...any) (any, error) {
+	var err error = nil
+	if len(args) != 0 {
+		err = args[0].(error)
+	}
+	return hardwareStartFailedEvent{err}, nil
+}
+func (e hardwareStartFailedEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
 
-type hardwareStopFailedEvent struct{ string }
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastHardware
+}
+
+type hardwareStopFailedEvent struct{ error }
 
 var _ = registerEvent(hardwareStopFailedEvent{})
 
 func (e hardwareStopFailedEvent) String() string { return "hardwareStopFailedEvent" }
-func (e hardwareStopFailedEvent) Error() string  { return e.string }
+func (e hardwareStopFailedEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e hardwareStopFailedEvent) New(args ...any) (any, error) {
+	var err error = nil
+	if len(args) != 0 {
+		err = args[0].(error)
+	}
+	return hardwareStopFailedEvent{err}, nil
+}
+func (e hardwareStopFailedEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastHardware
+}
 
 type hardwareStartedEvent struct{}
 
@@ -139,12 +241,31 @@ var _ = registerEvent(hardwareStoppedEvent{})
 
 func (e hardwareStoppedEvent) String() string { return "hardwareStoppedEvent" }
 
-type controllerFailureEvent struct{ string }
+type controllerFailureEvent struct{ error }
 
 var _ = registerEvent(controllerFailureEvent{})
 
 func (e controllerFailureEvent) String() string { return "controllerFailureEvent" }
-func (e controllerFailureEvent) Error() string  { return e.string }
+func (e controllerFailureEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e controllerFailureEvent) New(args ...any) (any, error) {
+	return controllerFailureEvent{args[0].(error)}, nil
+}
+func (e controllerFailureEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastHardware
+}
 
 type slateResetRequested struct{}
 
@@ -158,12 +279,35 @@ var _ = registerEvent(fixFailureEvent{})
 
 func (e fixFailureEvent) String() string { return "fixFailureEvent" }
 
-type invalidConfigurationEvent struct{ desc string }
+type invalidConfigurationEvent struct{ error }
 
 var _ = registerEvent(invalidConfigurationEvent{})
 
 func (e invalidConfigurationEvent) String() string { return "invalidConfigurationEvent" }
-func (e invalidConfigurationEvent) Error() string  { return e.desc }
+func (e invalidConfigurationEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e invalidConfigurationEvent) New(args ...any) (any, error) {
+	var err error = nil
+	if len(args) != 0 {
+		err = args[0].(error)
+	}
+	return invalidConfigurationEvent{err}, nil
+}
+func (e invalidConfigurationEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastConfiguration
+}
 
 type lowVoltageEvent struct{}
 
@@ -225,11 +369,71 @@ func (bus *basicEventBus) publish(event event) {
 	}
 }
 
+// unwrapErrEvent recursively unwraps the error and returns the last errorEvent
+// found in the chain.
+func unwrapErrEvent(err error, last errorEvent) errorEvent {
+	if unwrapped := errors.Unwrap(err); unwrapped != nil {
+		if unwrappedErrEvent, ok := unwrapped.(errorEvent); ok {
+			last = unwrappedErrEvent
+		}
+		return unwrapErrEvent(unwrapped, last)
+	}
+	return last
+}
+
 // stringToEvent returns an event given its name.
-func stringToEvent(name string) event {
-	e, err := registry.Get(name)
+func stringToEvent(name string, args ...interface{}) event {
+	e, err := registry.Get(name, args...)
 	if err != nil {
 		panic(fmt.Errorf("could not get event for string %s: %w", name, err))
 	}
 	return e.(event)
+}
+
+func marshalEvent(event event) []byte {
+	alias := struct {
+		Name string
+		Err  string
+	}{Name: event.String()}
+
+	if errEvent, ok := event.(error); ok {
+		// Trim event name from error string, this format is expected.
+		after, found := strings.CutPrefix(errEvent.Error(), "("+event.String()+") ")
+		if !found {
+			panic(fmt.Sprintf("event Error() does not have correct format, want: (<event name>) <error message>, got: %s", errEvent.Error()))
+		}
+
+		alias.Err = after
+	}
+
+	eventData, err := json.Marshal(alias)
+	if err != nil {
+		panic(fmt.Sprintf("could not marshal event: %v", err))
+	}
+
+	return eventData
+}
+
+func unmarshalEvent(eventData string) event {
+	alias := struct {
+		Name string
+		Err  error
+	}{}
+
+	err := json.Unmarshal([]byte(eventData), &alias)
+	if err != nil {
+		panic(fmt.Sprintf("could not unmarshal event: %v", err))
+	}
+
+	event := stringToEvent(alias.Name, alias.Err)
+
+	if _, ok := event.(error); alias.Err != nil && !ok {
+		panic(fmt.Sprintf("have error data for event: %s, but event is not an error: %T", alias.Name, event))
+	}
+
+	if _, ok := event.(registry.Newable); alias.Err != nil && !ok {
+		panic("have error data for event but can't New with data because not Newable")
+	}
+
+	return event
 }

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ausocean/cloud/cmd/oceantv/registry"
 	"github.com/ausocean/cloud/model"
+	"github.com/ausocean/cloud/notify"
 )
 
 func register(state registry.Named) struct{} {
@@ -152,7 +153,7 @@ func (s *hardwareRestarting) handleTimeEvent(t timeEvent) {
 	case *hardwareStopping:
 		withTimeout := s.Substate.(stateWithTimeout)
 		if withTimeout.timedOut(t.Time) {
-			s.bus.publish(hardwareStopFailedEvent{"hardware stop timed out"})
+			s.bus.publish(hardwareStopFailedEvent{errors.New("hardware stop timed out")})
 			return
 		}
 
@@ -160,7 +161,7 @@ func (s *hardwareRestarting) handleTimeEvent(t timeEvent) {
 	case *hardwareStarting:
 		withTimeout := s.Substate.(stateWithTimeout)
 		if withTimeout.timedOut(t.Time) {
-			s.bus.publish(hardwareStartFailedEvent{"exceeded starting timeout during hardware restart"})
+			s.bus.publish(hardwareStartFailedEvent{errors.New("exceeded starting timeout during hardware restart")})
 			return
 		}
 
@@ -199,7 +200,7 @@ func (s *hardwareRestarting) handleHardwareShutdownFailedEvent(event hardwareShu
 func (s *hardwareRestarting) cameraIsReporting() bool {
 	up, err := s.camera.isUp(s.broadcastContext, model.MacDecode(s.cfg.CameraMac))
 	if err != nil {
-		s.bus.publish(invalidConfigurationEvent{fmt.Sprintf("could not get camera reporting status: %v", err)})
+		s.bus.publish(invalidConfigurationEvent{fmt.Errorf("could not get camera reporting status: %w", err)})
 		return false
 	}
 	return up
@@ -234,32 +235,32 @@ func (s *hardwareStarting) enter() {
 
 	voltage, err := s.camera.voltage(s.broadcastContext)
 	if err != nil {
-		msg := fmt.Sprintf("could not get hardware voltage: %v", err)
-		s.log(msg)
-		s.bus.publish(invalidConfigurationEvent{msg})
+		errWrapped := fmt.Errorf("could not get hardware voltage: %w", err)
+		s.log(errWrapped.Error())
+		s.bus.publish(invalidConfigurationEvent{errWrapped})
 		return
 	}
 
 	alarmVoltage, err := s.camera.alarmVoltage(s.broadcastContext)
 	if err != nil {
-		msg := fmt.Sprintf("could not get alarm voltage: %v", err)
-		s.log(msg)
-		s.bus.publish(invalidConfigurationEvent{msg})
+		errWrapped := fmt.Errorf("could not get alarm voltage: %w", err)
+		s.log(errWrapped.Error())
+		s.bus.publish(invalidConfigurationEvent{errWrapped})
 		return
 	}
 
 	controllerIsOn, err := s.camera.isUp(s.broadcastContext, model.MacDecode(s.cfg.ControllerMAC))
 	if err != nil {
-		msg := fmt.Sprintf("could not get controller status: %v", err)
-		s.log(msg)
-		s.bus.publish(invalidConfigurationEvent{msg})
+		errWrapped := fmt.Errorf("could not get controller status: %w", err)
+		s.log(errWrapped.Error())
+		s.bus.publish(invalidConfigurationEvent{errWrapped})
 		return
 	}
 
 	if voltage <= alarmVoltage {
 		if controllerIsOn {
 			s.log("voltage less than alarm voltage but controller is on, something is configured incorrectly")
-			s.bus.publish(invalidConfigurationEvent{"voltage less than alarm voltage but controller is on"})
+			s.bus.publish(invalidConfigurationEvent{errors.New("voltage less than alarm voltage but controller is on")})
 			return
 		}
 		s.log("controller voltage is low, waiting for recovery before starting")
@@ -340,12 +341,37 @@ func sanatisedVoltageRecoveryTimeout(ctx *broadcastContext) int {
 	return ctx.cfg.VoltageRecoveryTimeout
 }
 
-type hardwareShutdownFailedEvent struct{ string }
+type hardwareShutdownFailedEvent struct{ error }
 
 var _ = registerEvent(hardwareShutdownFailedEvent{})
 
 func (e hardwareShutdownFailedEvent) String() string { return "hardwareShutdownFailedEvent" }
-func (e hardwareShutdownFailedEvent) Error() string  { return e.string }
+func (e hardwareShutdownFailedEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e hardwareShutdownFailedEvent) New(args ...any) (any, error) {
+	var err error = nil
+	if len(args) != 0 {
+		err = args[0].(error)
+	}
+	return hardwareShutdownFailedEvent{err}, nil
+}
+
+// Kind implements the errorEvent interface.
+func (e hardwareShutdownFailedEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastHardware
+}
 
 type hardwareShutdownEvent struct{}
 
@@ -376,12 +402,37 @@ func (s *hardwareShuttingDown) enter() {
 }
 func (s *hardwareShuttingDown) exit() {}
 
-type hardwarePowerOffFailedEvent struct{ string }
+type hardwarePowerOffFailedEvent struct{ error }
 
 var _ = registerEvent(hardwarePowerOffFailedEvent{})
 
 func (e hardwarePowerOffFailedEvent) String() string { return "hardwarePowerOffFailedEvent" }
-func (e hardwarePowerOffFailedEvent) Error() string  { return e.string }
+func (e hardwarePowerOffFailedEvent) Error() string {
+	if e.error == nil {
+		return "(" + e.String() + ") <nil>"
+	}
+	return "(" + e.String() + ") " + e.error.Error()
+}
+func (e hardwarePowerOffFailedEvent) New(args ...any) (any, error) {
+	var err error = nil
+	if len(args) != 0 {
+		err = args[0].(error)
+	}
+	return hardwarePowerOffFailedEvent{err}, nil
+}
+
+// Kind implements the errorEvent interface.
+func (e hardwarePowerOffFailedEvent) Kind() notify.Kind {
+	if errEvent, ok := e.error.(errorEvent); ok {
+		return errEvent.Kind()
+	}
+
+	if unwrapped := unwrapErrEvent(e.error, nil); unwrapped != nil {
+		return unwrapped.Kind()
+	}
+
+	return broadcastHardware
+}
 
 type hardwarePoweringOff struct {
 	stateWithTimeoutFields
@@ -527,7 +578,7 @@ func (s *hardwareStopping) handleTimeEvent(t timeEvent) {
 		s.log("(hardwareStopping) handling timeEvent in hardwareStopping state: substate is hardwareShuttingDown")
 		withTimeout := s.Substate.(stateWithTimeout)
 		if withTimeout.timedOut(t.Time) {
-			s.bus.publish(hardwareShutdownFailedEvent{"hardware shutdown timed out"})
+			s.bus.publish(hardwareShutdownFailedEvent{errors.New("hardware shutdown timed out")})
 			return
 		}
 
@@ -542,7 +593,7 @@ func (s *hardwareStopping) handleTimeEvent(t timeEvent) {
 		s.log("(hardwareStopping) handling timeEvent in hardwareStopping state: substate is hardwarePoweringOff")
 		withTimeout := s.Substate.(stateWithTimeout)
 		if withTimeout.timedOut(t.Time) {
-			s.bus.publish(hardwarePowerOffFailedEvent{"hardware power off timed out"})
+			s.bus.publish(hardwarePowerOffFailedEvent{errors.New("hardware power off timed out")})
 			return
 		}
 
@@ -572,7 +623,7 @@ func (s *hardwareStopping) handleHardwareShutdownFailedEvent(event hardwareShutd
 func (s *hardwareStopping) cameraIsReporting() bool {
 	up, err := s.camera.isUp(s.broadcastContext, model.MacDecode(s.cfg.CameraMac))
 	if err != nil {
-		s.bus.publish(invalidConfigurationEvent{fmt.Sprintf("could not get camera reporting status: %v", err)})
+		s.bus.publish(invalidConfigurationEvent{fmt.Errorf("could not get camera reporting status: %w", err)})
 		return false
 	}
 	return up
@@ -610,18 +661,32 @@ func newHardwareOff() *hardwareOff { return &hardwareOff{} }
 func (s *hardwareOff) enter()      {}
 func (s *hardwareOff) exit()       {}
 
-type hardwareFailure struct{ reason string }
+type hardwareFailure struct{ err error }
 
 var _ = register(hardwareFailure{})
 
-func newHardwareFailure(reason string) *hardwareFailure { return &hardwareFailure{reason} }
+func newHardwareFailure(err error) *hardwareFailure { return &hardwareFailure{err} }
 
 func (s hardwareFailure) Name() string { return "hardwareFailure" }
+
+func (s hardwareFailure) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct{ Err string }{Err: s.err.Error()})
+}
+
+func (s *hardwareFailure) UnmarshalJSON(data []byte) error {
+	aux := struct{ Err string }{}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	s.err = errors.New(aux.Err)
+	return nil
+}
 
 // New implements registry.Newable for creating a fresh value of
 // hardwareFailure from an existing value.
 func (s hardwareFailure) New(args ...interface{}) (any, error) {
-	return newableWithContext(func(ctx *broadcastContext) any { return newHardwareFailure("") }, args...)
+	return newableWithContext(func(ctx *broadcastContext) any { return newHardwareFailure(nil) }, args...)
 }
 func (s *hardwareFailure) enter() {}
 func (s *hardwareFailure) exit()  {}
@@ -705,7 +770,7 @@ func (sm *hardwareStateMachine) handleTimeEvent(t timeEvent) {
 	case *hardwareStarting:
 		withTimeout := sm.currentState.(stateWithTimeout)
 		if withTimeout.timedOut(t.Time) {
-			sm.ctx.bus.publish(hardwareStartFailedEvent{})
+			sm.ctx.bus.publish(hardwareStartFailedEvent{errors.New("exceed timeout during hardware starting")})
 			sm.transition(newHardwareOff())
 			return
 		}
@@ -717,17 +782,16 @@ func (sm *hardwareStateMachine) handleTimeEvent(t timeEvent) {
 	case *hardwareRecoveringVoltage:
 		withTimeout := sm.currentState.(stateWithTimeout)
 		if withTimeout.timedOut(t.Time) {
-			sm.ctx.logAndNotify(broadcastHardware, "voltage recovery timed out")
-			sm.ctx.bus.publish(hardwareStartFailedEvent{})
+			sm.ctx.bus.publish(hardwareStartFailedEvent{errors.New("voltage recovery timed out")})
 			sm.transition(newHardwareOff())
 			return
 		}
 
 		voltage, err := sm.ctx.camera.voltage(sm.ctx)
 		if err != nil {
-			msg := fmt.Sprintf("could not get hardware voltage: %v", err)
-			sm.log(msg)
-			sm.ctx.bus.publish(invalidConfigurationEvent{msg})
+			errWrapped := fmt.Errorf("could not get hardware voltage: %v", err)
+			sm.log(errWrapped.Error())
+			sm.ctx.bus.publish(invalidConfigurationEvent{errWrapped})
 			return
 		}
 
@@ -782,7 +846,7 @@ func (sm *hardwareStateMachine) handleHardwareStopFailedEvent(event hardwareStop
 	switch sm.currentState.(type) {
 	case *hardwareStopping, *hardwareRestarting:
 		sm.log("handling hardware stop failed event")
-		sm.transition(newHardwareFailure(fmt.Sprintf("hardware stop failed: %v", event.Error())))
+		sm.transition(newHardwareFailure(event))
 	}
 }
 
@@ -790,7 +854,7 @@ func (sm *hardwareStateMachine) handleHardwareStartFailedEvent(event hardwareSta
 	switch sm.currentState.(type) {
 	case *hardwareStarting, *hardwareRestarting:
 		sm.log("handling hardware start failed event")
-		sm.transition(newHardwareFailure(fmt.Sprintf("hardware start failed: %v", event.Error())))
+		sm.transition(newHardwareFailure(event))
 	}
 }
 
@@ -850,7 +914,7 @@ func (sm *hardwareStateMachine) handleHardwareResetRequestEvent(event hardwareRe
 }
 
 func (sm *hardwareStateMachine) handleControllerFailureEvent(event controllerFailureEvent) {
-	sm.transition(newHardwareFailure(fmt.Sprintf("got controller failure event: %v", event.Error())))
+	sm.transition(newHardwareFailure(event))
 }
 
 func (sm *hardwareStateMachine) handleLowVoltageEvent(event lowVoltageEvent) {
@@ -913,13 +977,13 @@ func (c *revidCameraClient) voltage(ctx *broadcastContext) (float64, error) {
 	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
 	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.cfg.ControllerMAC, ctx.cfg.BatteryVoltagePin)
 	if err != nil {
-		return 0, fmt.Errorf("could not get battery voltage sensor (%s.%s): %v", model.MacDecode(ctx.cfg.ControllerMAC), ctx.cfg.BatteryVoltagePin, err)
+		return 0, fmt.Errorf("could not get battery voltage sensor (%s.%s): %w", model.MacDecode(ctx.cfg.ControllerMAC), ctx.cfg.BatteryVoltagePin, err)
 	}
 
 	// Get current battery voltage.
 	voltage, err := model.GetSensorValue(context.Background(), ctx.store, sensor)
 	if err != nil {
-		return 0, fmt.Errorf("could not get current battery voltage: %v", err)
+		return 0, fmt.Errorf("could not get current battery voltage: %w", err)
 	}
 	return voltage, nil
 }
@@ -930,13 +994,13 @@ func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error)
 	controllerMACHex := (&model.Device{Mac: ctx.cfg.ControllerMAC}).Hex()
 	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, controllerMACHex+".AlarmVoltage")
 	if err != nil {
-		return 0, fmt.Errorf("could not get alarm voltage variable: %v", err)
+		return 0, fmt.Errorf("could not get alarm voltage variable: %w", err)
 	}
 	ctx.log("got AlarmVoltage for %s: %s", controllerMACHex, alarmVoltageVar.Value)
 
 	uncalibratedAlarmVoltage, err := strconv.Atoi(alarmVoltageVar.Value)
 	if err != nil {
-		return 0, fmt.Errorf("could not convert uncalibrated alarm voltage from string: %v", err)
+		return 0, fmt.Errorf("could not convert uncalibrated alarm voltage from string: %w", err)
 	}
 
 	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
@@ -947,13 +1011,13 @@ func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error)
 	}
 	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.cfg.ControllerMAC, batteryVoltagePin)
 	if err != nil {
-		return 0, fmt.Errorf("could not get battery voltage sensor: %v", err)
+		return 0, fmt.Errorf("could not get battery voltage sensor: %w", err)
 	}
 
 	// Transform the alarm voltage to the actual voltage.
 	alarmVoltage, err := sensor.Transform(float64(uncalibratedAlarmVoltage))
 	if err != nil {
-		return 0, fmt.Errorf("could not transform alarm voltage: %v", err)
+		return 0, fmt.Errorf("could not transform alarm voltage: %w", err)
 	}
 
 	return alarmVoltage, nil
@@ -962,7 +1026,7 @@ func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error)
 func (c *revidCameraClient) isUp(ctx *broadcastContext, mac string) (bool, error) {
 	deviceIsUp, err := model.DeviceIsUp(context.Background(), ctx.store, mac)
 	if err != nil {
-		return false, fmt.Errorf("could not get controller status: %v", err)
+		return false, fmt.Errorf("could not get controller status: %w", err)
 	}
 	return deviceIsUp, nil
 }
@@ -971,7 +1035,7 @@ func (c *revidCameraClient) start(ctx *broadcastContext) {
 	err := extStart(context.Background(), ctx.cfg, ctx.log)
 	if err != nil {
 		ctx.log("could not start external hardware: %v", err)
-		ctx.bus.publish(hardwareStartFailedEvent{})
+		ctx.bus.publish(hardwareStartFailedEvent{fmt.Errorf("external hardware start actions failed: %w", err)})
 		return
 	}
 }
@@ -979,8 +1043,7 @@ func (c *revidCameraClient) start(ctx *broadcastContext) {
 func (c *revidCameraClient) shutdown(ctx *broadcastContext) {
 	err := extShutdown(context.Background(), ctx.cfg, ctx.log)
 	if err != nil {
-		ctx.log("could not shutdown external hardware: %v", err)
-		ctx.bus.publish(hardwareShutdownFailedEvent{err.Error()})
+		ctx.bus.publish(hardwareShutdownFailedEvent{fmt.Errorf("could not perform shutdown actions: %w", err)})
 		return
 	}
 }
@@ -989,15 +1052,14 @@ func (c *revidCameraClient) stop(ctx *broadcastContext) {
 	err := extStop(context.Background(), ctx.cfg, ctx.log)
 	if err != nil {
 		ctx.log("could not stop external hardware: %v", err)
-		ctx.bus.publish(hardwareStopFailedEvent{})
+		ctx.bus.publish(hardwareStopFailedEvent{fmt.Errorf("could not perform stop actions: %w", err)})
 		return
 	}
 }
 
 func (c *revidCameraClient) publishEventIfStatus(ctx *broadcastContext, event event, status bool, mac int64, store Store, log func(string, ...interface{}), publish func(event event)) {
 	if mac == 0 {
-		log("camera is not set in configuration")
-		publish(invalidConfigurationEvent{"camera mac is empty"})
+		publish(invalidConfigurationEvent{errors.New("camera mac is empty")})
 		return
 	}
 	log("checking status of device with mac: %d", mac)

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -620,7 +620,12 @@ func TestHardwareStopAndRestart(t *testing.T) {
 				}
 
 				if tick > maxTicks {
-					t.Errorf("failed to reach expected state after %d ticks", maxTicks)
+					t.Errorf(
+						"failed to reach expected state after %d ticks, current state: %s, wanted state: %s",
+						maxTicks,
+						stateToString(sys.hsm.currentState),
+						stateToString(tt.finalHardwareState),
+					)
 					return
 				}
 

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -27,6 +27,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -440,13 +441,12 @@ func (h *dummyHardwareManager) stop(ctx *broadcastContext) {
 }
 func (h *dummyHardwareManager) publishEventIfStatus(ctx *broadcastContext, event event, status bool, mac int64, store Store, log func(format string, args ...interface{}), publish func(event event)) {
 	if h.checkMAC && mac == 0 {
-		log("camera is not set in configuration")
-		publish(invalidConfigurationEvent{"camera mac is empty"})
+		publish(invalidConfigurationEvent{errors.New("camera mac is empty")})
 		return
 	}
 	up, err := h.isUp(ctx, model.MacDecode(mac))
 	if err != nil {
-		publish(invalidConfigurationEvent{fmt.Sprintf("could not get device: %v", err)})
+		publish(invalidConfigurationEvent{fmt.Errorf("could not get device: %w", err)})
 		return
 	}
 

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.9.1"
+	version            = "v0.9.2"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
The intention here is to improve the function of events that represent erroneous conditions and make error information more available and clearer. We're also trying to use more consistent patterns around error conditions, and do more central notification on these error events.

Events representing erroneous conditions are errors themselves. They also hold errors instead of basic strings. This means we can chain error events/errors and maintain a history of the errors that led us to where we are. As such we have unwrapping functionality to find the initial error event type. We've also added a Kind() method to the interface that gives us the corresponding notify.Kind so that we can perform a notification of the correct kind.

Finally we've fixed some fundemental issues around storing events for processing; we weren't properly storing the error events internal error information, and would therefore loose this on the next SM tick.