### PR TITLE
Bench: Prevent nil dereference of Profile

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.36.1"
+	version     = "v0.36.2"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"
@@ -531,9 +531,11 @@ func writeTemplate(w http.ResponseWriter, r *http.Request, name string, data int
 	}
 	p = v.FieldByName("SuperAdmin")
 	if p.IsValid() {
-		log.Println("p is valid, checking email:", profile.Email)
-		log.Println("I am superAdmin:", isSuperAdmin(profile.Email))
-		p.SetBool(isSuperAdmin(profile.Email))
+		if profile == nil {
+			p.SetBool(false)
+		} else {
+			p.SetBool(isSuperAdmin(profile.Email))
+		}
 	}
 	p = v.FieldByName("LoginURL")
 	if p.IsValid() {


### PR DESCRIPTION
This change checks if the profile exists before trying to use it to set the superadmin bool.

Without this, an logged out user will have no profile, and hence the call to profile.Email tries to dereference a nil pointer, which panics the webapp before the user can even load anything to try and log in