### PR TITLE
OTV: Handle hardwarePowerOffFailedEvents

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -359,6 +359,12 @@ func (e hardwareShutdownFailedEvent) New(args ...any) (any, error) {
 	}
 	return hardwareShutdownFailedEvent{err}, nil
 }
+func (e hardwareShutdownFailedEvent) Is(target error) bool {
+	if targetEvent, ok := target.(hardwareShutdownFailedEvent); ok {
+		return errors.Is(e.error, targetEvent.error)
+	}
+	return errors.Is(e.error, target)
+}
 
 // Kind implements the errorEvent interface.
 func (e hardwareShutdownFailedEvent) Kind() notify.Kind {
@@ -616,7 +622,7 @@ func (s *hardwareStopping) handleHardwareShutdownFailedEvent(event hardwareShutd
 		// We want to get notified for failures and misconfigured configs, and log
 		// when shutdown is skipped.
 		if errors.Is(event, warnSkipShutdown) {
-			s.log("skipping shutdown: %v:", event.Error)
+			s.log("skipping shutdown: %v", event.Error())
 		} else if errors.Is(event, errNoShutdownActions) {
 			s.logAndNotify(broadcastHardware, "shutdown skipped: %v", event.Error())
 		} else {

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.9.2"
+	version            = "v0.10.0"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
This change handles the event that a camera fails to turn off (after a timeout)
by notifying the ops email, and transitioning into hardware failure.

This change also adds unit tests and helpers for this use case.

There is possibly an argument for not transitioning to hardwareFailure (through publishing a hardwareStopFailedEvent), and this can be done, but we need to add a new state type which tracks whether a notification has been sent, otherwise without transitioning, we would likely receive a notification on every timeout period. However, given that hardwareFailure does not change the variables at all, if the camera was setup to power off correctly, transitioning to hardwareFailure should not prevent this anyway.

This notification should probably be treated as high-priority, given that it could likely mean that a camera is sucking power overnight, and so the shutdown behaviour of the camera after the notification shouldn't matter as much.

closes #550