### PR TITLE
bench: make wait groups for panicing scalar tests

### DIFF
--- a/cmd/oceanbench/data_test.go
+++ b/cmd/oceanbench/data_test.go
@@ -38,6 +38,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/model"
 )
@@ -88,21 +90,26 @@ func TestPutScalars(t *testing.T) {
 
 	ts := int64(datastore.EpochStart)
 	samples := sampleSinusoid(amplitude, offset, minutesInDay)
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(50)
 	for i := 0; i < minutesInDay; i++ {
-		err := model.PutScalar(ctx, store, &model.Scalar{
-			ID:        id,
-			Timestamp: ts,
-			Value:     float64(samples[i]),
+		currentTS := ts
+		g.Go(func() error {
+			return model.PutScalar(gCtx, store, &model.Scalar{
+				ID:        id,
+				Timestamp: currentTS,
+				Value:     float64(samples[i]),
+			})
 		})
-		if err != nil {
-			t.Errorf("PutScalar failed with error: %v", err)
-		}
 		ts += 60
 
 		// Print progress every 10%.
 		if i%(minutesInDay/10) == 0 {
-			t.Logf("put %d/%d scalars", i, minutesInDay)
+			t.Logf("queued %d/%d scalars", i, minutesInDay)
 		}
+	}
+	if err := g.Wait(); err != nil {
+		t.Errorf("PutScalar failed with error: %v", err)
 	}
 }
 
@@ -138,21 +145,26 @@ func TestGetScalars(t *testing.T) {
 	t.Log("inserting fresh scalars for test")
 	ts := int64(datastore.EpochStart)
 	samples := sampleSinusoid(amplitude, offset, minutesInDay)
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(50)
 	for i := 0; i < minutesInDay; i++ {
-		err := model.PutScalar(ctx, store, &model.Scalar{
-			ID:        id,
-			Timestamp: ts,
-			Value:     float64(samples[i]),
+		currentTS := ts
+		g.Go(func() error {
+			return model.PutScalar(gCtx, store, &model.Scalar{
+				ID:        id,
+				Timestamp: currentTS,
+				Value:     float64(samples[i]),
+			})
 		})
-		if err != nil {
-			t.Fatalf("PutScalar failed with error: %v", err)
-		}
 		ts += 60
 
 		// Print progress every 10%.
 		if i%(minutesInDay/10) == 0 {
-			t.Logf("put %d/%d scalars", i, minutesInDay)
+			t.Logf("queued %d/%d scalars", i, minutesInDay)
 		}
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("PutScalar failed with error: %v", err)
 	}
 
 	t.Log("fetching scalars from datastore")
@@ -205,20 +217,25 @@ func TestFetchScalars(t *testing.T) {
 	t.Log("inserting fresh scalars for test.")
 	ts := int64(datastore.EpochStart)
 	samples := sampleSinusoid(amplitude, offset, minutesInDay)
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(50)
 	for i := 0; i < minutesInDay; i++ {
-		err := model.PutScalar(ctx, store, &model.Scalar{
-			ID:        id,
-			Timestamp: ts,
-			Value:     float64(samples[i]),
+		currentTS := ts
+		g.Go(func() error {
+			return model.PutScalar(gCtx, store, &model.Scalar{
+				ID:        id,
+				Timestamp: currentTS,
+				Value:     float64(samples[i]),
+			})
 		})
-		if err != nil {
-			t.Fatalf("PutScalar failed with error: %v", err)
-		}
 		ts += 60
 
 		if i%(minutesInDay/10) == 0 {
-			t.Logf("inserted %d/%d scalars", i, minutesInDay)
+			t.Logf("queued %d/%d scalars", i, minutesInDay)
 		}
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("PutScalar failed with error: %v", err)
 	}
 
 	t.Log("creating request to /data endpoint")


### PR DESCRIPTION
This was done because testing main was failing and panicing.

<details>

<summary>Test Logs</summary>
```
panic: test timed out after 10m0s
        running tests:
                TestFetchScalars (1m7s)

goroutine 125 [running]:
testing.(*M).startAlarm.func1()
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:2484 +0x394
created by time.goFunc
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/time/sleep.go:215 +0x2d

goroutine 1 [chan receive, 1 minutes]:
testing.(*T).Run(0xc000203340, {0x1622f0d?, 0xc000273b30?}, 0x1680730)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1859 +0x431
testing.runTests.func1(0xc000203340)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:2279 +0x37
testing.tRunner(0xc000203340, 0xc000273c70)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1792 +0xf4
testing.runTests(0xc0004360f0, {0x2463b20, 0xe, 0xe}, {0x2480cc0?, 0x7?, 0x247ed80?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:2277 +0x4b4
testing.(*M).Run(0xc0003c1a40)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:2142 +0x64a
main.main()
        _testmain.go:71 +0x9b

goroutine 67 [select]:
google.golang.org/grpc/internal/transport.(*ClientStream).waitOnHeader(0xc000526b60)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/client_stream.go:94 +0x65
google.golang.org/grpc/internal/transport.(*ClientStream).RecvCompress(...)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/client_stream.go:109
google.golang.org/grpc.(*csAttempt).recvMsg(0xc00017b680, {0x14e2ec0, 0xc000039e00}, 0x1000000000000?)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/stream.go:1130 +0x117
google.golang.org/grpc.(*clientStream).RecvMsg.func1(0x57?)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/stream.go:986 +0x1f
google.golang.org/grpc.(*clientStream).withRetry(0xc000541320, 0xc00006d710, 0xc00006d700)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/stream.go:806 +0x13b
google.golang.org/grpc.(*clientStream).RecvMsg(0xc000541320, {0x14e2ec0?, 0xc000039e00?})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/stream.go:985 +0x155
google.golang.org/grpc.invoke({0x17e5948?, 0xc000545770?}, {0x1644004?, 0xc00006d810?}, {0x155de00, 0xc0007ea300}, {0x14e2ec0, 0xc000039e00}, 0x58?, {0x0, ...})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/call.go:73 +0xc4
google.golang.org/grpc.(*ClientConn).Invoke(0xc000266c08, {0x17e5948?, 0xc000545770?}, {0x1644004?, 0x17be160?}, {0x155de00?, 0xc0007ea300?}, {0x14e2ec0?, 0xc000039e00?}, {0x0, ...})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/call.go:37 +0x23f
cloud.google.com/go/datastore/apiv1/datastorepb.(*datastoreClient).Commit(0xc0006f4990, {0x17e5948, 0xc000545770}, 0xc0007ea300, {0x0, 0x0, 0x0})
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/apiv1/datastorepb/datastore.pb.go:3609 +0xc8
cloud.google.com/go/datastore.(*datastoreClient).Commit.func2({0x17e5948?, 0xc000545770?})
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/client.go:112 +0x5a
cloud.google.com/go/datastore.(*datastoreClient).invoke.func1()
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/client.go:154 +0x1f
cloud.google.com/go/internal.retry({0x17e5948, 0xc000545770}, {0x5f5e100, 0x0, 0x0, 0x0}, 0xc00006d9f0, 0x1681888)
        /home/trek/go/pkg/mod/cloud.google.com/go@v0.118.1/internal/retry.go:39 +0x74
cloud.google.com/go/internal.Retry(...)
        /home/trek/go/pkg/mod/cloud.google.com/go@v0.118.1/internal/retry.go:32
cloud.google.com/go/datastore.(*datastoreClient).invoke(0x17e5948?, {0x17e5948, 0xc000545740}, 0xc00006daa0)
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/client.go:153 +0xc6
cloud.google.com/go/datastore.(*datastoreClient).Commit(0xc00061b2f0, {0x17e5948?, 0xc000545680?}, 0xc0007ea300, {0x0, 0x0, 0x0})
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/client.go:111 +0x152
cloud.google.com/go/datastore.(*Client).PutMulti(0xc00047d450, {0x17e58d8?, 0x24a0aa0?}, {0xc00006dc10, 0x1, 0x1}, {0x1263a20, 0xc000965b48})
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/datastore.go:660 +0x1f3
cloud.google.com/go/datastore.(*Client).Put(0xc00047d450, {0x17e58d8, 0x24a0aa0}, 0x14f9ac0?, {0x1468120, 0xc0008296e0})
        /home/trek/go/pkg/mod/cloud.google.com/go/datastore@v1.20.0/datastore.go:629 +0xa6
github.com/ausocean/cloud/datastore.(*CloudStore).Put(0x3?, {0x17e58d8?, 0x24a0aa0?}, 0x16400036f60?, {0x17dfd78, 0xc0008296e0})
        /home/trek/go/src/github.com/ausocean/cloud/datastore/cloudstore.go:187 +0x4a
github.com/ausocean/cloud/model.PutScalar({0x17e58d8, 0x24a0aa0}, {0x17ee160, 0xc00081fed8}, 0xc0008296e0)
        /home/trek/go/src/github.com/ausocean/cloud/model/scalar.go:110 +0x92
github.com/ausocean/cloud/cmd/oceanbench.TestFetchScalars(0xc000503500)
        /home/trek/go/src/github.com/ausocean/cloud/cmd/oceanbench/data_test.go:209 +0x365
testing.tRunner(0xc000503500, 0x1680730)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1792 +0xf4
created by testing.(*T).Run in goroutine 1
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/testing/testing.go:1851 +0x413

goroutine 9 [chan receive, 10 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc00044a1f0, {0x17e5980, 0xc0003b8960})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 8
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 10 [chan receive, 1 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc00044a220, {0x17e5980, 0xc0003b89b0})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 8
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 11 [chan receive, 1 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc00044a250, {0x17e5980, 0xc0003b8a00})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 8
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 70 [chan receive, 1 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc0006f46d0, {0x17e5980, 0xc00047d220})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 67
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 68 [chan receive, 1 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc0006f4670, {0x17e5980, 0xc00047d180})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 67
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 37 [select]:
google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc0005c0d00, 0x1)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/controlbuf.go:425 +0x108
google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc000443180)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/controlbuf.go:602 +0x78
google.golang.org/grpc/internal/transport.NewHTTP2Client.func6()
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:469 +0xd2
created by google.golang.org/grpc/internal/transport.NewHTTP2Client in goroutine 71
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:467 +0x24b2

goroutine 69 [chan receive, 1 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc0006f46a0, {0x17e5980, 0xc00047d1d0})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 67
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 60 [select, 1 minutes]:
google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc0004fb640, 0x1)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/controlbuf.go:425 +0x108
google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc0003c01e0)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/controlbuf.go:602 +0x78
google.golang.org/grpc/internal/transport.NewHTTP2Client.func6()
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:469 +0xd2
created by google.golang.org/grpc/internal/transport.NewHTTP2Client in goroutine 103
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:467 +0x24b2

goroutine 101 [chan receive, 5 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc0006405e0, {0x17e5980, 0xc00063d720})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 99
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 100 [chan receive, 5 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc0006405b0, {0x17e5980, 0xc00063d6d0})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 99
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 102 [chan receive, 5 minutes]:
google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(0xc000640610, {0x17e5980, 0xc00063d770})
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:88 +0xe5
created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer in goroutine 99
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/grpcsync/callback_serializer.go:52 +0x11a

goroutine 106 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x714159066eb0, 0x72)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc00046a780?, 0xc000217300?, 0x0)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00046a780, {0xc000217300, 0x1980, 0x1980})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_unix.go:165 +0x27a
net.(*netFD).Read(0xc00046a780, {0xc000217300?, 0xc000217300?, 0x5?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc0007a2b80, {0xc000217300?, 0x71414b79fa78?, 0x7141a066b5c0?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/net.go:194 +0x45
crypto/tls.(*atLeastReader).Read(0xc000562090, {0xc000217300?, 0x197b?, 0xc00011e970?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:809 +0x3b
bytes.(*Buffer).ReadFrom(0xc0004237b8, {0x17c4d40, 0xc000562090})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/bytes/buffer.go:211 +0x98
crypto/tls.(*Conn).readFromUntil(0xc000423508, {0x17c4ec0, 0xc0007a2b80}, 0x441c34?)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:831 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc000423508, 0x0)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:629 +0x3cf
crypto/tls.(*Conn).readRecord(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:591
crypto/tls.(*Conn).Read(0xc000423508, {0xc000766000, 0x8000, 0x7141a066b5c0?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:1385 +0x145
bufio.(*Reader).Read(0xc0007416e0, {0xc0005383c4, 0x9, 0x14cdb20?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/bufio/bufio.go:245 +0x197
io.ReadAtLeast({0x17c3720, 0xc0007416e0}, {0xc0005383c4, 0x9, 0x9}, 0x9)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/io/io.go:335 +0x91
io.ReadFull(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/io/io.go:354
golang.org/x/net/http2.readFrameHeader({0xc0005383c4, 0x9, 0x0?}, {0x17c3720?, 0xc0007416e0?})
        /home/trek/go/pkg/mod/golang.org/x/net@v0.46.1-0.20251013234738-63d1a5100f82/http2/frame.go:242 +0x65
golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc000538380)
        /home/trek/go/pkg/mod/golang.org/x/net@v0.46.1-0.20251013234738-63d1a5100f82/http2/frame.go:505 +0x6b
google.golang.org/grpc/internal/transport.(*framer).readFrame(0xc000075500)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http_util.go:486 +0x45
google.golang.org/grpc/internal/transport.(*http2Client).reader(0xc0002aeb48, 0xc000728af0)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:1655 +0x1ce
created by google.golang.org/grpc/internal/transport.NewHTTP2Client in goroutine 103
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:411 +0x1ed3

goroutine 124 [IO wait]:
internal/poll.runtime_pollWait(0x714159066c80, 0x72)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc000704980?, 0xc000215980?, 0x0)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000704980, {0xc000215980, 0x1980, 0x1980})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_unix.go:165 +0x27a
net.(*netFD).Read(0xc000704980, {0xc000215980?, 0xc000215980?, 0x5?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc0005a2018, {0xc000215980?, 0x71414832bda8?, 0x7141a066b5c0?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/net.go:194 +0x45
crypto/tls.(*atLeastReader).Read(0xc000965bc0, {0xc000215980?, 0x197b?, 0xc00011f970?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:809 +0x3b
bytes.(*Buffer).ReadFrom(0xc000422d38, {0x17c4d40, 0xc000965bc0})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/bytes/buffer.go:211 +0x98
crypto/tls.(*Conn).readFromUntil(0xc000422a88, {0x17c4ec0, 0xc0005a2018}, 0x441c34?)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:831 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc000422a88, 0x0)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:629 +0x3cf
crypto/tls.(*Conn).readRecord(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:591
crypto/tls.(*Conn).Read(0xc000422a88, {0xc00066c000, 0x8000, 0x7141a066b5c0?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:1385 +0x145
bufio.(*Reader).Read(0xc0005dde00, {0xc000000044, 0x9, 0x14cdb20?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/bufio/bufio.go:245 +0x197
io.ReadAtLeast({0x17c3720, 0xc0005dde00}, {0xc000000044, 0x9, 0x9}, 0x9)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/io/io.go:335 +0x91
io.ReadFull(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/io/io.go:354
golang.org/x/net/http2.readFrameHeader({0xc000000044, 0x9, 0x0?}, {0x17c3720?, 0xc0005dde00?})
        /home/trek/go/pkg/mod/golang.org/x/net@v0.46.1-0.20251013234738-63d1a5100f82/http2/frame.go:242 +0x65
golang.org/x/net/http2.(*Framer).ReadFrameHeader(0xc000000000)
        /home/trek/go/pkg/mod/golang.org/x/net@v0.46.1-0.20251013234738-63d1a5100f82/http2/frame.go:505 +0x6b
google.golang.org/grpc/internal/transport.(*framer).readFrame(0xc0007ea380)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http_util.go:486 +0x45
google.golang.org/grpc/internal/transport.(*http2Client).reader(0xc0002aed88, 0xc0005be460)
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:1655 +0x1ce
created by google.golang.org/grpc/internal/transport.NewHTTP2Client in goroutine 71
        /home/trek/go/pkg/mod/google.golang.org/grpc@v1.77.0/internal/transport/http2_client.go:411 +0x1ed3

goroutine 77 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x714159066d98, 0x72)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc00046a680?, 0xc00056c000?, 0x0)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc00046a680, {0xc00056c000, 0x1800, 0x1800})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/internal/poll/fd_unix.go:165 +0x27a
net.(*netFD).Read(0xc00046a680, {0xc00056c000?, 0xc00079b3a0?, 0xc000642000?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/fd_posix.go:55 +0x25
net.(*conn).Read(0xc000800060, {0xc00056c000?, 0x714149670c18?, 0x7141a066bf30?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/net.go:194 +0x45
crypto/tls.(*atLeastReader).Read(0xc00078cb40, {0xc00056c000?, 0xc00011c928?, 0xc00011c988?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:809 +0x3b
bytes.(*Buffer).ReadFrom(0xc0001557b8, {0x17c4d40, 0xc00078cb40})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/bytes/buffer.go:211 +0x98
crypto/tls.(*Conn).readFromUntil(0xc000155508, {0x17c4ec0, 0xc000800060}, 0x441c34?)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:831 +0xde
crypto/tls.(*Conn).readRecordOrCCS(0xc000155508, 0x0)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:629 +0x3cf
crypto/tls.(*Conn).readRecord(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:591
crypto/tls.(*Conn).Read(0xc000155508, {0xc0007bc000, 0x1000, 0xc00011cd38?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/crypto/tls/conn.go:1385 +0x145
bufio.(*Reader).Read(0xc000548a80, {0xc0005384a0, 0x9, 0xc0005039f0?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/bufio/bufio.go:245 +0x197
io.ReadAtLeast({0x17c3720, 0xc000548a80}, {0xc0005384a0, 0x9, 0x9}, 0x9)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/io/io.go:335 +0x91
io.ReadFull(...)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/io/io.go:354
net/http.http2readFrameHeader({0xc0005384a0, 0x9, 0xc00047a7b0?}, {0x17c3720?, 0xc000548a80?})
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/h2_bundle.go:1805 +0x65
net/http.(*http2Framer).ReadFrame(0xc000538460)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/h2_bundle.go:2072 +0x7d
net/http.(*http2clientConnReadLoop).run(0xc00011cfa8)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/h2_bundle.go:9933 +0xda
net/http.(*http2ClientConn).readLoop(0xc000503880)
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/h2_bundle.go:9812 +0x79
created by net/http.(*http2Transport).newClientConn in goroutine 76
        /home/trek/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/net/http/h2_bundle.go:8334 +0xde5
FAIL    github.com/ausocean/cloud/cmd/oceanbench        600.018s
?       github.com/ausocean/cloud/cmd/oceanbench/s/player       [no test files]
FAIL
```
</details>