### PR TITLE
Bench: Fix reference to failure mode toggle (#582)

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -372,7 +372,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		} else if err != nil {
 			reportError(w, r, req, "could not get broadcast from vars to check hardware state: %v", err)
 			return
-		} else if r.FormValue("hardware-in-failure") == "false" && curBroadcast.HardwareState == "hardwareFailure" {
+		} else if r.FormValue("in-failure") == "false" && curBroadcast.HardwareState == "hardwareFailure" {
 			cfg.HardwareState = "hardwareOff"
 		}
 

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.32.1"
+	version     = "v0.32.2"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This changes the reference to the broadcast form
from hardware-in-failure to in-failure. This was caused by a previous incorrect reference.