### PR TITLE
Bench: Hide broadcast UUID label

### DIFF
--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -68,7 +68,7 @@
               <input type="input" name="broadcast-name" class="form-control align-items-center w-50" value="{{.CurrentBroadcast.Name}}" />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">
-              <label for="broadcast-name" class="w-25 text-end">Broadcast UUID:</label>
+              <label for="broadcast-name" class="advanced w-25 text-end">Broadcast UUID:</label>
               <input type="input" name="broadcast-uuid" class="advanced form-control align-items-center w-50" value="{{.CurrentBroadcast.UUID}}" readonly />
             </div>
             <div class="d-flex align-items-center gap-1 mb-1">


### PR DESCRIPTION
This change fixes a small bug where the UUID input field was hidden but the label was not in basic mode.