### PR TITLE
bench/t/search: render GPS / NMEA text

### DIFF
--- a/cmd/oceanbench/search.go
+++ b/cmd/oceanbench/search.go
@@ -228,7 +228,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	sd.PinType = sd.Pn[0]
 	switch sd.PinType {
 	case 'T':
-		sd.Log = true
+		sd.Log = (sd.Pn == "T0")
 		fallthrough
 
 	case 'S', 'V':

--- a/cmd/oceanbench/t/search.html
+++ b/cmd/oceanbench/t/search.html
@@ -1,4 +1,5 @@
 <!doctype html>
+{{- $pn := printf "%v" .Pn -}}
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -86,6 +87,122 @@
           document.getElementById('ts').value = document.getElementById('st').value + '-' + document.getElementById('ft').value;
         }
       }
+
+      // Lightweight NMEA renderer for T1 pins.
+      function initNMEA(opts) {
+        // Fetch concatenated text for the selected range, then render raw and parsed views.
+        const url = `/get?id=${opts.id}&ts=${opts.st}-${opts.ft}`;
+        fetch(url).then(r => r.text()).then(txt => {
+          const lines = txt.split(/\r?\n/).filter(Boolean);
+          renderRaw(lines);
+          renderParsed(lines, opts.tz);
+          document.getElementById('nmea-count').textContent = lines.length.toString();
+        }).catch(err => {
+          const el = document.getElementById('nmea-error');
+          if (el) el.textContent = `Failed to load NMEA data: ${err}.`;
+        });
+      }
+
+      function renderRaw(lines) {
+        const pre = document.getElementById('nmea-raw');
+        if (pre) pre.textContent = lines.join('\n');
+      }
+
+      function renderParsed(lines, tzStr) {
+        const tbody = document.querySelector('#nmea-table tbody');
+        if (!tbody) return;
+        const tz = parseFloat(tzStr || "0");
+        const toLocal = (d) => new Date(d.getTime() + tz * 3600000);
+
+        // Very small parser for common sentences (RMC, GGA, GLL, VTG). Not exhaustive.
+        function parseSentence(s) {
+          // Strip checksum.
+          const body = s.replace(/^\$|[*][0-9A-Fa-f]{2}$/g, '');
+          const parts = body.split(',');
+          const talker = parts[0] || '';
+          const type = talker.slice(-3);
+          const p = parts;
+
+          const toDeg = (v, hemi) => {
+            // NMEA lat/long are DDMM.MMMM. Convert to decimal degrees.
+            if (!v) return null;
+            const dot = v.indexOf('.');
+            const minsStart = dot <= 2 ? 2 : (dot - 2);
+            const deg = parseFloat(v.slice(0, minsStart));
+            const min = parseFloat(v.slice(minsStart));
+            if (isNaN(deg) || isNaN(min)) return null;
+            let val = deg + (min / 60.0);
+            if (hemi === 'S' || hemi === 'W') val = -val;
+            return val;
+          };
+
+          // Provide a best-effort summary per type.
+          if (type === 'RMC') {
+            // $--RMC,hhmmss.sss,A,llll.ll,a,yyyyy.yy,a,x.x,x.x,ddmmyy,x.x,a*hh
+            const t = p[1], status = p[2], lat = toDeg(p[3], p[4]), lon = toDeg(p[5], p[6]);
+            const spdKn = p[7] ? parseFloat(p[7]) : null;
+            const cog = p[8] ? parseFloat(p[8]) : null;
+            return { type: 'RMC', status, lat, lon, speedKn: spdKn, course: cog, timeHHMMSS: t };
+          }
+          if (type === 'GGA') {
+            // $--GGA,hhmmss.sss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx*hh
+            const t = p[1], lat = toDeg(p[2], p[3]), lon = toDeg(p[4], p[5]);
+            const fixQ = p[6], sats = p[7], hdop = p[8], altM = p[9];
+            return { type: 'GGA', lat, lon, fix: fixQ, sats, hdop, altM, timeHHMMSS: t };
+          }
+          if (type === 'GLL') {
+            // $--GLL,llll.ll,a,yyyyy.yy,a,hhmmss.sss,A*hh
+            const lat = toDeg(p[1], p[2]), lon = toDeg(p[3], p[4]), t = p[5], status = p[6];
+            return { type: 'GLL', status, lat, lon, timeHHMMSS: t };
+          }
+          if (type === 'VTG') {
+            // $--VTG,c.x,T,,M,s.x,N,k.x,K*hh
+            const course = p[1], spdKn = p[5], spdKmh = p[7];
+            return { type: 'VTG', course, speedKn: spdKn, speedKmh: spdKmh };
+          }
+          return { type, raw: s };
+        }
+
+        // Render rows.
+        tbody.innerHTML = '';
+        for (const line of lines) {
+          const parsed = parseSentence(line);
+          const tr = document.createElement('tr');
+
+          const tdType = document.createElement('td');
+          tdType.textContent = parsed.type || '';
+          tr.appendChild(tdType);
+
+          const tdSummary = document.createElement('td');
+          if (parsed.lat != null && parsed.lon != null) {
+            tdSummary.textContent = `Lat ${parsed.lat.toFixed(6)}, Lon ${parsed.lon.toFixed(6)}`;
+          } else if (parsed.raw) {
+            tdSummary.textContent = parsed.raw;
+          } else {
+            tdSummary.textContent = '—';
+          }
+          tr.appendChild(tdSummary);
+
+          const tdExtra = document.createElement('td');
+          const extras = [];
+          if (parsed.speedKn != null) extras.push(`Speed ${parsed.speedKn} kn`);
+          if (parsed.speedKmh != null) extras.push(`Speed ${parsed.speedKmh} km/h`);
+          if (parsed.course != null) extras.push(`Course ${parsed.course}°`);
+          if (parsed.sats != null) extras.push(`Sats ${parsed.sats}`);
+          if (parsed.hdop != null) extras.push(`HDOP ${parsed.hdop}`);
+          if (parsed.altM != null) extras.push(`Alt ${parsed.altM} m`);
+          if (parsed.status) extras.push(`Status ${parsed.status}`);
+          tdExtra.textContent = extras.join(' · ') || '—';
+          tr.appendChild(tdExtra);
+
+          const tdRaw = document.createElement('td');
+          tdRaw.textContent = line;
+          tr.appendChild(tdRaw);
+
+          tbody.appendChild(tr);
+        }
+      }
+
       function init() {
         const inputs = document.querySelectorAll('input');
         for (const input of inputs) {
@@ -95,15 +212,27 @@
             }
           });
         }
-        {{if .Log -}}
+        // T0 → Logs view.
+        {{ if eq $pn "T0" -}}
         initLogs({
           {{if .Id}}id: {{.Id}},{{end}}
           {{if .St}}st: {{.St}},{{end}}
           {{if .Ft}}ft: {{.Ft}},{{end}}
           {{if .Lv}}lv: {{.Lv}},{{end}}
         });
-        {{- end}}
+        {{- end }}
+
+        // T1 → NMEA view.
+        {{ if eq $pn "T1" -}}
+          initNMEA({
+            {{if .Id}}id: {{.Id}},{{end}}
+            {{if .St}}st: {{.St}},{{end}}
+            {{if .Ft}}ft: {{.Ft}},{{end}}
+            {{if .Tz}}tz: "{{.Tz}}",{{end}}
+          });
+        {{- end }}
       }
+
       function searchQuery(form) {
         presubmit();
         form.querySelector("input[name='search']").value = true;
@@ -226,7 +355,7 @@
             </div>
             <br />
           </div>
-          {{- else if eq .PinType 'T' -}}
+          {{- else if eq $pn "T0" -}}
           <div class="d-flex align-items-center">
             <label>Log level:</label>
             <select class="form-select form-select-sm w-25" name="lv" onchange="this.form.submit()">
@@ -238,6 +367,8 @@
               <option value="fatal" {{if eq .Lv $fatal}}selected{{- end}}>Fatal only</option>
             </select>
           </div>
+          {{- else if eq $pn "T1" -}}
+            <p class="mb-0">T1 selected. No additional options.</p>
           {{- else if (or (eq .PinType 'A') (eq .PinType 'D') (eq .PinType 'X') (eq .Pn "throughput")) -}}
           <div class="d-flex flex-column">
             <div class="d-flex align-items-center mb-2">
@@ -276,7 +407,7 @@
       </form>
     </section>
 
-    {{ if and .Searching .Log }}
+    {{ if and .Searching (eq $pn "T0") }}
     <section>
       <h2>Results</h2>
       <p>
@@ -302,6 +433,41 @@
       </table>
     </section>
     {{- end }}
+
+    {{ if and .Searching (eq $pn "T1") }}
+    <section class="border rounded p-4 container-md bg-white">
+      <h2 class="mb-2">Results</h2>
+      <div class="d-flex justify-content-between align-items-center">
+        <div><strong><span id="nmea-count">0</span></strong> NMEA sentences.</div>
+        <div class="d-flex gap-2">
+          <a class="btn btn-primary btn-sm" href="/get?id={{ $.Id }}&ts={{ $.St }}-{{ $.Ft }}">Download raw</a>
+        </div>
+      </div>
+
+      <hr />
+
+      <h5 class="mt-3">Parsed summary.</h5>
+      <div class="table-responsive">
+        <table id="nmea-table" class="table table-sm table-striped">
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Position / Summary</th>
+              <th>Extra</th>
+              <th>Raw</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+
+      <h5 class="mt-4">Raw.</h5>
+      <pre id="nmea-raw" class="p-2 bg-light border" style="max-height: 300px; overflow:auto;"></pre>
+      <div id="nmea-error" class="text-danger mt-2"></div>
+    </section>
+    {{ end }}
+
+
     <div id="progress"></div>
     <div id="graph"></div>
 


### PR DESCRIPTION
This was done for testing/debugging GPS and NMEA sentence searching.

It does basic formatting, and provides the raw text to view and download. 

Closes #629 

(I also tested that viewing logs still works)

<img width="1929" height="1599" alt="image" src="https://github.com/user-attachments/assets/fc622bbe-47c7-47ae-b15b-3bfec8ad0237" />

<img width="1929" height="672" alt="image" src="https://github.com/user-attachments/assets/6d08d423-76ba-4a74-ba9a-5d27d0c3d5e8" />
