### PR TITLE
otv: fix otv test time problems

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -580,16 +580,16 @@ func TestHardwareStopAndRestart(t *testing.T) {
 
 			ctx, _ := context.WithCancel(context.Background())
 
+			// Use a monkey patch to replace time.Now() with a stable test time.
+			// This will be updated before each tick to simulate time passing.
+			testTime := fixedBroadcastTestTime(t)
+			monkey.Patch(time.Now, func() time.Time { return testTime })
+			defer monkey.Unpatch(time.Now)
+
 			// Apply broadcast config modifications
 			// and update the broadcast state based on the initial state.
 			cfg := &BroadcastConfig{}
 			tt.cfg(cfg)
-
-			// Use a monkey patch to replace time.Now() with our own time.
-			// This will be updated before each tick to simulate time passing.
-			testTime := time.Now()
-			monkey.Patch(time.Now, func() time.Time { return testTime })
-			defer monkey.Unpatch(time.Now)
 
 			sys, err := newHardwareOnlySystem(
 				ctx,

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -609,7 +609,9 @@ func TestHandleStartFailedEvent(t *testing.T) {
 
 	bCtx := standardMockBroadcastContext(t, false)
 
-	now := time.Now()
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
 
 	tests := []struct {
 		desc          string
@@ -681,7 +683,9 @@ func TestHandleBadHealthEvent(t *testing.T) {
 
 	bCtx := standardMockBroadcastContext(t, false)
 
-	now := time.Now()
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
 
 	tests := []struct {
 		desc          string
@@ -798,7 +802,9 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 
 	bCtx := standardMockBroadcastContext(t, false)
 
-	now := time.Now()
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
 
 	tests := []struct {
 		desc          string
@@ -913,7 +919,9 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 func TestHandleFinishEvent(t *testing.T) {
 	bCtx := standardMockBroadcastContext(t, false)
 
-	now := time.Now()
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
 	tests := []struct {
 		desc          string
 		initialState  state
@@ -1012,7 +1020,9 @@ func TestHandleFinishEvent(t *testing.T) {
 func TestHandleStartEvent(t *testing.T) {
 	bCtx := standardMockBroadcastContext(t, false)
 
-	now := time.Now()
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
 	tests := []struct {
 		desc          string
 		initialState  state
@@ -1117,7 +1127,9 @@ func TestHandleStartEvent(t *testing.T) {
 func TestHandleStartedEvent(t *testing.T) {
 	bCtx := standardMockBroadcastContext(t, false)
 
-	now := time.Now()
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
 	tests := []struct {
 		desc          string
 		initialState  state
@@ -1421,17 +1433,17 @@ func TestHandleCameraConfiguration(t *testing.T) {
 
 			ctx, _ := context.WithCancel(context.Background())
 
+			// Use a monkey patch to replace time.Now() with a stable test time.
+			// This will be updated before each tick to simulate time passing.
+			testTime := fixedBroadcastTestTime(t)
+			monkey.Patch(time.Now, func() time.Time { return testTime })
+			defer monkey.Unpatch(time.Now)
+
 			// Apply broadcast config modifications
 			// and update the broadcast state based on the initial state.
 			cfg := prepopulatedConfig()
 			tt.cfg(cfg)
 			updateBroadcastBasedOnState(tt.initialState, cfg)
-
-			// Use a monkey patch to replace time.Now() with our own time.
-			// This will be updated before each tick to simulate time passing.
-			testTime := time.Now()
-			monkey.Patch(time.Now, func() time.Time { return testTime })
-			defer monkey.Unpatch(time.Now)
 
 			sys, err := newBroadcastSystem(
 				ctx,
@@ -1826,17 +1838,17 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 
 			ctx, _ := context.WithCancel(context.Background())
 
+			// Use a monkey patch to replace time.Now() with a stable test time.
+			// This will be updated before each tick to simulate time passing.
+			testTime := fixedBroadcastTestTime(t)
+			monkey.Patch(time.Now, func() time.Time { return testTime })
+			defer monkey.Unpatch(time.Now)
+
 			// Apply broadcast config modifications
 			// and update the broadcast state based on the initial state.
 			cfg := prepopulatedConfig()
 			tt.cfg(cfg)
 			updateBroadcastBasedOnState(tt.initialBroadcastState, cfg)
-
-			// Use a monkey patch to replace time.Now() with our own time.
-			// This will be updated before each tick to simulate time passing.
-			testTime := time.Now()
-			monkey.Patch(time.Now, func() time.Time { return testTime })
-			defer monkey.Unpatch(time.Now)
 
 			sys, err := newBroadcastSystem(
 				ctx,

--- a/cmd/oceantv/broadcast_manager_test.go
+++ b/cmd/oceantv/broadcast_manager_test.go
@@ -5,10 +5,15 @@ import (
 	"testing"
 	"time"
 
+	"bou.ke/monkey"
 	"github.com/ausocean/cloud/notify"
 )
 
 func TestBroadcastCanBeReused(t *testing.T) {
+	now := fixedBroadcastTestTime(t)
+	monkey.Patch(time.Now, func() time.Time { return now })
+	defer monkey.Unpatch(time.Now)
+
 	tests := []struct {
 		name          string
 		svc           BroadcastService

--- a/cmd/oceantv/test_time_test.go
+++ b/cmd/oceantv/test_time_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func fixedBroadcastTestTime(t testing.TB) time.Time {
+	t.Helper()
+
+	loc, err := time.LoadLocation(locationID)
+	if err != nil {
+		t.Fatalf("could not load test location %q: %v", locationID, err)
+	}
+
+	// Midday in Adelaide standard time avoids date rollovers and DST edge cases.
+	return time.Date(2025, time.June, 18, 12, 0, 0, 0, loc)
+}


### PR DESCRIPTION
We were having issues with using time.Now() because some
components of the broadcast system rely on the assumption
certain things are happening during the day. Therefore
with using time.Now() we can have rollover issues if the
test are ran around midnight.

We are already using monkey patching on time.Now() so we
can simply use a fixed initial time instead. We're also
using the monkey patch for time.Now() in more places
for any tests that could have issues with using time.Now().
We're also moving the patch to before the tests with a
tt.cfg(cfg) call because this uses time.Now().