### PR TITLE
bench: check if input is a radio button before skipping

### DIFF
--- a/cmd/oceanbench/s/device.js
+++ b/cmd/oceanbench/s/device.js
@@ -39,11 +39,11 @@ async function updateVars(event, deleteVar) {
   const vv = form.querySelectorAll("input[name=vv]");
   let values = [];
   vv.forEach((elem) => {
-    // Only use the value if the input is both shown, and checked.
+    // Only use the value if the input is both shown, and checked (if it is a radio button).
     if (elem.getAttribute("hidden") == "true") {
       return;
     }
-    if (!elem.checked) {
+    if (!elem.checked && elem.type == "radio") {
       return;
     }
     values.push(elem.value);


### PR DESCRIPTION
This fixes a regression that caused non-radio buttons to send an empty value when changed. The checked property only exists for radio buttons, which causes all other input types to be skipped as !undefined == true.