### PR TITLE
otv: improve unknown broadcast state panic message

### DIFF
--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -383,7 +383,7 @@ func broadcastCfgToState(ctx *broadcastContext) state {
 	case !vid && !slate && !unhealthy && !starting && !isSecondary && inFailure:
 		newState = newDirectFailure(ctx, nil)
 	default:
-		panic(fmt.Sprintf("unknown state for broadcast, vid: %v, active: %v, slate: %v, unhealthy: %v, starting: %v, secondary: %v, transitioning: %v", vid, active, slate, unhealthy, starting, isSecondary, transitioning))
+		panic(fmt.Sprintf("unknown state for broadcast %v, vid: %v, active: %v, slate: %v, unhealthy: %v, starting: %v, secondary: %v, transitioning: %v", ctx.cfg.Name, vid, active, slate, unhealthy, starting, isSecondary, transitioning))
 	}
 
 	err := json.Unmarshal(ctx.cfg.StateData, &newState)

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	projectID             = "oceantv"
-	version               = "v0.13.5"
+	version               = "v0.13.6"
 	projectURL            = "https://tv.cloudblue.org"
 	cronServiceAccount    = "oceancron@appspot.gserviceaccount.com"
 	oceanTVServiceAccount = "oceantv@appspot.gserviceaccount.com"


### PR DESCRIPTION
If this message causes a panic and we get a notification through email re the panic, we can't see what broadcast caused it, so we're fixing this by adding the broadcast name.