### PR TITLE
auth: if one-tap token is valid, return from GetProfile

### DIFF
--- a/gauth/userauth.go
+++ b/gauth/userauth.go
@@ -514,6 +514,7 @@ func (ua *UserAuth) GetProfile(h backend.Handler) (*Profile, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to set token session key: %w", err)
 		}
+		return profile, nil
 	}
 
 	err = sess.Set(profileKey, profile)


### PR DESCRIPTION
This was done so that it mirrors the oauth token route and fixes the session expiry token not adopting the maxoauthAge.

I tested this locally and it works. Before the change closing the browser of a one-tap session would require log in at browser open and revisit (Session expiry), now it has a 7 day expiry and the user stays logged in after browser close.