### PR TITLE
Bench: Convert more places to UUID (#666)

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -386,7 +386,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		// Check if we've just pulled the hardware out of a failure state.
 		// We do this by checking if the hardware was in a failure state and
 		// now it's not.
-		curBroadcast, err := broadcastFromVars(req.BroadcastVars, cfg.Name)
+		curBroadcast, err := broadcastFromVars(req.BroadcastVars, cfg.UUID)
 		if errors.Is(err, ErrBroadcastNotFound{}) {
 			// Assume the broadcast is newly saved.
 		} else if err != nil {
@@ -575,7 +575,7 @@ func resetState(ctx context.Context, cfg *Cfg) error {
 // list and CurrentBroadcast config to clear the form on next page write.
 func deleteBroadcast(ctx context.Context, req *broadcastRequest, store datastore.Store) error {
 	cfg := &req.CurrentBroadcast
-	err := model.DeleteVariable(ctx, store, cfg.SKey, broadcastScope+"."+cfg.Name)
+	err := model.DeleteVariable(ctx, store, cfg.SKey, broadcastScope+"."+cfg.UUID)
 	if err != nil {
 		return fmt.Errorf("could not delete broadcast: %v", err)
 	}
@@ -614,10 +614,10 @@ func loadExistingSettings(r *http.Request, req *broadcastRequest) (bool, error) 
 
 // getExistingAccount will return the current associated account of the broadcast with the current config
 // name. This should be used to ensure that the associated account is only updated using the generate token method.
-// If no broadcast/account is found, then an empty string will be returned
+// If no broadcast/account is found, then an empty string will be returned.
 func getExistingAccount(broadcasts []model.Variable, cfg *BroadcastConfig) (string, error) {
-	cfg, err := broadcastFromVars(broadcasts, cfg.Name)
-	if errors.Is(err, ErrBroadcastNotFound{}) {
+	cfg, err := broadcastFromVars(broadcasts, cfg.UUID)
+	if errors.Is(err, ErrBroadcastNotFound{cfg.UUID}) {
 		return "", nil
 	}
 	if err != nil {

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.35.0"
+	version     = "v0.35.1"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/utils.go
+++ b/cmd/oceanbench/utils.go
@@ -116,11 +116,11 @@ func (e ErrBroadcastNotFound) Is(target error) bool {
 }
 
 // broadcastFromVars searches a slice of broadcast variables for a broadcast
-// config with the provided name and returns if found, otherwise an error is
+// config with the provided uuid and returns if found, otherwise an error is
 // returned.
-func broadcastFromVars(broadcasts []model.Variable, name string) (*BroadcastConfig, error) {
+func broadcastFromVars(broadcasts []model.Variable, uuid string) (*BroadcastConfig, error) {
 	for _, v := range broadcasts {
-		if name == v.Name || name == strings.TrimPrefix(v.Name, broadcastScope+".") {
+		if uuid == v.Name || uuid == strings.TrimPrefix(v.Name, broadcastScope+".") {
 			var cfg BroadcastConfig
 			err := json.Unmarshal([]byte(v.Value), &cfg)
 			if err != nil {
@@ -129,7 +129,7 @@ func broadcastFromVars(broadcasts []model.Variable, name string) (*BroadcastConf
 			return &cfg, nil
 		}
 	}
-	return nil, ErrBroadcastNotFound{name}
+	return nil, ErrBroadcastNotFound{uuid}
 }
 
 // isTimeStr returns true if the provided string is a valid 24hr time in format


### PR DESCRIPTION
This change fixes a few bugs, and potential bugs by ensuring more of the logic was using UUIDs. All of the current datastore broadcasts have been updated to UUIDs, and so no handling for other versions is guaranteed to work, so local filestores may have to be updated. Saving a broadcast without a UUID should still generate a new UUID for it.

closes #666 :imp: 