### PR TITLE
otv: handle no voltage value when ESP off

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.10.0"
+	version            = "v0.10.1"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
When we have a low voltage case, the ESP goes into alarm mode, but then there will be no voltage sensor value. So if we get a no such entity error, we assume the voltage is the alarm voltage.