### PR TITLE
datastore: add time.Time support to filestore filters

### DIFF
--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -623,6 +623,27 @@ func (q *FileQuery) Filter(filterStr string, value interface{}) error {
 		return nil
 	}
 
+	t, ok := value.(time.Time)
+	if ok {
+		n := t.UnixMilli()
+		q.value[idx] = append(q.value[idx], strconv.FormatInt(n, 10))
+		switch filterStr[i:] {
+		case "=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) == toInt64(b) })
+		case "<":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) < toInt64(b) })
+		case ">":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) > toInt64(b) })
+		case "<=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) <= toInt64(b) })
+		case ">=":
+			q.cmp[idx] = append(q.cmp[idx], func(a, b string) bool { return toInt64(a) >= toInt64(b) })
+		default:
+			return ErrInvalidOperator
+		}
+		return nil
+	}
+
 	return ErrInvalidValue
 }
 


### PR DESCRIPTION
Done because AusOceanTV Actions have a time.Time field.

Tests were failing locally because we converted time.Time to timestamp for the filestore, but the tests failed on the cloud because it was trying to use timestamps on the time.Time field. 
Now since I have implemented time.Time filtering, we can just leave them and filters will work on both stores.