### PR TITLE
bench: fix TestGetScalars panic

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -55,3 +55,8 @@ cmd/ausoceantv/.git
 cmd/ausoceantv/.gitignore
 cmd/ausoceantv/node_modules/
 cmd/ausoceantv/webapp/node_modules/
+
+cmd/decode/*
+cmd/cloudblue/*
+cmd/oceancast/*
+cmd/roadmap/*

--- a/cmd/oceanbench/data_test.go
+++ b/cmd/oceanbench/data_test.go
@@ -103,16 +103,16 @@ func TestGetScalars(t *testing.T) {
 	ctx := context.Background()
 	store, err := datastore.NewStore(ctx, "cloud", "vidgrind", "")
 	if err != nil {
-		t.Errorf("NewStore failed with error: %v", err)
+		t.Fatalf("NewStore failed with error: %v", err)
 	}
 
 	id := model.ToSID(mac, pin)
 	scalars, err := model.GetScalars(ctx, store, id, []int64{datastore.EpochStart, datastore.EpochStart + minutesInDay*60})
 	if err != nil {
-		t.Errorf("GetScalars failed with error: %v", err)
+		t.Fatalf("GetScalars failed with error: %v", err)
 	}
 	if len(scalars) != minutesInDay {
-		t.Errorf("Expected %d scalars, got %d", minutesInDay, len(scalars))
+		t.Fatalf("Expected %d scalars, got %d", minutesInDay, len(scalars))
 	}
 
 	samples := sampleSinusoid(amplitude, offset, minutesInDay)

--- a/cmd/oceanbench/data_test.go
+++ b/cmd/oceanbench/data_test.go
@@ -76,8 +76,11 @@ func TestPutScalars(t *testing.T) {
 	if err != nil {
 		t.Errorf("GetScalars failed with error: %v", err)
 	}
+	if len(scalars) > 0 && len(scalars) < minutesInDay {
+		t.Skipf("Skipping TestPutScalars. Partial scalar data found (%d/%d). Clean up required.", len(scalars), minutesInDay)
+	}
 	if len(scalars) == minutesInDay {
-		t.Skip("Skipping TestPutScalars")
+		t.Skip("Skipping TestPutScalars, scalar data already exists.")
 	}
 
 	ts := int64(datastore.EpochStart)
@@ -109,7 +112,7 @@ func TestGetScalars(t *testing.T) {
 		t.Errorf("GetScalars failed with error: %v", err)
 	}
 	if len(scalars) != minutesInDay {
-		t.Errorf("Expected %d scalars, got %d", minutesInDay*60, len(scalars))
+		t.Errorf("Expected %d scalars, got %d", minutesInDay, len(scalars))
 	}
 
 	samples := sampleSinusoid(amplitude, offset, minutesInDay)


### PR DESCRIPTION
This was done so that the test wouldn't panic when it fails. It's still unclear why it failed and is now passing.

Fixes the panic in issue #542 