### PR TITLE
github: only run deploy PR action when docs are changed

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,7 +2,10 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
 
 permissions:
   checks: write


### PR DESCRIPTION
Done because it was spammy getting the comment and email for every PR.