### PR TITLE
otv & bench: add notification suppression rules

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -158,6 +158,7 @@ type BroadcastConfig struct {
 	VoltageRecoveryTimeout   int           // Max allowable hours for voltage recovery before failure.
 	RegisterOpenFish         bool          // True if the video should be registered with openfish for annotation.
 	OpenFishCaptureSource    string        // The capture source to register the stream to.
+	NotifySuppressRules      string        // Suppression rules for notifications.
 }
 
 func (b *BroadcastConfig) PrettyHardwareStateData() string {
@@ -230,6 +231,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 			RegisterOpenFish:      r.FormValue("register-openfish") == "register-openfish",
 			OpenFishCaptureSource: r.FormValue("openfish-capturesource"),
 			BatteryVoltagePin:     r.FormValue("battery-voltage-pin"),
+			NotifySuppressRules:   r.FormValue("notify-suppress-rules"),
 		},
 		Action:             r.FormValue("action"),
 		ListingSecondaries: r.FormValue("list-secondaries") == "listing-secondaries",

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.31.5"
+	version     = "v0.32.0"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -272,6 +272,10 @@
               <label for="openfish-capturesource" class="advanced w-25 text-end">OpenFish Capture Source:</label>
               <input class="advanced w-50 form-control" type="input" name="openfish-capturesource" value="{{.CurrentBroadcast.OpenFishCaptureSource}}" />
             </div>
+            <div class="d-flex align-items-center gap-1 mb-1">
+              <label for="notify-suppress-rules" class="advanced w-25 text-end">Notification Suppression Rules:</label>
+              <input class="advanced w-50 form-control" type="input" name="notify-suppress-rules" value="{{.CurrentBroadcast.NotifySuppressRules}}" />
+            </div>
           </fieldset>
           <input type="hidden" name="broadcast-id" value="{{.CurrentBroadcast.ID}}" />
           <input type="hidden" name="active" value="{{.CurrentBroadcast.Active}}" />

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -134,6 +134,7 @@ type BroadcastConfig struct {
 	VoltageRecoveryTimeout   int           // Max allowable hours for voltage recovery before failure.
 	RegisterOpenFish         bool          // True if the video should be registered with openfish for annotation.
 	OpenFishCaptureSource    string        // The capture source to register the stream to.
+	NotifySuppressRules      string        // Suppression rules for notifications.
 }
 
 func (b *BroadcastConfig) PrettyHardwareStateData() string {

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.9.3"
+	version            = "v0.10.0"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.
@@ -429,6 +429,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		_cfg.RegisterOpenFish = cfg.RegisterOpenFish
 		_cfg.OpenFishCaptureSource = cfg.OpenFishCaptureSource
 		_cfg.BatteryVoltagePin = cfg.BatteryVoltagePin
+		_cfg.NotifySuppressRules = cfg.NotifySuppressRules
 
 		// Values that are parsed into floats from their form values.
 		_cfg.RequiredStreamingVoltage = cfg.RequiredStreamingVoltage


### PR DESCRIPTION
This allows us to add notification rules through the broadcast page. This means we can suppress notifications of a particular kind or containing a particular string. The rules are in a JSON format: { "SuppressKinds" : ["kind1","kind2", ... ], "SuppressContaining": ["some str"] }