### PR TITLE
oceantv: Fix test that expected the log format to never change

### DIFF
--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -1385,8 +1385,8 @@ func TestHandleCameraConfiguration(t *testing.T) {
 			expectedNotify: map[int64]map[notify.Kind][]string{
 				testSiteKey: {
 					broadcastConfiguration: []string{
-						"(name: , id: ) error event: (invalidConfigurationEvent) camera mac is empty",
-						"(name: , id: ) entering direct broadcast failure state due to: (invalidConfigurationEvent) camera mac is empty",
+						"error event: (invalidConfigurationEvent) camera mac is empty",
+						"entering direct broadcast failure state due to: (invalidConfigurationEvent) camera mac is empty",
 					},
 				},
 			},

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -505,7 +505,8 @@ func (m *mockNotifier) checkNotifications(want map[int64]map[notify.Kind][]strin
 				)
 			}
 			for i, msg := range msgs {
-				if !strings.Contains(msg, m.sent[skey][kind][i]) {
+				// Check that the actual message contains the expected message.
+				if !strings.Contains(m.sent[skey][kind][i], msg) {
 					return fmt.Errorf("expected message %s for site %d and kind %s, got %s", msg, skey, kind, m.sent[skey][kind][i])
 				}
 			}


### PR DESCRIPTION
This is so that the log format can change in the future.