### PR TITLE
otv: add missing event handling for powerOffFailedEvent

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -393,6 +393,8 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 		if withTimeout.timedOut(event.Time) {
 			sm.transition(newVidforwardPermanentFailure(sm.ctx))
 		}
+	case *directFailure:
+		// Do nothing.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	projectID          = "oceantv"
-	version            = "v0.10.4"
+	version            = "v0.10.5"
 	projectURL         = "https://oceantv.appspot.com"
 	cronServiceAccount = "oceancron@appspot.gserviceaccount.com"
 	locationID         = "Australia/Adelaide" // TODO: Use site location.


### PR DESCRIPTION
In the hardwareStopping state, if the poweringOff substate fails a hardwarePowerOffFailedEvent is emitted, but we weren't handling this. We need to handling this in the hardwareStopping state and then transition to hardwareFailed.