### PR TITLE
Bench/API: Add sensor data endpoint

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.32.5"
+	version     = "v0.33.5"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"


### PR DESCRIPTION
This change adds an endpoint to the API which returns the transformed data from a sensor, with a timestamp and float value.

This is required for ausocean/ausoceantv#71