### PR TITLE
vars response now includes rc and ts

### DIFF
--- a/cmd/datablue/handlers.go
+++ b/cmd/datablue/handlers.go
@@ -516,6 +516,11 @@ func varsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := `{"id":"` + dev.Hex() + `",`
+	if dev.Status != model.DeviceStatusOK {
+		resp += `"rc":` + strconv.Itoa(int(dev.Status)) + `,`
+	}
+	resp += `"ts":` + strconv.Itoa(int(time.Now().Unix())) + `,`
+
 	for _, v := range vars {
 		if v.IsSystemVariable() {
 			continue

--- a/cmd/datablue/main.go
+++ b/cmd/datablue/main.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	version   = "v0.4.0"
+	version   = "v0.5.0"
 	projectID = "datablue"
 )
 


### PR DESCRIPTION
Now that the ESP NetSender client always requests vars upon restart, it is useful to include the request code (rc) and timestamp (ts) in the response, as we do for config requests.