### PR TITLE
otv: add panic notification limiting

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	projectID             = "oceantv"
-	version               = "v0.13.4"
+	version               = "v0.13.5"
 	projectURL            = "https://tv.cloudblue.org"
 	cronServiceAccount    = "oceancron@appspot.gserviceaccount.com"
 	oceanTVServiceAccount = "oceantv@appspot.gserviceaccount.com"
@@ -102,12 +102,29 @@ func main() {
 		log.Fatalf("could not get mailjetPrivateKey, can't send panic recovery notification")
 	}
 
+	const (
+		limiterMaxTokens  = 3
+		limiterRefillRate = 1 // per hour
+		limiterID         = "panic_notification_limiter"
+	)
+	panicNotificationLimiter, err := GetOceanTokenBucketLimiter(limiterMaxTokens, limiterRefillRate, limiterID, store)
+	if err != nil {
+		log.Fatalf("could not get panic notification limiter: %v", err)
+	}
+
 	mux := utils.NewRecoverableServeMux(
 		utils.NewConfigurableRecoveryHandler(
 			// Only consider handled if we can get a notification off.
 			utils.WithHandledConditions(utils.HandledConditions{HandledOnNotification: true}),
 			utils.WithLogOutput(log.Println),
-			utils.WithNotification(func(msg string) error { return sendPanicNotification(publicKey, privateKey, msg) }),
+			utils.WithNotification(
+				func(msg string) error {
+					if panicNotificationLimiter.RequestOK() {
+						return sendPanicNotification(publicKey, privateKey, msg)
+					}
+					return nil
+				},
+			),
 			utils.WithHttpError(http.StatusInternalServerError),
 			utils.WithHandlers(errNoGlobalNotifierHandler(secrets)),
 		),


### PR DESCRIPTION
If a broadcast SM spins up every minute and the broadcast is in a bad state, we can run into a situation where we're spamming the notification email list every minute. This change adds a token bucket based limiter to these
notifications. Currently configured for 3 first hour, then 1 every hour after.