### PR TITLE
model/subfeed: remove feedID from already unique key

### DIFF
--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1543,7 +1543,7 @@ func TestSubFeed(t *testing.T) {
 		t.Errorf("could not create subfeed: %v", err)
 	}
 
-	subfeed2, err := GetSubFeed(ctx, store, testSubFeedID, testSubFeedFeedID)
+	subfeed2, err := GetSubFeed(ctx, store, testSubFeedID)
 	if err != nil {
 		t.Errorf("could not get subfeed: %v", err)
 	}
@@ -1556,7 +1556,7 @@ func TestSubFeed(t *testing.T) {
 		t.Errorf("could not update subfeed: %v", err)
 	}
 
-	subfeed3, err := GetSubFeed(ctx, store, testSubFeedID, testSubFeedFeedID)
+	subfeed3, err := GetSubFeed(ctx, store, testSubFeedID)
 	if err != nil {
 		t.Errorf("could not get subfeed: %v", err)
 	}
@@ -1583,12 +1583,12 @@ func TestSubFeed(t *testing.T) {
 
 	assert.Equal(t, []SubFeed{*subfeed, *newSubfeed}, subfeeds, "Got different subfeeds than put, got: \n%+v, wanted \n%+v", subfeeds, []SubFeed{*subfeed, *newSubfeed})
 
-	err = DeleteSubFeed(ctx, store, testSubFeedID, testSubFeedFeedID)
+	err = DeleteSubFeed(ctx, store, testSubFeedID)
 	if err != nil {
 		t.Errorf("could not delete subfeed: %v", err)
 	}
 
-	subfeed4, err := GetSubFeed(ctx, store, testSubFeedID, testSubFeedFeedID)
+	subfeed4, err := GetSubFeed(ctx, store, testSubFeedID)
 	if !errors.Is(err, datastore.ErrNoSuchEntity) {
 		t.Errorf("expected ErrNoSuchEntity, got %v", err)
 	}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1576,11 +1576,23 @@ func TestSubFeed(t *testing.T) {
 		t.Errorf("could not create new subfeed: %v", err)
 	}
 
+	newSubfeed2 := &SubFeed{
+		ID:     testSubFeedID + 2,
+		FeedID: testSubFeedFeedID + 1,
+		Source: "https://youtube.com/watch?v=1122334455",
+		Active: true,
+		Start:  startTime,
+		Finish: finishTime,
+	}
+	err = CreateSubFeed(ctx, store, newSubfeed2)
+	if err != nil {
+		t.Errorf("could not create new subfeed: %v", err)
+	}
+
 	subfeeds, err := GetSubFeedsByFeed(ctx, store, testSubFeedFeedID)
 	if err != nil {
 		t.Errorf("could not get all subfeeds: %v", err)
 	}
-
 	assert.Equal(t, []SubFeed{*subfeed, *newSubfeed}, subfeeds, "Got different subfeeds than put, got: \n%+v, wanted \n%+v", subfeeds, []SubFeed{*subfeed, *newSubfeed})
 
 	err = DeleteSubFeed(ctx, store, testSubFeedID)

--- a/model/subfeed.go
+++ b/model/subfeed.go
@@ -63,8 +63,8 @@ func (f *SubFeed) GetCache() datastore.Cache {
 }
 
 // GetSubFeed retrieves a SubFeed entity from the datastore by its ID.
-func GetSubFeed(ctx context.Context, store datastore.Store, ID, feedID int64) (*SubFeed, error) {
-	key := store.NameKey(typeSubFeed, fmt.Sprintf("%d.%d", feedID, ID))
+func GetSubFeed(ctx context.Context, store datastore.Store, ID int64) (*SubFeed, error) {
+	key := store.IDKey(typeSubFeed, ID)
 
 	subfeed := &SubFeed{}
 	err := store.Get(ctx, key, subfeed)
@@ -77,7 +77,7 @@ func GetSubFeed(ctx context.Context, store datastore.Store, ID, feedID int64) (*
 
 // GetAllSubFeeds retrieves all SubFeed entities from the datastore for a given FeedID.
 func GetSubFeedsByFeed(ctx context.Context, store datastore.Store, feedID int64) ([]SubFeed, error) {
-	q := store.NewQuery(typeSubFeed, false, "FeedID", "ID")
+	q := store.NewQuery(typeSubFeed, false, "ID")
 	q.FilterField("FeedID", "=", feedID)
 	subfeeds := []SubFeed{}
 	_, err := store.GetAll(ctx, q, &subfeeds)
@@ -90,13 +90,13 @@ func GetSubFeedsByFeed(ctx context.Context, store datastore.Store, feedID int64)
 
 // CreateSubFeed creates a subfeed, or returns an error if a subfeed with the given ID exists.
 func CreateSubFeed(ctx context.Context, store datastore.Store, subfeed *SubFeed) error {
-	key := store.NameKey(typeSubFeed, fmt.Sprintf("%d.%d", subfeed.FeedID, subfeed.ID))
+	key := store.IDKey(typeSubFeed, subfeed.ID)
 	return store.Create(ctx, key, subfeed)
 }
 
 // UpdateSubFeed updates a subfeed, or returns an error if the subfeed does not exist.
 func UpdateSubFeed(ctx context.Context, store datastore.Store, subfeed *SubFeed) (*SubFeed, error) {
-	key := store.NameKey(typeSubFeed, fmt.Sprintf("%d.%d", subfeed.FeedID, subfeed.ID))
+	key := store.IDKey(typeSubFeed, subfeed.ID)
 	updated := &SubFeed{}
 	err := store.Update(ctx, key, func(e datastore.Entity) {
 		_subfeed := e.(*SubFeed)
@@ -111,8 +111,8 @@ func UpdateSubFeed(ctx context.Context, store datastore.Store, subfeed *SubFeed)
 }
 
 // MarkSubFeedInactive updates the Active field of a given subfeed to false.
-func MarkSubFeedInactive(ctx context.Context, store datastore.Store, ID, feedID int64) error {
-	key := store.NameKey(typeSubFeed, fmt.Sprintf("%d.%d", feedID, ID))
+func MarkSubFeedInactive(ctx context.Context, store datastore.Store, ID int64) error {
+	key := store.IDKey(typeSubFeed, ID)
 	return store.Update(ctx, key, func(e datastore.Entity) {
 		subfeed := e.(*SubFeed)
 		subfeed.Active = false
@@ -120,7 +120,7 @@ func MarkSubFeedInactive(ctx context.Context, store datastore.Store, ID, feedID 
 }
 
 // DeleteSubFeed deletes a subfeed, or returns an error if the subfeed does not exist.
-func DeleteSubFeed(ctx context.Context, store datastore.Store, ID, feedID int64) error {
-	key := store.NameKey(typeSubFeed, fmt.Sprintf("%d.%d", feedID, ID))
+func DeleteSubFeed(ctx context.Context, store datastore.Store, ID int64) error {
+	key := store.IDKey(typeSubFeed, ID)
 	return store.Delete(ctx, key)
 }


### PR DESCRIPTION
This was done because have two globally unique IDs in the key is unnecessary.

NOTE: I'll also need to bump the openfish version once I've created a tag for the latest PR (https://github.com/ausocean/openfish/pull/330).
I tested this using the openfish changes locally, and it passed.