### PR TITLE
Fix: Refresh button always visible (#670)

### DIFF
--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -41,7 +41,7 @@
       <div class="border rounded p-4 container-md bg-white">
         <form action="/admin/broadcast" enctype="multipart/form-data" method="post">
           <div class="d-flex align-items-center gap-1 mb-1">
-            <button class="advanced btn btn-primary btn-sm" onclick="submitSelect()">Refresh</button>
+            <button class="btn btn-primary btn-sm" onclick="submitSelect()">Refresh</button>
           </div>
           <div class="d-flex align-items-center gap-1 mb-1">
             <label for="broadcast-select" class="w-25 text-end">Select Broadcast:</label>


### PR DESCRIPTION
This PR makes the Refresh button always visible instead of only in Advanced Options.
This is my first contribution to this project — if I’ve made any mistakes, I sincerely apologize.

✔️ Fixes issue #670