### PR TITLE
gauth: pass on refresh token when getting new access token

### DIFF
--- a/gauth/userauth.go
+++ b/gauth/userauth.go
@@ -487,6 +487,9 @@ func (ua *UserAuth) GetProfile(h backend.Handler) (*Profile, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not get refreshed token: %w", err)
 		}
+		if newTok.RefreshToken == "" {
+			newTok.RefreshToken = tok.RefreshToken
+		}
 		clt := ua.cfg.Client(ctx, newTok)
 		data := profile.Data // Save optional data.
 		profile, err = fetchProfile(clt)


### PR DESCRIPTION
This was done so that we don't lose the refresh token. I think this has been happening.