### PR TITLE
tv (show): move notification suppression to logAndNotify

### DIFF
--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -764,7 +764,7 @@ func (s *hardwareFailure) enter() {
 		}
 		notifyMsg = fmt.Sprintf("entering hardware failure state due to: %v", s.err)
 	}
-	s.logAndNotify(notifyKind, notifyMsg)
+	s.logAndNotify(notifyKind, "%s", notifyMsg)
 }
 func (s *hardwareFailure) exit() {}
 

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -51,6 +51,41 @@ var errNoGlobalNotifier = errors.New("global notifier is nil")
 
 func (ctx *broadcastContext) logAndNotify(kind notify.Kind, msg string, args ...interface{}) {
 	ctx.log(msg, args...)
+
+	formattedMsg := fmt.Sprintf(msg, args...)
+
+	// Unmarshal the notification suppression rules from the broadcast configuration.
+	// It is of format (case-insensitive for both kinds and containing strings):
+	// {
+	//  "SuppressKinds": ["broadcast-network" , "broadcast-hardware"],
+	// 	"SuppressContaining": ["shutdown failed", "failed to start"]
+	// }
+	suppressionRules := &struct {
+		SuppressKinds      []string
+		SuppressContaining []string
+	}{}
+
+	if ctx.cfg.NotifySuppressRules != "" {
+		err := json.Unmarshal([]byte(ctx.cfg.NotifySuppressRules), suppressionRules)
+		if err != nil {
+			ctx.log("could not unmarshal notification suppression rules: %v", err)
+		} else {
+			for _, k := range suppressionRules.SuppressKinds {
+				if strings.EqualFold(k, string(kind)) {
+					ctx.log("suppressing notification of kind %s: %s", kind, formattedMsg)
+					return
+				}
+			}
+
+			for _, cont := range suppressionRules.SuppressContaining {
+				if strings.Contains(strings.ToLower(formattedMsg), strings.ToLower(cont)) {
+					ctx.log("suppressing notification containing %q: %s", cont, formattedMsg)
+					return
+				}
+			}
+		}
+	}
+
 	// If context has nil notifier, use global notifier
 	if ctx.notifier == nil {
 		ctx.log("broadcast context notifier is nil, setting to global notifier")

--- a/cmd/oceantv/state_direct_failure.go
+++ b/cmd/oceantv/state_direct_failure.go
@@ -48,7 +48,7 @@ func (s *directFailure) enter() {
 		}
 		notifyMsg = fmt.Sprintf("entering direct broadcast failure state due to: %v", s.err)
 	}
-	s.logAndNotify(notifyKind, notifyMsg)
+	s.logAndNotify(notifyKind, "%s", notifyMsg)
 
 	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
 	if err != nil {

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
@@ -142,47 +140,12 @@ func newBroadcastSystem(ctx context.Context, store Store, cfg *BroadcastConfig, 
 	broadcastContext := &broadcastContext{cfg, man, store, svc, NewVidforwardService(log), bus, &revidCameraClient{}, logOutput, nil}
 
 	// Subscribe event handler that notifies on events that implement errorEvent.
-	// Suppress if they satisfy the notification suppression rules.
 	bus.subscribe(func(event event) error {
 		if _, ok := event.(errorEvent); !ok {
 			return nil
 		}
 
 		errEvent := event.(errorEvent)
-
-		// Unmarshal the notification suppression rules from the broadcast configuration.
-		// It is of format:
-		// {
-		//  "SuppressKinds": ["broadcast-kind1" , "broadcast-kind2"],
-		// 	"SuppressContaining": ["shutdown failed", "failed to start"]
-		// }
-		suppressionRules := &struct {
-			SuppressKinds      []string
-			SuppressContaining []string
-		}{}
-
-		// Completely empty string indicates no suppression rules.
-		if cfg.NotifySuppressRules != "" {
-			err := json.Unmarshal([]byte(cfg.NotifySuppressRules), suppressionRules)
-			if err != nil {
-				broadcastContext.logAndNotify(errEvent.Kind(), "could not unmarshal notification suppression rules: %v", err)
-				return nil
-			}
-		}
-
-		for _, kind := range suppressionRules.SuppressKinds {
-			if notify.Kind(kind) == errEvent.Kind() {
-				broadcastContext.log("error event: %s", errEvent.Error())
-				return nil
-			}
-		}
-
-		for _, cont := range suppressionRules.SuppressContaining {
-			if strings.Contains(errEvent.Error(), cont) {
-				broadcastContext.log("error event: %s", errEvent.Error())
-				return nil
-			}
-		}
 
 		broadcastContext.logAndNotify(errEvent.Kind(), "error event: %s", errEvent.Error())
 		return nil


### PR DESCRIPTION
This was done because we weren't checking for suppression rules when using logAndNotify directly. This resulted in unwanted emails.