### PR TITLE
Fix: align labels and inputs evenly

### DIFF
--- a/cmd/oceanbench/s/main.css
+++ b/cmd/oceanbench/s/main.css
@@ -144,3 +144,23 @@ th.wide { width: 20rem; }
 
 
 div[popover] {position: fixed; width: 100vw; height: 100vh; background: #00000088}
+
+.inline {
+  label {
+    padding: 0.2rem;
+    margin: 0.2rem;
+    width: 20%;
+  }
+
+  input {
+    margin: 0.2rem;
+    padding: 0.2rem;
+  }
+}
+
+#users {
+  th,
+  td {
+    padding: 5px;
+  }
+}


### PR DESCRIPTION
Inputs and labels were aligned as shown in the following screenshot:
<img width="1499" height="790" alt="Screenshot 2025-12-01 at 17 43 39" src="https://github.com/user-attachments/assets/122aeb95-58d5-47a1-ad95-085bf8caff4b" />
