### PR TITLE
Bench: Search Longer Device Names (#567)

### DIFF
--- a/cmd/oceanbench/t/search.html
+++ b/cmd/oceanbench/t/search.html
@@ -160,16 +160,17 @@
         <fieldset>
           <legend>Input source</legend>
           <div class="d-flex align-items-center gap-2">
-            <label>Device:</label>
-            <select class="form-select form-select-sm w-25" name="ma" onchange="this.form.submit();">
-              <option value="" selected>- Select device -</option>
-              {{ range .Devices }}
-              <option value="{{ .MAC }}" {{ if eq .MAC $.Ma }}selected{{ end }}>{{ .Name }}</option>
-              {{ end }}
-            </select>
+              <label style="width: 60px;">Device:</label>
+              <select class="form-select form-select-sm w-100" name="ma" onchange="this.form.submit();">
+                <option value="" selected>- Select device -</option>
+                {{ range .Devices }}
+                <option value="{{ .MAC }}" {{ if eq .MAC $.Ma }}selected{{ end }}>{{ .Name }}</option>
+                {{ end }}
+              </select>
+            </div>
             {{ if .Device }}
-            <div class="d-flex align-items-center">
-              <span>Pin:</span>
+            <div class="d-flex align-items-center gap-2">
+              <label style="width: 60px;">Pin:</label>
               <select class="form-select form-select-sm" name="pn" onchange="this.form.submit();">
                 <option value="" selected>- Select pin -</option>
                 {{ range .Device.InputList }}


### PR DESCRIPTION
This change extends the length of the select element on the search page to make longer device names easier to read.
![image](https://github.com/user-attachments/assets/e3ef67b9-408f-42d3-a664-b794e8d2cdf6)
