### PR TITLE
datastore: add datastore package from openfish

### DIFF
--- a/datastore/cache.go
+++ b/datastore/cache.go
@@ -1,0 +1,108 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package datastore
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Cache defines the (optional) caching interface used by Entity.
+type Cache interface {
+	Set(key *Key, src Entity) error // Set adds or updates a value to the cache.
+	Get(key *Key, dst Entity) error // Get retrieves a value from the cache, or returns ErrCacheMiss.
+	Delete(key *Key)                // Delete removes a value from the cache.
+	Reset()                         // Reset resets (clears) the cache.
+}
+
+// EntityCache, which implements Cache, represents a cache for holding
+// datastore entities indexed by key.
+type EntityCache struct {
+	data  map[Key]Entity
+	mutex sync.RWMutex
+}
+
+// ErrCacheMiss is the type of error returned when a key is not found in the cache.
+type ErrCacheMiss struct {
+	key Key
+}
+
+// Error returns an error string for errors of type ErrCacheMiss.
+func (e ErrCacheMiss) Error() string {
+	return fmt.Sprintf("cache miss for key: %v", e.key)
+}
+
+// NewEntityCache returns a new EntityCache.
+func NewEntityCache() *EntityCache {
+	return &EntityCache{data: make(map[Key]Entity)}
+}
+
+// Set adds or updates a value to the cache.
+func (c *EntityCache) Set(key *Key, src Entity) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	v, err := src.Copy(nil)
+	if err != nil {
+		return err
+	}
+	c.data[*key] = v
+	return nil
+}
+
+// Get retrieves a value from the cache, or returns ErrcacheMiss.
+func (c *EntityCache) Get(key *Key, dst Entity) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	v, ok := c.data[*key]
+	if !ok {
+		return ErrCacheMiss{*key}
+	}
+	_, err := v.Copy(dst)
+	return err
+}
+
+// Delete removes a value from the cache.
+func (c *EntityCache) Delete(key *Key) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.data, *key)
+}
+
+// Reset resets (clears) the cache.
+func (c *EntityCache) Reset() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.data = map[Key]Entity{}
+}
+
+// NilCache returns a nil Cache, which denotes no caching.
+func NilCache() Cache {
+	return nil
+}
+
+// NoCache is a helper struct to reduce boilerplate code when implementing the Entity interface for entities that do not require caching.
+type NoCache struct{}
+
+// GetCache returns nil, indicating no caching.
+func (NoCache) GetCache() Cache {
+	return nil
+}

--- a/datastore/cache_test.go
+++ b/datastore/cache_test.go
@@ -1,0 +1,124 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package datastore
+
+import (
+	"errors"
+	"testing"
+)
+
+func Test(t *testing.T) {
+	tests := []struct {
+		action, name, value, want string
+		ok                        bool // true if action returns an error and is expected to succeed.
+	}{
+		{
+			action: "get",
+			name:   "a",
+			ok:     false,
+		},
+		{
+			action: "set",
+			name:   "a",
+			value:  "aa",
+		},
+		{
+			action: "get",
+			name:   "a",
+			want:   "aa",
+			ok:     true,
+		},
+		{
+			action: "set",
+			name:   "b",
+			value:  "bb",
+		},
+		{
+			action: "delete",
+			name:   "a",
+		},
+		{
+			action: "get",
+			name:   "a",
+			ok:     false,
+		},
+		{
+			action: "get",
+			name:   "b",
+			want:   "bb",
+			ok:     true,
+		},
+		{
+			action: "reset",
+		},
+		{
+			action: "get",
+			name:   "b",
+			ok:     false,
+		},
+	}
+
+	var cache Cache = NewEntityCache()
+
+	for i, test := range tests {
+		var k Key = Key{Name: test.name}
+
+		switch test.action {
+		case "get":
+			var v NameValue
+			err := cache.Get(&k, &v)
+			if err != nil {
+				if test.ok {
+					t.Errorf("Test %d: Get(%s) returned unexpected error: %v", i, test.name, err)
+				}
+				var errCacheMiss ErrCacheMiss
+				if !errors.As(err, &errCacheMiss) {
+					t.Errorf("Test %d: Get(%s) returned wrong error: %v", i, test.name, err)
+				}
+				continue // Got expected type of error.
+			}
+			if !test.ok {
+				t.Errorf("Test %d: Get(%s) did not return error", i, test.name)
+			}
+			if test.want != v.Value {
+				t.Errorf("Test %d: Get(%s) returned wrong value: %s", i, test.name, v.Value)
+			}
+
+		case "set":
+			v := NameValue{Name: test.name, Value: test.value}
+			err := cache.Set(&k, &v)
+			if err != nil {
+				t.Errorf("Test %d: Set(%s,%s) returned unexpected error: %v", i, test.name, test.value, err)
+			}
+
+		case "delete":
+			cache.Delete(&k)
+
+		case "reset":
+			cache.Reset()
+
+		default:
+			panic("unexpected test action: " + test.action)
+		}
+
+	}
+}

--- a/datastore/cloudstore.go
+++ b/datastore/cloudstore.go
@@ -1,0 +1,268 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"cloud.google.com/go/datastore"
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+)
+
+// CloudStore implements Store for the Google Cloud Datastore.
+type CloudStore struct {
+	client *datastore.Client
+}
+
+// newCloudStore returns a new CloudStore, using the given URL to
+// retrieve credentials and authenticate.
+// The ID can be passed with an optional database name in the format
+// <ID>/<Database_Name>, if there is no database name given, the default
+// database will be used.
+// To obtain credentials from a Google storage bucket, URL takes the
+// form gs://bucket_name/creds. A URL without a scheme is interpreted
+// as a file. If the environment variable <ID>_CREDENTIALS is defined
+// it overrides the supplied URL.
+func newCloudStore(ctx context.Context, id, url string) (*CloudStore, error) {
+	s := new(CloudStore)
+
+	var db string
+	parts := strings.Split(id, "/")
+	if len(parts) == 2 {
+		db = parts[1]
+	} else if len(parts) != 1 {
+		return nil, ErrInvalidStoreID
+	}
+
+	id = parts[0]
+
+	ev := strings.ToUpper(id) + "_CREDENTIALS"
+	if os.Getenv(ev) != "" {
+		url = os.Getenv(ev)
+	}
+
+	var err error
+	if url == "" {
+		// Attempt authentication using the default credentials.
+		s.client, err = datastore.NewClientWithDatabase(ctx, id, db)
+		if err != nil {
+			log.Printf("datastore.NewCient failed: %v ", err)
+			return nil, err
+		}
+		return s, nil
+	}
+
+	var creds []byte
+	if strings.HasPrefix(url, "gs://") {
+		// Obtain credentials from a Google Storage bucket.
+		url = url[5:]
+		sep := strings.IndexByte(url, '/')
+		if sep == -1 {
+			log.Printf("invalid gs bucket URL: %s", url)
+			return nil, errors.New("invalid gs bucket URL")
+		}
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			log.Printf("storage.NewCient failed: %v ", err)
+			return nil, err
+		}
+		bkt := client.Bucket(url[:sep])
+		obj := bkt.Object(url[sep+1:])
+		r, err := obj.NewReader(ctx)
+		if err != nil {
+			log.Printf("NewReader failed for gs bucket %s: %v", url, err)
+			return nil, err
+		}
+		defer r.Close()
+		creds, err = ioutil.ReadAll(r)
+		if err != nil {
+			log.Printf("cannot read gs bucket %s: %v ", url, err)
+			return nil, err
+		}
+
+	} else {
+		// Interpret url as a file name.
+		creds, err = ioutil.ReadFile(url)
+		if err != nil {
+			log.Printf("cannot read file %s: %v", url, err)
+			return nil, err
+		}
+	}
+
+	s.client, err = datastore.NewClientWithDatabase(ctx, id, db, option.WithCredentialsJSON(creds))
+	return s, err
+}
+
+// IDKey returns an ID key given a kind and an int64 ID.
+func (s *CloudStore) IDKey(kind string, id int64) *Key {
+	return datastore.IDKey(kind, id, nil)
+}
+
+// NameKey returns an name key given a kind and a (string) name.
+func (s *CloudStore) NameKey(kind, name string) *Key {
+	return datastore.NameKey(kind, name, nil)
+}
+
+// IncompleteKey returns an incomplete key given a kind.
+func (s *CloudStore) IncompleteKey(kind string) *Key {
+	return datastore.IncompleteKey(kind, nil)
+}
+
+// NewQuery returns a new CloudQuery and is a wrapper for
+// datastore.NewQuery. If keysOnly is true the query is set to keys
+// only, but keyParts are ignored.
+func (s *CloudStore) NewQuery(kind string, keysOnly bool, keyParts ...string) Query {
+	q := new(CloudQuery)
+	q.query = datastore.NewQuery(kind)
+	if keysOnly {
+		q.query = q.query.KeysOnly()
+	}
+	return q
+}
+
+func (s *CloudStore) Get(ctx context.Context, key *Key, dst Entity) error {
+	if cache := dst.GetCache(); cache != nil {
+		err := cache.Get(key, dst)
+		if err == nil {
+			return nil
+		}
+	}
+	err := s.client.Get(ctx, key, dst)
+	if err == datastore.ErrNoSuchEntity {
+		return ErrNoSuchEntity
+	}
+	return err
+}
+
+func (s *CloudStore) GetAll(ctx context.Context, query Query, dst interface{}) ([]*Key, error) {
+	q, ok := query.(*CloudQuery)
+	if !ok {
+		return nil, errors.New("expected *CloudQuery type")
+	}
+	return s.client.GetAll(ctx, q.query, dst)
+}
+
+func (s *CloudStore) Create(ctx context.Context, key *Key, src Entity) error {
+	_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+		err := tx.Get(key, src)
+		if err == nil {
+			return ErrEntityExists
+		}
+		if err != ErrNoSuchEntity {
+			return err
+		}
+		_, err = tx.Put(key, src)
+		return err
+	})
+	return err
+}
+
+func (s *CloudStore) Put(ctx context.Context, key *Key, src Entity) (*Key, error) {
+	key, err := s.client.Put(ctx, key, src)
+	if err != nil {
+		return key, err
+	}
+	if cache := src.GetCache(); cache != nil {
+		cache.Set(key, src)
+	}
+	return key, err
+}
+
+func (s *CloudStore) Update(ctx context.Context, key *Key, fn func(Entity), dst Entity) error {
+	_, err := s.client.RunInTransaction(ctx, func(tx *datastore.Transaction) error {
+		err := tx.Get(key, dst)
+		if err != nil {
+			return err
+		}
+		fn(dst)
+		_, err = tx.Put(key, dst)
+		return err
+	})
+	return err
+}
+
+func (s *CloudStore) DeleteMulti(ctx context.Context, keys []*Key) error {
+	err := s.client.DeleteMulti(ctx, keys)
+	if err != nil {
+		return err
+	}
+	for _, k := range keys {
+		if cache := GetCache(k.Kind); cache != nil {
+			cache.Delete(k)
+		}
+	}
+	return nil
+}
+
+func (s *CloudStore) Delete(ctx context.Context, key *Key) error {
+	err := s.client.Delete(ctx, key)
+	if err != nil {
+		return err
+	}
+	if cache := GetCache(key.Kind); cache != nil {
+		cache.Delete(key)
+	}
+	return nil
+}
+
+// CloudQuery implements Query for the Google Cloud Datastore.
+type CloudQuery struct {
+	query *datastore.Query
+}
+
+func (q *CloudQuery) Filter(filterStr string, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	q.query = q.query.Filter(filterStr, value)
+	return nil
+}
+
+// FilterField filters a query.
+func (q *CloudQuery) FilterField(fieldName string, operator string, value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	q.query = q.query.FilterField(fieldName, operator, value)
+	return nil
+}
+
+func (q *CloudQuery) Order(fieldName string) {
+	q.query = q.query.Order(fieldName)
+}
+
+// Limit limits the number of results returned.
+func (q *CloudQuery) Limit(limit int) {
+	q.query = q.query.Limit(limit)
+}
+
+// Offset sets the number of keys to skip before returning results.
+func (q *CloudQuery) Offset(offset int) {
+	q.query = q.query.Offset(offset)
+}

--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -1,0 +1,244 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+// Package datastore offers common datastore API with multiple store implementations:
+//
+//   - CloudStore is a Google datastore implementation.
+//   - FileStore is a simple file-based store implementation.
+package datastore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+
+	"cloud.google.com/go/datastore"
+)
+
+// CloudStore limits.
+const (
+	MaxKeys = 500     // Maximum number of datastore keys to retrieve in one go.
+	MaxBlob = 1000000 // 1MB
+)
+
+// FileStore constants.
+const (
+	EpochStart  = 1483228800    // Start of the AusOcean epoch, namely 2017-01-01 00:00:00+Z.
+	EpochEnd    = math.MaxInt64 // End of the epoch.
+	SubTimeBits = 3             // Sub-second time bits.
+)
+
+var (
+	ErrDecoding        = errors.New("decoding error")
+	ErrUnimplemented   = errors.New("unimplemented feature")
+	ErrInvalidField    = errors.New("invalid field")
+	ErrInvalidFilter   = errors.New("invalid filter")
+	ErrInvalidOperator = errors.New("invalid operator")
+	ErrInvalidValue    = errors.New("invalid value")
+	ErrOperatorMissing = errors.New("operator missing")
+	ErrNoSuchEntity    = datastore.ErrNoSuchEntity
+	ErrEntityExists    = errors.New("entity exists")
+	ErrWrongType       = errors.New("wrong type")
+	ErrInvalidType     = datastore.ErrInvalidEntityType
+	ErrInvalidStoreID  = errors.New("invalid datastore id")
+)
+
+// We reuse some Google Datastore types.
+type (
+	Key      = datastore.Key      // Datastore key.
+	Property = datastore.Property // Datastore property.
+)
+
+// Entity defines the common interface for our datastore entities.
+type Entity interface {
+	Copy(dst Entity) (Entity, error) // Copy an entity to dst, or return a copy of the entity when dst is nil.
+	GetCache() Cache                 // Returns a cache, or nil for no caching.
+}
+
+// EntityEncoder defines an Entity with a custom encoding function.
+type EntityEncoder interface {
+	Encode() []byte // Encode an entity into bytes.
+}
+
+// EntityDecoder defines an Entity with a custom decoding function.
+type EntityDecoder interface {
+	Decode([]byte) error // Decode bytes into an entity.
+}
+
+// CopyEntity copies src into dst (if non-nil) or allocates a new *T.
+// It also enforces that dst is of the correct concrete type.
+//
+// It is a generic helper function to reduce boilerplate code when implementing the Entity interface.
+// T is the concrete struct type (e.g. Plan), and PT is a pointer to T (e.g. *Plan).
+// PT must implement the Entity interface.
+func CopyEntity[T any, PT interface {
+	*T
+	Entity
+}](src PT, dst Entity) (Entity, error) {
+	if dst == nil {
+		dst = PT(new(T))
+	}
+
+	v, ok := dst.(PT)
+	if !ok {
+		return nil, ErrWrongType
+	}
+
+	*v = *src
+	return v, nil
+}
+
+// encode encodes an entity into bytes, by default using json.Marshal.
+func encode(e Entity) []byte {
+	encodable, ok := e.(EntityEncoder)
+	if ok {
+		return encodable.Encode()
+	}
+	bytes, _ := json.Marshal(e)
+	return bytes
+}
+
+// decode decodes an entity from bytes, by default using json.Unmarshal.
+func decode(e Entity, b []byte) error {
+	decodable, ok := e.(EntityDecoder)
+	if ok {
+		return decodable.Decode(b)
+	}
+
+	// Default implementation.
+	return json.Unmarshal(b, e)
+}
+
+// newEntity maps entity type names to their respective constructor function.
+// It is populated by RegisterEntity.
+var newEntity = map[string]func() Entity{}
+
+// Store defines the datastore interface. It is a blend and subset of
+// Google Cloud datastore functions and datastore.Client methods.
+//
+// See also https://godoc.org/cloud.google.com/go.
+type Store interface {
+	IDKey(kind string, id int64) *Key                                        // Returns an ID key.
+	NameKey(kind, name string) *Key                                          // Returns a name key.
+	IncompleteKey(kind string) *Key                                          // Returns an incomplete key.
+	NewQuery(kind string, keysOnly bool, keyParts ...string) Query           // Returns a new query.
+	Get(ctx context.Context, key *Key, dst Entity) error                     // Gets a single entity by its key.
+	GetAll(ctx context.Context, q Query, dst interface{}) ([]*Key, error)    // Runs a query and returns all matching entities.
+	Create(ctx context.Context, key *Key, src Entity) error                  // Creates a single entity by its key.
+	Put(ctx context.Context, key *Key, src Entity) (*Key, error)             // Put or creates a single entity by its key.
+	Update(ctx context.Context, key *Key, fn func(Entity), dst Entity) error // Atomically updates a single entity by its key.
+	Delete(ctx context.Context, key *Key) error                              // Deletes a single entity by its key.
+	DeleteMulti(ctx context.Context, keys []*Key) error                      // Deletes multiple entities by their keys.
+}
+
+// Query defines the query interface, which is a subset of Google
+// Cloud's datastore.Query. Note that unlike datastore.Query methods,
+// these methods modify the Query value without returning it.
+// A nil value denotes a wild card (match anything).
+//
+// See also Google Cloud datastore.Query.Filter and datastore.Query.Order.
+type Query interface {
+	Filter(filterStr string, value interface{}) error                       // Filters a query (deprecated).
+	FilterField(fieldName string, operator string, value interface{}) error // Filters a query.
+	Order(fieldName string)                                                 // Orders a query.
+	Limit(limit int)                                                        // Limits the number of results returned.
+	Offset(offset int)                                                      // How many keys to skip before returning results.
+}
+
+// RegisterEntity registers a new kind of entity and its constructor.
+func RegisterEntity(kind string, construct func() Entity) {
+	newEntity[kind] = construct
+}
+
+// NewEntity instantiates a new entity of the given kind, else returns an error.
+func NewEntity(kind string) (Entity, error) {
+	construct, ok := newEntity[kind]
+	if !ok {
+		return nil, ErrInvalidType
+	}
+	return construct(), nil
+}
+
+// NewStore returns a new Store. If kind is "cloud" a CloudStore is
+// returned. If kind is "file" a FileStore is returned. The id is the
+// Project ID of the requested datastore service. The url parameter is
+// a URL to credentials for CloudStore, or a directory path for
+// FileStore.
+func NewStore(ctx context.Context, kind, id, url string) (s Store, err error) {
+	switch kind {
+	case "cloud":
+		return newCloudStore(ctx, id, url)
+	case "file":
+		return newFileStore(ctx, id, url)
+	default:
+		return nil, errors.New("unexpected kind: " + kind)
+	}
+}
+
+// IDKey makes a datastore ID key by combining an ID, a Unix timestamp
+// and an optional subtime (st). The latter is used to
+// disambiguate otherwise-identical timestamps.
+//
+//   - The least significant 32 bits of the ID.
+//   - The timestamp from the start of the "AusOcean epoch", 2017-01-01 00:00:00+Z (29 bits).
+//   - The subtime (3 bits).
+func IDKey(id, ts, st int64) int64 {
+	ts = ts - EpochStart
+	if ts < 0 {
+		ts = 0
+	}
+	return id<<32 | ts<<SubTimeBits | st&((1<<SubTimeBits)-1)
+}
+
+// SplitIDKey is the inverse of IDKey and splits an ID key into
+// its parts. See IDKey.
+func SplitIDKey(id int64) (int64, int64, int64) {
+	return int64(uint64(id) >> 32), ((id & 0xffffffff) >> SubTimeBits) + EpochStart, id & ((1 << SubTimeBits) - 1)
+}
+
+// DeleteMulti is a wrapper for store.DeleteMulti which returns the
+// number of deletions.
+func DeleteMulti(ctx context.Context, store Store, keys []*Key) (int, error) {
+	n := 0
+	for sz := len(keys); sz > 0; sz = len(keys) {
+		if sz > MaxKeys {
+			sz = MaxKeys
+		}
+		err := store.DeleteMulti(ctx, keys[:sz])
+		if err != nil {
+			return n, err
+		}
+		n += sz
+		keys = keys[sz:]
+	}
+	return n, nil
+}
+
+// GetCache returns a cache corresponding to a given kind, or nil otherwise.
+func GetCache(kind string) Cache {
+	entity := newEntity[kind]
+	if entity == nil {
+		return nil
+	}
+	return entity().GetCache()
+}

--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -1,0 +1,594 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+const typeNameValue = "NameValue" // NameValue datastore type.
+const typeMixed = "Mixed"         // Mixed datastore type.
+
+// NameValue represents a key/value pair.
+type NameValue struct {
+	Name  string
+	Value string
+	cache Cache
+}
+
+// Encode serializes a NameValue into tab-separated values.
+func (v *NameValue) Encode() []byte {
+	return []byte(fmt.Sprintf("%s\t%s", v.Name, v.Value))
+}
+
+// Decode deserializes a NameValue from tab-separated values.
+func (v *NameValue) Decode(b []byte) error {
+	p := strings.Split(string(b), "\t")
+	if len(p) != 2 {
+		return ErrDecoding
+	}
+	v.Name = p[0]
+	v.Value = p[1]
+	return nil
+}
+
+// Copy copies a NameValue to dst, or returns a copy of the NameValue when dst is nil.
+func (v *NameValue) Copy(dst Entity) (Entity, error) {
+	return CopyEntity(v, dst)
+}
+
+// GetCache returns the NameValue cache.
+func (v *NameValue) GetCache() Cache {
+	return v.cache
+}
+
+// Mixed represents a mixed entity for testing various comparisons.
+type Mixed struct {
+	ID      string    // primary key
+	Str     string    // test string comparisons
+	Int     int64     // test integer comparisons
+	Float   float64   // test float comparisons
+	Created time.Time // test time comparisons if needed
+	cache   Cache
+}
+
+// Copy copies a Mixed to dst, or returns a copy of the Mixed when dst is nil.
+func (m *Mixed) Copy(dst Entity) (Entity, error) {
+	return CopyEntity(m, dst)
+}
+
+// GetCache returns the Mixed cache.
+func (m *Mixed) GetCache() Cache {
+	return m.cache
+}
+
+// CreateNameValue creates a NameValue.
+func CreateNameValue(ctx context.Context, store Store, key, value string) error {
+	k := store.NameKey(typeNameValue, key)
+	v := &NameValue{Name: key, Value: value}
+	return store.Create(ctx, k, v)
+}
+
+// PutNameValue creates or updates a NameValue.
+func PutNameValue(ctx context.Context, store Store, key, value string) error {
+	k := store.NameKey(typeNameValue, key)
+	v := &NameValue{Name: key, Value: value}
+	_, err := store.Put(ctx, k, v)
+	return err
+}
+
+// GetNameValue gets a NameValue.
+func GetNameValue(ctx context.Context, store Store, key string) (*NameValue, error) {
+	k := store.NameKey(typeNameValue, key)
+	v := new(NameValue)
+	return v, store.Get(ctx, k, v)
+}
+
+// UpdateNameValue updates a NameValue by applying the given function.
+func UpdateNameValue(ctx context.Context, store Store, key string, fn func(Entity)) (*NameValue, error) {
+	k := store.NameKey(typeNameValue, key)
+	v := new(NameValue)
+	return v, store.Update(ctx, k, fn, v)
+}
+
+// DeleteNameValue deletes a NameValue.
+func DeleteNameValue(ctx context.Context, store Store, key string) error {
+	k := store.NameKey(typeNameValue, key)
+	return store.DeleteMulti(ctx, []*Key{k})
+}
+
+// init registers the NameValue entitity.
+func init() {
+	RegisterEntity(typeNameValue, func() Entity { return new(NameValue) })
+	RegisterEntity(typeMixed, func() Entity { return new(Mixed) })
+}
+
+// TestFile tests the file store.
+func TestFile(t *testing.T) {
+	testNameValue(t, "file", nil)
+}
+
+// TestCloud tests the cloud store without caching.
+// OPENFISH_CREDENTIALS must be supplied.
+func TestCloud(t *testing.T) {
+	if os.Getenv("OPENFISH_CREDENTIALS") == "" {
+		t.Skip("OPENFISH_CREDENTIALS")
+	}
+	testNameValue(t, "cloud", nil)
+}
+
+// TestCloudCaching tests the cloud store with caching.
+// OPENFISH_CREDENTIALS must be supplied.
+func TestCloudCaching(t *testing.T) {
+	if os.Getenv("OPENFISH_CREDENTIALS") == "" {
+		t.Skip("OPENFISH_CREDENTIALS")
+	}
+	testNameValue(t, "cloud", NewEntityCache())
+}
+
+// testNameValue tests various NameValue methods.
+func testNameValue(t *testing.T, kind string, cache Cache) {
+	ctx := context.Background()
+
+	store, err := NewStore(ctx, kind, "openfish", "")
+	if err != nil {
+		t.Errorf("NewStore(%s, openfish) failed with error: %v", kind, err)
+	}
+
+	tests := []struct {
+		key   string
+		value string
+		cache Cache
+	}{
+		{
+			key:   "foo",
+			value: "bar1",
+			cache: cache,
+		},
+		{
+			key:   "_foo",
+			value: "bar2",
+			cache: cache,
+		},
+		{
+			key:   "dev.foo",
+			value: "bar3",
+			cache: cache,
+		},
+	}
+
+	for i, test := range tests {
+		err = PutNameValue(ctx, store, test.key, test.value)
+		if err != nil {
+			t.Errorf("PutNameValue %d failed with error: %v", i, err)
+		}
+		err = CreateNameValue(ctx, store, test.key, test.value)
+		if err != ErrEntityExists {
+			t.Errorf("CreateNameValue %d failed with unexpected error: %v", i, err)
+		}
+		v, err := GetNameValue(ctx, store, test.key)
+		if err != nil {
+			t.Errorf("GetNameValue %d failed with error: %v", i, err)
+		}
+		if v.Value != test.value {
+			t.Errorf("GetNameValue %d returned wrong value; expected %s, got %s", i, test.value, v.Value)
+		}
+		v, err = UpdateNameValue(ctx, store, test.key, clearValue)
+		if err != nil {
+			t.Errorf("UpdateNameValue %d failed with error: %v", i, err)
+		}
+		if v.Value != "" {
+			t.Errorf("GetNameValue %d returned wrong value; expected empty string, got %s", i, v.Value)
+		}
+		err = DeleteNameValue(ctx, store, test.key)
+		if err != nil {
+			t.Errorf("DeleteNameValue %d failed with error: %v", i, err)
+		}
+		if test.cache != nil {
+			// Check that the value was cleared from the cache.
+			k := store.NameKey(typeNameValue, test.key)
+			var v NameValue
+			err := cache.Get(k, &v)
+			if err == nil {
+				t.Errorf("cache.Get %d returned no error", i)
+			}
+			var errCacheMiss ErrCacheMiss
+			if !errors.As(err, &errCacheMiss) {
+				t.Errorf("cache.Get %d returned wrong error: %v", i, err)
+			}
+		}
+	}
+}
+
+// clearValue clears the value of a NameValue.
+func clearValue(e Entity) {
+	v, ok := e.(*NameValue)
+	if ok {
+		v.Value = ""
+	}
+}
+
+// TestFileDirect tests direct file store operations.
+func TestFileDirect(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewStore(ctx, "file", "test", "store")
+	if err != nil {
+		t.Fatalf("could not create file store: %v", err)
+	}
+
+	const (
+		name1 = "1"
+		name2 = "2"
+		value = "localuser@localhost"
+	)
+
+	// Put two NameValue entities with the same value.
+	_, err = store.Put(ctx, store.NameKey(typeNameValue, name1+"."+value), &NameValue{Name: name1, Value: value})
+	if err != nil {
+		t.Errorf("Put name1 failed: %v", err)
+	}
+	_, err = store.Put(ctx, store.NameKey(typeNameValue, name2+"."+value), &NameValue{Name: name2, Value: value})
+	if err != nil {
+		t.Errorf("Put name2 failed: %v", err)
+	}
+
+	// GetAll by name, returning key only.
+	q := store.NewQuery(typeNameValue, true, "Name", "Value")
+	q.Filter("Name =", name1)
+	keys, err := store.GetAll(ctx, q, nil)
+	if err != nil {
+		t.Errorf("GetAll by name, keys only failed: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Errorf("GetAll by name returned %d keys, expected 1", len(keys))
+	}
+
+	// GetAll by name, returning 1 entity.
+	q = store.NewQuery(typeNameValue, false, "Name", "Value")
+	q.Filter("Name =", name1)
+	var entities []NameValue
+	_, err = store.GetAll(ctx, q, &entities)
+	if err != nil {
+		t.Errorf("GetAll by name, returning entities failed: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Errorf("GetAll by name returned %d entities, expected 1", len(entities))
+	}
+
+	// GetAll by value, returning 2 entities.
+	q = store.NewQuery(typeNameValue, false, "Name", "Value")
+	q.Filter("Value =", value)
+	entities = nil
+	_, err = store.GetAll(ctx, q, &entities)
+	if err != nil {
+		t.Errorf("GetAll by value failed: %v", err)
+	}
+	if len(entities) != 2 {
+		t.Errorf("GetAll by value returned %d entities, expected 2", len(entities))
+	}
+
+	// GetAll by value, returning entities, limited to 1.
+	q = store.NewQuery(typeNameValue, false, "Name", "Value")
+	q.Filter("Value =", value)
+	q.Limit(1)
+	entities = nil
+	_, err = store.GetAll(ctx, q, &entities)
+	if err != nil {
+		t.Errorf("GetAll by value failed: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Errorf("GetAll by value returned %d entities, expected 1", len(entities))
+	}
+}
+
+// TestFileFilterField tests filestore filtering by a field that is not part of the key.
+func TestFileFilterField(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewStore(ctx, "file", "test", "store")
+	if err != nil {
+		t.Fatalf("could not create file store: %v", err)
+	}
+
+	// Clear store dir for clean test (optional in your setup).
+	_ = os.RemoveAll("store/test/NameValue")
+
+	// Insert test data.
+	values := []NameValue{
+		{Name: "A", Value: "abalone"},
+		{Name: "B", Value: "bullseye"},
+		{Name: "C", Value: "abalone"},
+	}
+	for _, nv := range values {
+		_, err := store.Put(ctx, store.NameKey(typeNameValue, nv.Name), &nv)
+		if err != nil {
+			t.Fatalf("failed to insert test entity %s: %v", nv.Name, err)
+		}
+	}
+
+	// Filter by Value using FilterField (not part of key name).
+	q := store.NewQuery(typeNameValue, false, "Name") // keyParts only include Name.
+	q.FilterField("Value", "=", "abalone")
+
+	var results []NameValue
+	_, err = store.GetAll(ctx, q, &results)
+	if err != nil {
+		t.Fatalf("FilterField query failed: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results for Value = 'abalone', got %d", len(results))
+	}
+
+	// Filter by Name using FilterField (should fall back to Filter for efficiency).
+	q = store.NewQuery(typeNameValue, false, "Name")
+	q.FilterField("Name", "=", "B")
+
+	results = nil
+	_, err = store.GetAll(ctx, q, &results)
+	if err != nil {
+		t.Fatalf("FilterField fallback-to-key query failed: %v", err)
+	}
+	if len(results) != 1 || results[0].Name != "B" {
+		t.Errorf("expected 1 result for Name = 'B', got %+v", results)
+	}
+}
+
+func TestFileFilterFieldVariants(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewStore(ctx, "file", "test", "store")
+	if err != nil {
+		t.Fatalf("could not create file store: %v", err)
+	}
+
+	// Reset the directory for a clean run.
+	_ = os.RemoveAll("store/test/NameValue")
+
+	// Insert test data.
+	data := []NameValue{
+		{Name: "a", Value: "apple"},
+		{Name: "b", Value: "banana"},
+		{Name: "c", Value: "carrot"},
+		{Name: "d", Value: "apple"},
+		{Name: "e", Value: "eggplant"},
+		{Name: "f", Value: ""},
+		{Name: "g", Value: "ápple"}, // Unicode variant
+		{Name: "h", Value: "appl"},  // Prefix of "apple"
+		{Name: "i", Value: "Apple"}, // Capitalized
+		{Name: "j", Value: "zucchini"},
+	}
+	for _, nv := range data {
+		_, err := store.Put(ctx, store.NameKey(typeNameValue, nv.Name), &nv)
+		if err != nil {
+			t.Fatalf("failed to insert test entity %s: %v", nv.Name, err)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		field       string
+		operator    string
+		value       interface{}
+		keyParts    []string
+		limit       int
+		offset      int
+		expectNames []string
+	}{
+		{
+			name:        "Value = apple",
+			field:       "Value",
+			operator:    "=",
+			value:       "apple",
+			keyParts:    []string{"Name"},
+			expectNames: []string{"a", "d"},
+		},
+		{
+			name:        "Value < banana",
+			field:       "Value",
+			operator:    "<",
+			value:       "banana",
+			keyParts:    []string{"Name"},
+			expectNames: []string{"a", "d", "f", "h", "i"},
+		},
+		{
+			name:        "Value >= carrot",
+			field:       "Value",
+			operator:    ">=",
+			value:       "carrot",
+			keyParts:    []string{"Name"},
+			expectNames: []string{"c", "e", "g", "j"},
+		},
+		{
+			name:        "Value = '' (empty string)",
+			field:       "Value",
+			operator:    "=",
+			value:       "",
+			keyParts:    []string{"Name"},
+			expectNames: []string{"f"},
+		},
+		{
+			name:        "Unicode comparison (Value > apple)",
+			field:       "Value",
+			operator:    ">",
+			value:       "apple",
+			keyParts:    []string{"Name"},
+			expectNames: []string{"b", "c", "e", "g", "j"},
+		},
+		{
+			name:        "Name = h (uses key path)",
+			field:       "Name",
+			operator:    "=",
+			value:       "h",
+			keyParts:    []string{"Name"},
+			expectNames: []string{"h"},
+		},
+		{
+			name:        "Limit and offset combo",
+			field:       "Value",
+			operator:    ">",
+			value:       "a",
+			keyParts:    []string{"Name"},
+			limit:       2,
+			offset:      1,
+			expectNames: []string{"b", "c"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := store.NewQuery(typeNameValue, false, tc.keyParts...)
+			q.FilterField(tc.field, tc.operator, tc.value)
+			q.Order(tc.field)
+			if tc.limit > 0 {
+				q.Limit(tc.limit)
+			}
+			if tc.offset > 0 {
+				q.Offset(tc.offset)
+			}
+
+			var results []NameValue
+			_, err := store.GetAll(ctx, q, &results)
+			if err != nil {
+				t.Fatalf("GetAll failed: %v", err)
+			}
+
+			var gotNames []string
+			for _, r := range results {
+				gotNames = append(gotNames, r.Name)
+			}
+
+			if !equalUnordered(gotNames, tc.expectNames) {
+				t.Errorf("unexpected result names: got %v, want %v", gotNames, tc.expectNames)
+			}
+		})
+	}
+}
+
+func TestFileFilterFieldMixedTypes(t *testing.T) {
+	ctx := context.Background()
+	store, err := NewStore(ctx, "file", "test", "store")
+	if err != nil {
+		t.Fatalf("could not create file store: %v", err)
+	}
+	_ = os.RemoveAll("store/test/Mixed")
+
+	now := time.Now().UTC()
+	entities := []Mixed{
+		{ID: "1", Str: "alpha", Int: 10, Float: 1.1, Created: now.Add(-10 * time.Hour)},
+		{ID: "2", Str: "bravo", Int: 20, Float: 2.2, Created: now.Add(-5 * time.Hour)},
+		{ID: "3", Str: "charlie", Int: 30, Float: 3.3, Created: now.Add(-1 * time.Hour)},
+		{ID: "4", Str: "delta", Int: 40, Float: 4.4, Created: now},
+	}
+
+	for _, e := range entities {
+		_, err := store.Put(ctx, store.NameKey(typeMixed, e.ID), &e)
+		if err != nil {
+			t.Fatalf("failed to insert test Mixed entity %s: %v", e.ID, err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		field     string
+		operator  string
+		value     interface{}
+		keyParts  []string
+		expectIDs []string
+	}{
+		{
+			name:      "Int >= 30",
+			field:     "Int",
+			operator:  ">=",
+			value:     int64(30),
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"3", "4"},
+		},
+		{
+			name:      "Float < 3.0",
+			field:     "Float",
+			operator:  "<",
+			value:     3.0,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "2"},
+		},
+		{
+			name:      "Str > 'bravo'",
+			field:     "Str",
+			operator:  ">",
+			value:     "bravo",
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"3", "4"},
+		},
+		{
+			name:      "Created < now",
+			field:     "Created",
+			operator:  "<",
+			value:     now,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "2", "3"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := store.NewQuery(typeMixed, false, tc.keyParts...)
+			q.FilterField(tc.field, tc.operator, tc.value)
+			q.Order(tc.field)
+
+			var results []Mixed
+			_, err := store.GetAll(ctx, q, &results)
+			if err != nil {
+				t.Fatalf("GetAll failed: %v", err)
+			}
+
+			var gotIDs []string
+			for _, r := range results {
+				gotIDs = append(gotIDs, r.ID)
+			}
+			if !equalUnordered(gotIDs, tc.expectIDs) {
+				t.Errorf("unexpected result IDs: got %v, want %v", gotIDs, tc.expectIDs)
+			}
+		})
+	}
+}
+
+// equalUnordered checks that two string slices have the same elements, regardless of order.
+func equalUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int)
+	for _, x := range a {
+		counts[x]++
+	}
+	for _, x := range b {
+		if counts[x] == 0 {
+			return false
+		}
+		counts[x]--
+	}
+	return true
+}

--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -1,0 +1,666 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This is free software: you can redistribute it and/or modify it
+  under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  It is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FileStore implements Store for file storage. Each entity is
+// represented as a file named <key> under the directory
+// <dir>/<id>/<kind>, where <kind> and <key> are the entity kind and
+// key respectively.
+//
+// FileStore implements a simple form of indexing based on the
+// period-separated parts of key names. For example, a User has the
+// key structure <Skey>.<Email>. Filestore queries that utilize
+// key-based indexes must specify the optional key parts when
+// constructing the query.
+//
+//	q = store.NewQuery(ctx, "User", "Skey", "Email")
+//
+// All but the last part of the key must not contain periods. In this
+// example, only Email may contain periods.
+//
+// The key "671314941988.test@ausocean.org" would match 671314941988 or
+// "test@ausocean.org" or both.
+//
+// To match both Skey and Email:
+//
+//	q.Filter("Skey =", 671314941988)
+//	q.Filter("Email =", "test@ausocean.org)
+//
+// To match just Skey, i.e., return all entities for a given site,
+// simply omit the Email part as follows.
+//
+//	q.Filter("Skey =", 671314941988)
+//
+// Alternatively, specify nil for the Email which is a wild card.
+//
+//	q.Filter("Skey =", 671314941988)
+//	q.Filter("Email =", nil)
+//
+// Using nil is most useful however when ignoring a key part which has
+// key parts before and after that must be matched.
+//
+// To match just Email, i.e., return all entities for a given user:
+//
+//	q.Filter("Email =", "test@ausocean.org")
+//
+// The following query would however fail due to the wrong order:
+//
+//	q.Filter("Email =", "test@ausocean.org")
+//	q.Filter("Skey =", 671314941988)
+//
+// FileStore represents all keys as strings. To facilitate substring
+// comparisons, 64-bit ID keys are represented as two 32-bit integers
+// separated by a period and the keyParts in NewQuery must reflect
+// this.
+//
+// In addition to key-based filtering, FileStore supports content-based
+// filtering using FilterField. If the field name matches a key part,
+// the query is evaluated efficiently using the file name. Otherwise,
+// the entity file is read, parsed, and the field is evaluated using
+// reflection. This allows for flexible filtering even on fields not
+// encoded in the key.
+type FileStore struct {
+	mu  sync.Mutex
+	id  string
+	dir string
+}
+
+// newFileStore returns a new FileStore, using the given id and dir to
+// create the storage directory, <dir>/<id>. If dir is empty it
+// defaults to the current directory.
+func newFileStore(ctx context.Context, id, dir string) (*FileStore, error) {
+	if dir == "" {
+		dir = "."
+	}
+	store := FileStore{id: id, dir: dir}
+	dir = filepath.Join(dir, id)
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(dir, 0766)
+		if err != nil {
+			return &store, err
+		}
+	}
+	return &store, nil
+}
+
+// IDKey returns a FileStore ID key for the given kind, setting Name
+// to the file name. A 64-bit ID is represented as two 32-bit unsigned
+// integers separated by a period.
+func (s *FileStore) IDKey(kind string, id int64) *Key {
+	dir := filepath.Join(s.dir, s.id, kind)
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(dir, 0766)
+	}
+	var name string
+	id_ := uint64(id)
+	if id_ < 1<<32 {
+		name = strconv.FormatUint(id_, 10)
+	} else {
+		name = strconv.FormatUint(id_>>32, 10) + "." + strconv.FormatUint(id_&0xffffffff, 10)
+	}
+	return &Key{Kind: kind, ID: id, Name: name}
+}
+
+// NameKey returns a FileStore name key for the given kind, setting Name to the file name.
+func (s *FileStore) NameKey(kind, name string) *Key {
+	dir := filepath.Join(s.dir, s.id, kind)
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(dir, 0766)
+	}
+	return &Key{Kind: kind, Name: name}
+}
+
+// IncompleteKey returns an incomplete key given a kind.
+func (s *FileStore) IncompleteKey(kind string) *Key {
+	// Continue selecting an ID until we find one not used.
+	for {
+		var name string
+		ID := rand.Int63()
+		if ID < 1<<32 {
+			name = strconv.FormatInt(ID, 10)
+		} else {
+			name = strconv.FormatInt(ID>>32, 10) + "." + strconv.FormatInt(ID&0xffffffff, 10)
+		}
+		path := filepath.Join(s.dir, s.id, kind, name)
+		_, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			return &Key{Kind: kind, ID: ID, Name: name}
+		}
+	}
+}
+
+// NewQuery creates and returns a new FileQuery.
+func (s *FileStore) NewQuery(kind string, keysOnly bool, keyParts ...string) Query {
+	query := FileQuery{kind: kind, keysOnly: keysOnly, keyParts: keyParts, limit: MaxKeys}
+	return &query
+}
+
+// Get returns a single entity by its key.
+func (s *FileStore) Get(ctx context.Context, key *Key, dst Entity) error {
+	bytes, err := ioutil.ReadFile(filepath.Join(s.dir, s.id, key.Kind, key.Name))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ErrNoSuchEntity
+		}
+		return err
+	}
+	decode(dst, bytes)
+	return nil
+}
+
+// GetAll implements Store.GetAll for FileStore. Unlike CloudStore
+// queries are only valid against key parts. If the entity has a
+// property named Key, it is automatically populated with its Key
+// value.
+func (s *FileStore) GetAll(ctx context.Context, query Query, dst interface{}) ([]*Key, error) {
+	q, ok := query.(*FileQuery)
+	if !ok {
+		return nil, errors.New("expected *FileQuery type")
+	}
+
+	// Construct keys from file names.
+	var keys []*Key
+	dir := filepath.Join(s.dir, s.id, q.kind)
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		os.MkdirAll(dir, 0766)
+		return keys, nil
+	}
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range files {
+		keys = append(keys, &Key{Kind: q.kind, ID: extractID(f.Name()), Name: f.Name()})
+	}
+
+	// Apply filters, if any.
+	if q.filter {
+		var filtered []*Key
+		for _, k := range keys {
+			var matches bool
+			// Split the key into its parts.
+			parts := strings.SplitN(k.Name, ".", len(q.keyParts))
+			if len(parts) != len(q.keyParts) {
+				continue // No match.
+			}
+			// Apply filter to each key part.
+			matches = true
+			for i, part := range parts {
+				if q.cmp[i] == nil {
+					continue
+				}
+				// All comparisons must pass in order for the filter to match as a whole.
+				for j := range q.cmp[i] {
+					if !q.cmp[i][j](part, q.value[i][j]) {
+						matches = false
+						break
+					}
+				}
+			}
+			if matches {
+				filtered = append(filtered, k)
+			}
+		}
+		keys = filtered
+	}
+
+	// Sort the keys if ordering.
+	if q.order {
+		sort.Slice(keys, func(i, j int) bool {
+			if keys[i].ID != 0 {
+				return keys[i].ID < keys[j].ID
+			} else {
+				return keys[i].Name < keys[j].Name
+			}
+		})
+	}
+
+	// Apply query's limit and offset to the keys.
+	if q.offset+q.limit > len(keys) {
+		keys = keys[q.offset:]
+	} else {
+		keys = keys[q.offset:(q.offset + q.limit)]
+	}
+
+	if q.keysOnly {
+		return keys, nil
+	}
+
+	// Get the constructor for this kind of entity.
+	entity := newEntity[q.kind]
+	if entity == nil {
+		return nil, ErrUnimplemented
+	}
+
+	// Get each entity and append it to dst.
+	dv := reflect.ValueOf(dst).Elem()
+	for _, k := range keys {
+		e := entity()
+		err := s.Get(ctx, k, e)
+		if err != nil {
+			return nil, err
+		}
+		// The underlying entity type is a pointer, so we need its indirect type.
+
+		// Apply field filters if needed.
+		if len(q.fieldFilters) > 0 && !matchesFieldFilters(e, q.fieldFilters) {
+			continue
+		}
+
+		ev := reflect.Indirect(reflect.ValueOf(e))
+		// As with the Cloud datastore, if the Key field is present we populate it.
+		fld := ev.FieldByName("Key")
+		if fld.IsValid() {
+			fld.Set(reflect.ValueOf(k))
+		}
+		dv.Set(reflect.Append(dv, ev))
+	}
+
+	return keys, nil
+}
+
+// matchesFieldFilters returns true if the given entity matches all the specified fieldFilters.
+// It uses reflection to extract struct fields by name and compares their values based on the
+// provided operator (e.g., "=", "<=", ">"). If any filter does not match, it returns false.
+func matchesFieldFilters(e Entity, filters []fieldFilter) bool {
+	v := reflect.Indirect(reflect.ValueOf(e))
+	for _, f := range filters {
+		field := v.FieldByName(f.Field)
+		if !field.IsValid() {
+			return false
+		}
+
+		switch f.Operator {
+		case "=":
+			if field.Interface() != f.Value {
+				return false
+			}
+		case "<", ">", "<=", ">=":
+			if !compare(field.Interface(), f.Value, f.Operator) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func compare(a, b interface{}, op string) bool {
+	// Try string comparison first.
+	as, aok := a.(string)
+	bs, bok := b.(string)
+	if aok && bok {
+		switch op {
+		case "=":
+			return as == bs
+		case "<":
+			return as < bs
+		case ">":
+			return as > bs
+		case "<=":
+			return as <= bs
+		case ">=":
+			return as >= bs
+		}
+		return false
+	}
+
+	// Try time.Time comparison.
+	at, aok := a.(time.Time)
+	bt, bok := b.(time.Time)
+	if aok && bok {
+		switch op {
+		case "=":
+			return at.Equal(bt)
+		case "<":
+			return at.Before(bt)
+		case ">":
+			return at.After(bt)
+		case "<=":
+			return at.Before(bt) || at.Equal(bt)
+		case ">=":
+			return at.After(bt) || at.Equal(bt)
+		}
+		return false
+	}
+
+	// Compare as integers if both values are int-compatible.
+	ai, aok := toInt64Strict(a)
+	bi, bok := toInt64Strict(b)
+	if aok && bok {
+		switch op {
+		case "=":
+			return ai == bi
+		case "<":
+			return ai < bi
+		case ">":
+			return ai > bi
+		case "<=":
+			return ai <= bi
+		case ">=":
+			return ai >= bi
+		}
+		return false
+	}
+
+	// Fallback to float64 comparison.
+	af, aok := toFloat64Safe(a)
+	bf, bok := toFloat64Safe(b)
+	if !aok || !bok {
+		return false
+	}
+	switch op {
+	case "=":
+		return af == bf
+	case "<":
+		return af < bf
+	case ">":
+		return af > bf
+	case "<=":
+		return af <= bf
+	case ">=":
+		return af >= bf
+	default:
+		return false
+	}
+}
+
+func toFloat64Safe(x interface{}) (float64, bool) {
+	switch v := x.(type) {
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case float32:
+		return float64(v), true
+	case float64:
+		return v, true
+	default:
+		return 0, false
+	}
+}
+
+func toInt64Strict(x interface{}) (int64, bool) {
+	switch v := x.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint64:
+		if v <= math.MaxInt64 {
+			return int64(v), true
+		}
+		return 0, false // Value too large to fit in int64.
+	default:
+		return 0, false
+	}
+}
+
+// extractID attempts to extract an integer ID from a key name,
+// returning zero otherwise. IDs are names comprising either a single
+// unsigned integer or two dot-separated 32-bit unsigned integers. The
+// latter are recombined into a 64-bit integer.
+func extractID(name string) int64 {
+	sep := strings.Index(name, ".")
+	if sep < 0 {
+		n, err := strconv.ParseUint(name, 10, 64)
+		if err != nil {
+			return 0
+		}
+		return int64(n)
+	}
+
+	msb, err := strconv.ParseUint(name[:sep], 10, 64)
+	if err != nil {
+		return 0
+	}
+	lsb, err := strconv.ParseUint(name[sep+1:], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return int64(msb<<32 | lsb&0xffffffff)
+}
+
+func (s *FileStore) Create(ctx context.Context, key *Key, src Entity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	err := s.Get(ctx, key, src)
+	if err == nil {
+		return ErrEntityExists
+	}
+	if err != ErrNoSuchEntity {
+		return err
+	}
+	_, err = s.Put(ctx, key, src)
+	return err
+}
+
+func (s *FileStore) Put(ctx context.Context, key *Key, src Entity) (*Key, error) {
+	bytes := encode(src)
+	err := ioutil.WriteFile(filepath.Join(s.dir, s.id, key.Kind, key.Name), bytes, 0777)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func (s *FileStore) Update(ctx context.Context, key *Key, fn func(Entity), dst Entity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	err := s.Get(ctx, key, dst)
+	if err != nil {
+		return err
+	}
+	fn(dst)
+	_, err = s.Put(ctx, key, dst)
+	return err
+}
+
+func (s *FileStore) Delete(ctx context.Context, key *Key) error {
+	return os.Remove(filepath.Join(s.dir, s.id, key.Kind, key.Name))
+}
+
+func (s *FileStore) DeleteMulti(ctx context.Context, keys []*Key) error {
+	for _, k := range keys {
+		err := os.Remove(filepath.Join(s.dir, s.id, k.Kind, k.Name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type fieldFilter struct {
+	Field    string
+	Operator string
+	Value    interface{}
+}
+
+// FileQuery implements Query for FileStore.
+type FileQuery struct {
+	kind         string                        // Our datastore type.
+	keysOnly     bool                          // True if this is a keys only query.
+	order        bool                          // True if results are ordered.
+	filter       bool                          // True if a filter is defined.
+	keyParts     []string                      // Defines the parts of the key.
+	value        [][]string                    // Filter value(s).
+	cmp          [][]func(string, string) bool // Filter comparison function(s).
+	limit        int                           // Limits the number of results returned.
+	offset       int                           // How many keys to skip before returning results.
+	fieldFilters []fieldFilter                 // Filters on entity fields in the file.
+}
+
+// Filter implements FileQuery matching against key parts.
+// This function transforms certain properties commonly used in queries:
+//
+//   - Properties named ID or MID are reduced to their least-significant 32 bits.
+//   - Properties named Timestamp are converted from the Unix epoch to the AusOcean epoch.
+func (q *FileQuery) Filter(filterStr string, value interface{}) error {
+	if !q.filter {
+		q.filter = true
+		q.value = make([][]string, len(q.keyParts))
+		q.cmp = make([][]func(string, string) bool, len(q.keyParts))
+	}
+
+	if value == nil {
+		return nil
+	}
+
+	// The filter field must match one of the key parts, otherwise it is invalid.
+	pos := strings.IndexAny(filterStr, " =<>")
+	if pos == -1 {
+		return ErrInvalidFilter
+	}
+	fld := filterStr[:pos]
+	idx := -1
+	for i, part := range q.keyParts {
+		if fld == part {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return ErrInvalidField
+	}
+
+	// Now extract the comparison operation.
+	i := strings.IndexAny(filterStr, "=<>")
+	if i == -1 {
+		return ErrOperatorMissing
+	}
+
+	// We support string values and numeric (int64) values, but both are
+	// represented as strings to simplify key/value matching.
+	s, ok := value.(string)
+	if ok {
+		// String value.
+		q.value[idx] = append(q.value[idx], s)
+		switch filterStr[i:] {
+		case "=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return a == b })
+		case "<":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return a > b })
+		case ">":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return a > b })
+		case "<=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return a <= b })
+		case ">=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return a >= b })
+		default:
+			return ErrInvalidOperator
+		}
+		return nil
+	}
+
+	n, ok := value.(int64)
+	if ok {
+		// Numeric value.
+		switch fld {
+		case "ID", "MID":
+			n &= 0xffffffff
+		case "Timestamp":
+			n = (n - EpochStart) << SubTimeBits
+		}
+		q.value[idx] = append(q.value[idx], strconv.FormatInt(n, 10))
+		switch filterStr[i:] {
+		case "=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) == toInt64(b) })
+		case "<":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) < toInt64(b) })
+		case ">":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) > toInt64(b) })
+		case "<=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) <= toInt64(b) })
+		case ">=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) >= toInt64(b) })
+		default:
+			return ErrInvalidOperator
+		}
+		return nil
+	}
+
+	return ErrInvalidValue
+}
+
+// FilterField filters a query by field name and value using the specified operator.
+// If the field name matches one of the declared keyParts, the query is handled efficiently
+// using filename-based key filtering via Filter. Otherwise, the query falls back to
+// reflection-based entity field filtering, which reads and inspects each entity file.
+func (q *FileQuery) FilterField(fieldName string, operator string, value interface{}) error {
+	for _, part := range q.keyParts {
+		if part == fieldName {
+			return q.Filter(fieldName+" "+operator, value)
+		}
+	}
+	// Fallback to reflection-based filtering.
+	q.fieldFilters = append(q.fieldFilters, fieldFilter{
+		Field:    fieldName,
+		Operator: operator,
+		Value:    value,
+	})
+	return nil
+}
+
+// toInt64 converts a string to an int64, or returns 0.
+func toInt64(s string) int64 {
+	i, _ := strconv.ParseInt(s, 10, 64)
+	return i
+}
+
+func (q *FileQuery) Order(fieldName string) {
+	q.order = true
+}
+
+// Limit limits the number of results returned.
+func (q *FileQuery) Limit(limit int) {
+	q.limit = limit
+}
+
+// Offset sets the number of keys to skip before returning results.
+func (q *FileQuery) Offset(offset int) {
+	q.offset = offset
+}


### PR DESCRIPTION
Straight copy from openfish v0.2.2.
This repo is a more logical location for the package.

The license has been changed with permission from contributors.