### PR TITLE
otv: fix event marshalling/unmarshalling and error matching

### DIFF
--- a/cmd/oceantv/broadcast_events_test.go
+++ b/cmd/oceantv/broadcast_events_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -148,6 +150,155 @@ func TestStringToEvent(t *testing.T) {
 			got := stringToEvent(tt.name)
 			if !tt.wantPanic && !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("stringToEvent() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestErrorsIs(t *testing.T) {
+	type testCase struct {
+		name        string
+		err         error
+		target      error
+		expectMatch bool
+	}
+
+	warn := warnSkipShutdown
+
+	tests := []testCase{
+		{
+			name:        "ShutdownEvent wraps warnSkipShutdown directly",
+			err:         hardwareShutdownFailedEvent{warn},
+			target:      warn,
+			expectMatch: true,
+		},
+		{
+			name:        "ShutdownEvent wraps fmt.Errorf with warnSkipShutdown",
+			err:         hardwareShutdownFailedEvent{fmt.Errorf("could not perform shutdown actions: %w", warn)},
+			target:      warn,
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOffEvent wraps empty ShutdownEvent directly",
+			err:         hardwarePowerOffFailedEvent{hardwareShutdownFailedEvent{}},
+			target:      hardwareShutdownFailedEvent{},
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOffEvent wraps fmt.Errorf with empty ShutdownEvent",
+			err:         hardwarePowerOffFailedEvent{fmt.Errorf("got error event: %w", hardwareShutdownFailedEvent{})},
+			target:      hardwareShutdownFailedEvent{},
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOffEvent wraps fmt.Errorf with ShutdownEvent{warn}",
+			err:         hardwarePowerOffFailedEvent{fmt.Errorf("got error event: %w", hardwareShutdownFailedEvent{warn})},
+			target:      hardwareShutdownFailedEvent{},
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOffEvent wraps fmt.Errorf with ShutdownEvent{warn}, match on warn",
+			err:         hardwarePowerOffFailedEvent{fmt.Errorf("got error event: %w", hardwareShutdownFailedEvent{warn})},
+			target:      warn,
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOffEvent wraps ShutdownEvent{warn} directly",
+			err:         hardwarePowerOffFailedEvent{hardwareShutdownFailedEvent{warn}},
+			target:      hardwareShutdownFailedEvent{},
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOffEvent wraps ShutdownEvent{warn} directly, match on warn",
+			err:         hardwarePowerOffFailedEvent{hardwareShutdownFailedEvent{warn}},
+			target:      warn,
+			expectMatch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match := errors.Is(tc.err, tc.target)
+			if match != tc.expectMatch {
+				t.Errorf("errors.Is(%v, %v) = %v; want %v", tc.err, tc.target, match, tc.expectMatch)
+			}
+		})
+	}
+}
+
+func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       event
+		target      error // Only relevant if input is errorEvent
+		expectMatch bool  // Only applies for errorEvent + target
+	}{
+		{
+			name:        "Shutdown wraps warn",
+			input:       hardwareShutdownFailedEvent{warnSkipShutdown},
+			target:      warnSkipShutdown,
+			expectMatch: true,
+		},
+		{
+			name:        "Shutdown wraps fmt.Errorf(warn)",
+			input:       hardwareShutdownFailedEvent{fmt.Errorf("wrap: %w", warnSkipShutdown)},
+			target:      warnSkipShutdown,
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOff wraps Shutdown{warn}",
+			input:       hardwarePowerOffFailedEvent{hardwareShutdownFailedEvent{warnSkipShutdown}},
+			target:      hardwareShutdownFailedEvent{},
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOff wraps fmt.Errorf(wrapped Shutdown{warn})",
+			input:       hardwarePowerOffFailedEvent{fmt.Errorf("wrap: %w", hardwareShutdownFailedEvent{warnSkipShutdown})},
+			target:      warnSkipShutdown,
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOff wraps Shutdown with no cause",
+			input:       hardwarePowerOffFailedEvent{hardwareShutdownFailedEvent{}},
+			target:      hardwareShutdownFailedEvent{},
+			expectMatch: true,
+		},
+		{
+			name:        "PowerOff wraps Shutdown with no cause – doesn't match warn",
+			input:       hardwarePowerOffFailedEvent{hardwareShutdownFailedEvent{}},
+			target:      warnSkipShutdown,
+			expectMatch: false,
+		},
+		{
+			name:        "Non-error startEvent round-trip",
+			input:       startEvent{},
+			target:      nil,
+			expectMatch: false, // unused
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := marshalEvent(tc.input)
+			unmarshalled := unmarshalEvent(data)
+
+			if _, ok := tc.input.(error); ok && tc.target != nil {
+				// Check that Error() returns the same string.
+				if fmt.Sprint(unmarshalled) != fmt.Sprint(tc.input) {
+					t.Errorf("expected error event %v, got %v", tc.input, unmarshalled)
+				}
+
+				// Check that we can still perform matching.
+				match := errors.Is(unmarshalled.(error), tc.target)
+				if match != tc.expectMatch {
+					t.Errorf("errors.Is(..., %v) = %v, want %v", tc.target, match, tc.expectMatch)
+				}
+
+			} else {
+				// Non-error case: check structural identity.
+				if fmt.Sprint(unmarshalled) != fmt.Sprint(tc.input) {
+					t.Errorf("expected non-error event %v, got %v", tc.input, unmarshalled)
+				}
 			}
 		})
 	}

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -373,6 +373,15 @@ func (e hardwareShutdownFailedEvent) Kind() notify.Kind {
 	return broadcastHardware
 }
 
+func (e hardwareShutdownFailedEvent) Unwrap() error { return e.error }
+
+func (e hardwareShutdownFailedEvent) Is(target error) bool {
+	if _, ok := target.(hardwareShutdownFailedEvent); ok {
+		return true
+	}
+	return errors.Is(e.error, target)
+}
+
 type hardwareShutdownEvent struct{}
 
 var _ = registerEvent(hardwareShutdownEvent{})
@@ -432,6 +441,15 @@ func (e hardwarePowerOffFailedEvent) Kind() notify.Kind {
 	}
 
 	return broadcastHardware
+}
+
+func (e hardwarePowerOffFailedEvent) Unwrap() error { return e.error }
+
+func (e hardwarePowerOffFailedEvent) Is(target error) bool {
+	if _, ok := target.(hardwarePowerOffFailedEvent); ok {
+		return true
+	}
+	return errors.Is(e.error, target)
 }
 
 type hardwarePoweringOff struct {

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.9.2"
+	version            = "v0.9.3"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -212,7 +212,7 @@ func (bs *broadcastSystem) tick() error {
 	}
 
 	for _, eventData := range bs.ctx.cfg.Events {
-		event := unmarshalEvent(eventData)
+		event := unmarshalEvent([]byte(eventData))
 		bs.log("publishing stored event: %s", event.String())
 		bs.ctx.bus.publish(event)
 	}


### PR DESCRIPTION
Events are complex in that they can be of errorEvent type which means that they can chain other errorEvents or normal errors.

This change fixes error matching using Is and marshalling/unmarshalling so that it happen recursively and reconstruct the events exactly as they were. We've also added testing to verify things are working as expected.