### PR TITLE
697-2-log-handler

### DIFF
--- a/cmd/oceanbench/device-log.go
+++ b/cmd/oceanbench/device-log.go
@@ -45,7 +45,7 @@ import (
 func createLogHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := context.Background()
 
-	// Validate the user is logged in and has at least admin permissions to the site.
+	// Validate the user is logged in.
 	profile, err := getProfile(w, r)
 	if err != nil {
 		if err != gauth.TokenNotFound {


### PR DESCRIPTION
the LogHandler function creates device logs in the datastore. First by checking user permissions, then using the PutLog function.