### PR TITLE
OTV: Send idle states to ausoceanTV (#680)

### DIFF
--- a/cmd/oceantv/hooks.go
+++ b/cmd/oceantv/hooks.go
@@ -134,9 +134,10 @@ func (d *aotvWebHookData) subject() string {
 // ausoceanTVWebhook is a callback function used to make webhook requests to the
 // AusOceanTV service.
 func ausoceanTVWebhook(s state, cfg *Cfg) {
-	// Only continue if we have a directLive state.
-	// NOTE this can be removed if we wish to webhook for all states.
-	if _, ok := s.(*directLive); !ok {
+	// Only continue if we have a directLive or directIdle state.
+	_, live := s.(*directLive)
+	_, idle := s.(*directIdle)
+	if !live && !idle {
 		return
 	}
 

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	projectID             = "oceantv"
-	version               = "v0.13.3"
+	version               = "v0.13.4"
 	projectURL            = "https://tv.cloudblue.org"
 	cronServiceAccount    = "oceancron@appspot.gserviceaccount.com"
 	oceanTVServiceAccount = "oceantv@appspot.gserviceaccount.com"


### PR DESCRIPTION
This change now sends webhooks for idle states as well as live states which will allow the subfeeds on AusOceanTV to be marked as inactive.

requires ausocean/ausoceantv#176
closes #680 