### PR TITLE
OTV: Add nil error check (#657)

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID            = "oceantv"
-	version              = "v0.13.0"
+	version              = "v0.13.1"
 	projectURL           = "https://tv.cloudblue.org"
 	cronServiceAccount   = "oceancron@appspot.gserviceaccount.com"
 	locationID           = "Australia/Adelaide" // TODO: Use site location.

--- a/cmd/oceantv/state_direct_failure.go
+++ b/cmd/oceantv/state_direct_failure.go
@@ -60,7 +60,11 @@ func (s *directFailure) enter() {
 }
 
 func (s *directFailure) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct{ Err string }{Err: s.err.Error()})
+	if s.err != nil {
+		return json.Marshal(struct{ Err string }{Err: s.err.Error()})
+	}
+
+	return json.Marshal(struct{ Err string }{Err: ""})
 }
 
 func (s *directFailure) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
This change adds a conditional check to the JSON marshaller for the direct failure state. If the error is nil, a blank string is returned instead of dereferencing the nil pointer.

closes #657