### PR TITLE
Bench: Add calibration for alarm var

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.32.3"
+	version     = "v0.32.4"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -530,13 +530,13 @@ func calibrateDevicesHandler(w http.ResponseWriter, r *http.Request) {
 		// Calibrate the alarm voltage and alarm recovery voltage variables.
 		skey, _ := profileData(p)
 		if va > 0 {
-			err := model.PutVariable(ctx, settingsStore, skey, model.NameAlarmVoltage, strconv.FormatFloat(va/scaleFactor, 'f', -1, 64))
+			err := model.PutVariable(ctx, settingsStore, skey, model.NameAlarmVoltage, fmt.Sprintf("%d", int(va/scaleFactor)))
 			if err != nil {
 				msgs = append(msgs, fmt.Sprintf("unable to set alarm voltage: %v", err))
 			}
 		}
 		if vr > 0 {
-			err := model.PutVariable(ctx, settingsStore, skey, model.NameAlarmRecoveryVoltage, strconv.FormatFloat(vr/scaleFactor, 'f', -1, 64))
+			err := model.PutVariable(ctx, settingsStore, skey, model.NameAlarmRecoveryVoltage, fmt.Sprintf("%d", int(vr/scaleFactor)))
 			if err != nil {
 				msgs = append(msgs, fmt.Sprintf("unable to set alarm recovery voltage: %v", err))
 			}

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -247,13 +247,13 @@
             <div class="row d-flex gx-1">
               <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Alarm Voltage:</label>
               <div class="col-sm-10 col-md-6 col-12">
-                <input class="form-control" type="input" name="va" />
+                <input class="form-control" type="input" name="va" value="24.5" />
               </div>
             </div>
             <div class="row d-flex gx-1">
               <label class="col-sm-2 col-md-3 col-1 text-end pt-2">Alarm Recovery Voltage:</label>
               <div class="col-sm-10 col-md-6 col-12">
-                <input class="form-control" type="input" name="vr" />
+                <input class="form-control" type="input" name="vr" value="25" />
               </div>
             </div>
             <div class="row d-flex gx-1 align-items-center">
@@ -261,6 +261,7 @@
               <input type="submit" class="btn btn-primary w-50" value="Calibrate Now" />
             </div>
           </form>
+          <small>NOTE: Sensors will only be calibrated whilst reading non-zero values</small>
         </div>
       </div>
       {{if .Msg}}

--- a/docs/oceanbench/device-configuration.md
+++ b/docs/oceanbench/device-configuration.md
@@ -131,6 +131,9 @@ That will open the follow popover menu.
 ![Calibration Popover](../images/device-calibrate-popover.png)
 Measure the actual values for the measured voltage fields. In most cases, it will be acceptable to only measure the battery voltage (input screw terminals to the PCB), and use this as the calibration value for all voltages. If that is acceptable, leave the lock icon in the locked state. If each voltage needs to be calibrated independently, click on the padlock icon and leave it in the unlocked state. This will use the entered value to calibrate each voltage separately.
 
+> [!NOTE]
+> When calibrating a controller, calibration will only occur for non-zero sensor readings. To calibrate all sensors, ensure that all power variables are turned on, such that Power 1, 2, and 3 are all reading a non-zero voltage.
+
 Enter the voltage value that the controller should enter a low voltage alarm, and the voltage which it should recover.
 
 For any field that is left empty, this value will not be calibrated.


### PR DESCRIPTION
This change adds the auto-calibration functionality to the alarm variable. This calibrates the alarm voltage, and alarm recovery voltage whenever the battery voltage is calibrated.

This also fixes an error, where calibrating voltages that are reading 0 returns an inf, or NaN result.