### PR TITLE
Bench: Template variables separate

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.34.1"
+	version     = "v0.34.2"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"
@@ -216,6 +216,7 @@ func main() {
 	http.HandleFunc("/set/devices/edit/actuator", editActuatorHandler)
 	http.HandleFunc("/set/devices/edit/calibrate", calibrateDevicesHandler)
 	http.HandleFunc("/set/devices/edit", editDevicesHandler)
+	http.HandleFunc("/set/devices/vars", setDevicesVars)
 	http.HandleFunc("/set/devices/", setDevicesHandler)
 	http.HandleFunc("/set/crons/edit", editCronsHandler)
 	http.HandleFunc("/set/crons/", setCronsHandler)

--- a/cmd/oceanbench/s/device.js
+++ b/cmd/oceanbench/s/device.js
@@ -1,0 +1,18 @@
+// loadVars loads the variable element.
+async function loadVars() {
+  let varElement = document.getElementById("var-element");
+
+  // Get the MAC of the device to fetch vars for.
+  const params = new URLSearchParams(window.location.search);
+  const ma = params.get("ma");
+
+  const url = new URL("/set/devices/vars", window.location.origin);
+  if (ma) {
+    url.searchParams.set("ma", ma);
+  }
+
+  const resp = await fetch(url.toString());
+  const html = await resp.text();
+
+  varElement.innerHTML = html;
+}

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -200,7 +200,6 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 	var (
 		uptimeVar    *model.Variable
 		localAddrVar *model.Variable
-		vars         []model.Variable
 		varTypes     []model.Variable
 		sensors      []model.SensorV2
 		actuators    []model.ActuatorV2
@@ -225,14 +224,6 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 			return fmt.Errorf("get localaddr variable error: %v", err)
 		}
 		return nil
-	})
-	g.Go(func() error {
-		vs, err := model.GetVariablesBySite(gctx2, settingsStore, skey, data.Device.Hex())
-		if err == nil || errors.Is(err, datastore.ErrNoSuchEntity) {
-			vars = vs
-			return nil
-		}
-		return fmt.Errorf("get variables by site error: %v", err)
 	})
 	g.Go(func() error {
 		vt, err := model.GetVariablesBySite(gctx2, settingsStore, skey, "_type")
@@ -283,7 +274,6 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 		data.Device.SetOther("localaddr", localAddrVar.Value)
 	}
 
-	data.Vars = vars
 	data.VarTypes = varTypes
 	data.Sensors = sensors
 	data.Actuators = actuators

--- a/cmd/oceanbench/set_devices.go
+++ b/cmd/oceanbench/set_devices.go
@@ -1,0 +1,77 @@
+/*
+DESCRIPTION
+  OceanBench device page handling.
+
+AUTHORS
+  David Sutton <davidsutton@ausocean.org>
+
+LICENSE
+  Copyright (C) 2025 the Australian Ocean Lab (AusOcean)
+
+  This file is part of Ocean Bench. Ocean Bench is free software: you can
+  redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option)
+  any later version.
+
+  Ocean Bench is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt.  If not, see
+  <http://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/ausocean/cloud/gauth"
+	"github.com/ausocean/cloud/model"
+)
+
+// setDevicesVars handles requests for the variables of the device, returning
+// the populated template.
+func setDevicesVars(w http.ResponseWriter, r *http.Request) {
+	profile, err := getProfile(w, r)
+	if err != nil {
+		if err != gauth.TokenNotFound {
+			log.Printf("authentication error: %v", err)
+		}
+		http.Redirect(w, r, "/", http.StatusUnauthorized)
+		return
+	}
+	skey, _ := profileData(profile)
+
+	data := devicesData{
+		commonData: commonData{},
+		Mac:        r.FormValue("ma"),
+		Device:     &model.Device{},
+	}
+
+	ctx := r.Context()
+
+	// Return early if no device is selected.
+	if data.Mac == "" {
+		writeTemplate(w, r, "set/device_vars.html", &data, "")
+	}
+
+	data.Device.Mac = model.MacEncode(data.Mac)
+
+	ma := strings.ToLower(strings.ReplaceAll(data.Mac, ":", ""))
+
+	vars, err := model.GetVariablesBySite(ctx, settingsStore, skey, ma)
+	if err != nil {
+		writeError(w, fmt.Errorf("unable to get vars for device: %w", err))
+	}
+
+	data.Vars = vars
+
+	writeTemplate(w, r, "set/device_vars.html", &data, "")
+}

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -41,7 +41,7 @@
           return false;
         }
         return true;
-      }
+      };
 
       function setValue(id) {
         if (id == "") {
@@ -110,6 +110,8 @@
       }
 
       function init() {
+        loadVars();
+
         for (let k in varTypes) {
           let v = varTypes[k];
           if (v == "bool") {
@@ -150,9 +152,9 @@
 
       function validateVar(vv) {
         if (vv.validity.valid) {
-          vv.form.querySelector('.msg').className = 'td msg hidden'
+          vv.form.querySelector('.msg').className = 'msg hidden'
         } else {
-          vv.form.querySelector('.msg').className = 'td msg'
+          vv.form.querySelector('.msg').className = 'msg'
         }
       }
 
@@ -270,7 +272,7 @@
       {{end}}
       <h1 class="container-md">Devices</h1>
       <div class="border rounded p-4 container-md bg-white">
-        <form action="/set/devices/" enctype="multipart/form-data" method="post">
+        <form action="/set/devices/" enctype="multipart/form-data" method="get">
           <fieldset class="row d-flex gx-1 align-items-center">
             <label class="col-sm-2 col-md-3 col-1 text-end pt-1">Select Device:</label>
             <div class="col-sm-10 col-md-6 col-12">
@@ -437,42 +439,7 @@
         </div>
         {{end}} {{if .Device }}
         <div class="advanced flex-column">
-          <h2>Variables</h2>
-          <hr />
-          <table class="table mx-auto" style="max-width: 500px">
-            <thead>
-              <th></th>
-              <th class="text-center">Name</th>
-              <th class="text-center">Value</th>
-            </thead>
-            <tbody>
-              {{range .Vars}}
-              <tr>
-                <form class="row gx-1 d-flex align-items-center" id="{{ .Basename }}" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" novalidate>
-                  <td class="d-flex justify-content-end h-75"><img src="/s/delete.png" onclick="deleteVar('{{$.Device.MAC}}','{{ .Basename }}');" /></td>
-                  <td><input class="form-control form-control-sm w-100" type="text" name="vn" value="{{ .Basename }}" readonly /></td>
-                  <td>
-                    <input class="form-control form-control-sm w-100" type="text" name="vv" value="{{ .Value }}" onchange="submitVar(this)" oninput="validateVar(this)" />
-                    {{if .IsLink }}
-                    <a href="{{ .Value }}" target="_blank"><img src="/s/link.png" /></a>
-                    {{end}}
-                  </td>
-                  <span class="td msg hidden"></span>
-                  <input type="hidden" name="ma" value="{{$.Device.MAC}}" />
-                </form>
-              </tr>
-              {{end}}
-              <tr>
-                <form class="row gx-1 d-flex align-items-center" id="_newvar" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" onsubmit="return checkVar();" novalidate>
-                  <td class="d-flex justify-content-end h-75"><input type="image" src="/s/add.png" /></td>
-                  <td><input type="text" class="form-control form-control-sm w-100" name="vn" id="vn" list="list_vars" onchange="setValue('_newvar');" /></td>
-                  <td><input type="text" class="form-control form-control-sm w-100" name="vv" oninput="validateVar(this)" /></td>
-                  <td class="td msg hidden"></td>
-                  <input type="hidden" name="ma" value="{{$.Device.MAC}}" />
-                </form>
-              </tr>
-            </tbody>
-          </table>
+          <div id="var-element"></div>
         </div>
         <div class="advanced flex-column">
           <div class="d-flex gap-2 align-items-center">

--- a/cmd/oceanbench/t/set/device_vars.html
+++ b/cmd/oceanbench/t/set/device_vars.html
@@ -1,0 +1,32 @@
+<h2>Variables</h2>
+<hr />
+
+<div class="row fw-bold m-auto mb-2" style="max-width: 500px">
+  <div class="col text-center">Name</div>
+  <div class="col text-center">Value</div>
+</div>
+
+{{range .Vars}}
+<form class="row align-items-center gx-1 m-auto" style="max-width: 500px" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" novalidate>
+  <div class="col-auto">
+    <img style="width: 16px; height: 16px" src="/s/delete.png" onclick="deleteVar('{{$.Device.MAC}}','{{ .Basename }}');" />
+  </div>
+  <input class="col form-control form-control-sm w-100" type="text" name="vn" value="{{ .Basename }}" readonly />
+  <input class="col form-control form-control-sm w-100" type="text" name="vv" value="{{ .Value }}" onchange="submitVar(this)" oninput="validateVar(this)" />
+  {{if .IsLink }}
+  <a href="{{ .Value }}" target="_blank"><img src="/s/link.png" /></a>
+  {{end}}
+  <p class="msg hidden"></p>
+  <input class="col" type="hidden" name="ma" value="{{$.Device.MAC}}" />
+</form>
+{{end}}
+
+<form class="row gx-1 align-items-center m-auto" style="max-width: 500px" id="_newvar" enctype="multipart/form-data" action="/set/devices/edit/var" method="post" onsubmit="return checkVar();" novalidate>
+  <div class="col-auto">
+    <input type="image" src="/s/add.png" />
+  </div>
+  <input type="text" class="col form-control form-control-sm w-100" name="vn" id="vn" list="list_vars" onchange="setValue('_newvar');" />
+  <td><input type="text" class="col form-control form-control-sm w-100" name="vv" oninput="validateVar(this)" /></td>
+  <input type="hidden" name="ma" value="{{$.Device.MAC}}" />
+  <p class="msg hidden"></p>
+</form>


### PR DESCRIPTION
This change adds a new handler which returns the template for variables on the device page separately. This is the beginning of loading the different elements of the device page individually, to allow better load times, and more modular design without doing a full redesign with front-end rendering.