### PR TITLE
Bench/Devices: missing vartypes fail silent (#704)

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 const (
-	version     = "v0.36.3"
+	version     = "v0.36.4"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -240,9 +240,9 @@ func writeDevices(w http.ResponseWriter, r *http.Request, msg string, args ...in
 		case model.DevTypeTest:
 			fallthrough
 		case model.DevTypeHydrophone:
-			return errNotImplemented
+			fallthrough // This does not need to error.
 		default:
-			return model.ErrInvalidDevType
+			return nil
 		}
 		return nil
 	})


### PR DESCRIPTION
This change fails silently for devices which do not yet have registered static var types. This prevents an unnecessary error message, and also allows the sensors to load correctly.

closes #704 