### PR TITLE
update go versions to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ausocean/cloud
 
-go 1.24.0
+go 1.26.0
 
 require (
 	bou.ke/monkey v1.0.2

--- a/oceanbench.yaml
+++ b/oceanbench.yaml
@@ -1,5 +1,5 @@
 # gcloud app deploy --version V --project oceanbench oceanbench.yaml
-runtime: go121
+runtime: go126
 
 env_variables:
   AUSOCEAN_CREDENTIALS: gs://ausocean/AusOcean-ef9cd79f81a8.json

--- a/oceancenter.yaml
+++ b/oceancenter.yaml
@@ -1,5 +1,5 @@
 # gcloud app deploy --version 3 --project oceancenter oceancenter.yaml
-runtime: go121
+runtime: go126
 
 env_variables:
   AUSOCEAN_CREDENTIALS: gs://ausocean/AusOcean-ef9cd79f81a8.json

--- a/oceancron.yaml
+++ b/oceancron.yaml
@@ -1,5 +1,5 @@
 # gcloud app deploy --project oceancron --version 2 oceancron.yaml
-runtime: go121
+runtime: go126
 
 env_variables:
   AUSOCEAN_CREDENTIALS: gs://ausocean/AusOcean-ef9cd79f81a8.json

--- a/oceantv.yaml
+++ b/oceantv.yaml
@@ -1,5 +1,5 @@
 # gcloud app deploy --version V --project oceantv oceantv.yaml
-runtime: go121
+runtime: go126
 
 env_variables:
   OPENFISH_OAUTH2_CLIENT_ID: 174291483773-8s16fhobt5ifdp41j9ism7989c6u22fu.apps.googleusercontent.com


### PR DESCRIPTION
Done because go121 is no longer supported on app-engine.

All apps build.