### PR TITLE
bench (show): commit version in footer on all pages

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -61,6 +61,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	rtdebug "runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -106,6 +107,7 @@ type commonData struct {
 	Standalone     bool
 	Debug          bool
 	Version        string
+	CommitHash     string
 	Msg            string
 	Pages          []page
 	PageData       interface{}
@@ -149,7 +151,22 @@ var (
 var (
 	cronScheduler proxyScheduler
 	cronSecret    []byte
+	commitHash    string
 )
+
+func init() {
+	if info, ok := rtdebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commitHash = setting.Value
+				if len(commitHash) > 7 {
+					commitHash = commitHash[:7]
+				}
+				break
+			}
+		}
+	}
+}
 
 // templateFuncs defines custom template functions.
 var templateFuncs = template.FuncMap{
@@ -588,6 +605,10 @@ func writeTemplate(w http.ResponseWriter, r *http.Request, name string, data int
 	p = v.FieldByName("Version")
 	if p.IsValid() {
 		p.SetString(version)
+	}
+	p = v.FieldByName("CommitHash")
+	if p.IsValid() {
+		p.SetString(commitHash)
 	}
 	p = v.FieldByName("Msg")
 	if p.IsValid() {

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -50,7 +50,6 @@ LICENSE
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -116,7 +115,6 @@ type commonData struct {
 	LoginURL       string
 	LogoutURL      string
 	Users          []model.User
-	Footer         template.HTML
 	CurrentSiteKey int64
 }
 
@@ -640,22 +638,16 @@ func writeTemplate(w http.ResponseWriter, r *http.Request, name string, data int
 		p.Set(reflect.ValueOf("/logout?redirect=" + r.URL.RequestURI()))
 	}
 
-	const footer = "footer.html"
-	var b bytes.Buffer
-	err := templates.ExecuteTemplate(&b, footer, data)
-	if err != nil {
-		log.Fatalf("ExecuteTemplate failed on %s: %v", footer, err)
-	}
-	p = v.FieldByName("Footer")
-	p.Set(reflect.ValueOf(template.HTML(b.String())))
-
 	if strings.HasPrefix(name, "set/") {
-		err = setTemplates.ExecuteTemplate(w, name[4:], data)
+		err := setTemplates.ExecuteTemplate(w, name[4:], data)
+		if err != nil {
+			log.Fatalf("ExecuteTemplate failed on %s: %v", name, err)
+		}
 	} else {
-		err = templates.ExecuteTemplate(w, name, data)
-	}
-	if err != nil {
-		log.Fatalf("ExecuteTemplate failed on %s: %v", name, err)
+		err := templates.ExecuteTemplate(w, name, data)
+		if err != nil {
+			log.Fatalf("ExecuteTemplate failed on %s: %v", name, err)
+		}
 	}
 }
 

--- a/cmd/oceanbench/t/admin.html
+++ b/cmd/oceanbench/t/admin.html
@@ -31,6 +31,7 @@
         return copyFormValues("delete_user", "users", { email: "input" });
       }
     </script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="init()">
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -171,6 +172,6 @@
       </div>
       <!--rounded box -->
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -14,6 +14,7 @@
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
     <script type="text/javascript" src="/s/broadcast.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
@@ -313,6 +314,6 @@
     <div id="sensor-list" style="display: none" data-sensor-list="{{json .CurrentBroadcast.SensorList}}"></div>
     <div id="send-msg" style="display: none" data-send-msg="{{.CurrentBroadcast.SendMsg}}"></div>
 
-    {{.Footer}}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/configure.html
+++ b/cmd/oceanbench/t/configure.html
@@ -9,6 +9,7 @@
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
     <script type="text/javascript" src="/s/configure.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="init();">
     <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
@@ -87,6 +88,6 @@
         </form>
       </div>
     </section>
-    {{.Footer}}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/cron-index.html
+++ b/cmd/oceanbench/t/cron-index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="/s/main.css" rel="stylesheet" type="text/css" />
     <title>Ocean Cron</title>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header id="header" class="header">
@@ -27,6 +28,6 @@
         .
       </p>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/footer.html
+++ b/cmd/oceanbench/t/footer.html
@@ -5,6 +5,9 @@
     <a rel="license" href="https://www.ausocean.org/license">License</a>
     )
   </p>
+  <p style="opacity: 0.5; font-size: 0.8em; margin-top: 5px;">
+    {{.Version}}{{if .CommitHash}} ({{.CommitHash}}){{end}}
+  </p>
   {{if .SuperAdmin}}
   <a href="/admin/tv-overview">TV Overview</a>
   {{end}}

--- a/cmd/oceanbench/t/footer.html
+++ b/cmd/oceanbench/t/footer.html
@@ -1,2 +1,0 @@
-<script type="module" src="/s/lit/site-footer.js"></script>
-<site-footer version="{{.Version}}" commit="{{.CommitHash}}" {{if .SuperAdmin}}superadmin{{end}}></site-footer>

--- a/cmd/oceanbench/t/footer.html
+++ b/cmd/oceanbench/t/footer.html
@@ -1,14 +1,2 @@
-<!-- This a template fragment, not a complete HTML template. -->
-<footer>
-  <p>
-    &copy;2019-2026 Australian Ocean Laboratory Limited (AusOcean) (
-    <a rel="license" href="https://www.ausocean.org/license">License</a>
-    )
-  </p>
-  <p style="opacity: 0.5; font-size: 0.8em; margin-top: 5px;">
-    {{.Version}}{{if .CommitHash}} ({{.CommitHash}}){{end}}
-  </p>
-  {{if .SuperAdmin}}
-  <a href="/admin/tv-overview">TV Overview</a>
-  {{end}}
-</footer>
+<script type="module" src="/s/lit/site-footer.js"></script>
+<site-footer version="{{.Version}}" commit="{{.CommitHash}}" {{if .SuperAdmin}}superadmin{{end}}></site-footer>

--- a/cmd/oceanbench/t/index.html
+++ b/cmd/oceanbench/t/index.html
@@ -10,6 +10,7 @@
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
     <script type="text/javascript" src="/s/index.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -52,5 +53,5 @@
       </div>
     </section>
   </body>
-  {{ .Footer }}
+  <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
 </html>

--- a/cmd/oceanbench/t/log.html
+++ b/cmd/oceanbench/t/log.html
@@ -15,6 +15,7 @@
         form.submit();
       }
     </script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -49,5 +50,5 @@
       </div>
     </section>
   </body>
-  {{ .Footer }}
+  <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
 </html>

--- a/cmd/oceanbench/t/media-manager.html
+++ b/cmd/oceanbench/t/media-manager.html
@@ -31,7 +31,7 @@
         <h1 class="container-md">Media Manager</h1>
         <media-manager></media-manager>
     </section>
-    <site-footer></site-footer>
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
 </body>
 
 </html>

--- a/cmd/oceanbench/t/mission-control.html
+++ b/cmd/oceanbench/t/mission-control.html
@@ -30,6 +30,6 @@
       <h1 class="container-md">Mission Control</h1>
       <admin-site-lists></admin-site-lists>
     </section>
-    <site-footer></site-footer>
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/monitor.html
+++ b/cmd/oceanbench/t/monitor.html
@@ -11,6 +11,7 @@
     <script type="text/javascript" src="/s/main.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -166,6 +167,6 @@
         {{ end }}
       </div>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/play.html
+++ b/cmd/oceanbench/t/play.html
@@ -17,6 +17,7 @@
     <script type="module" src="https://unpkg.com/wavesurfer.js@6.6.3/dist/wavesurfer.js"></script>
     <script type="module" src="https://unpkg.com/wavesurfer.js@6.6.3/dist/plugin/wavesurfer.spectrogram.js"></script>
     <script type="module" src="/s/play.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -64,6 +65,6 @@
         <div id="view"></div>
       </div>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/register.html
+++ b/cmd/oceanbench/t/register.html
@@ -7,6 +7,7 @@
     <title>CloudBlue | Register Site</title>
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -44,6 +45,6 @@
       <!--rounded box -->
       <br />
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/sandbox.html
+++ b/cmd/oceanbench/t/sandbox.html
@@ -8,6 +8,7 @@
     <title>Devices</title>
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{.Version}}" {{if .Profile}}auth="true" {{end}}>
@@ -82,6 +83,6 @@
         {{end}} {{end}}
       </div>
     </section>
-    {{.Footer}}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/search.html
+++ b/cmd/oceanbench/t/search.html
@@ -261,6 +261,7 @@
         }
       }
     </script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="init()">
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -506,5 +507,5 @@
     </section>
     {{ end }} {{ end }} {{ if and .Searching (not (or .Log .Timestamps)) }}No results.{{ end }}
   </body>
-  {{ .Footer }}
+  <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
 </html>

--- a/cmd/oceanbench/t/set/cron.html
+++ b/cmd/oceanbench/t/set/cron.html
@@ -10,6 +10,7 @@
     <script type="text/javascript" src="/s/main.js"></script>
     <script type="text/javascript" src="/s/cron.js"></script>
     <script type="module" src="/s/lit/cron-settings.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -48,6 +49,6 @@
         <cron-settings class="w-100" new-cron></cron-settings>
       </div>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/set/device.html
+++ b/cmd/oceanbench/t/set/device.html
@@ -200,6 +200,7 @@
         document.cookie = (checked ? "advanced=on;" : "advanced=off;") + " path=/set/devices";
       }
     </script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="init();">
     <div id="data">
@@ -608,7 +609,7 @@
         </div>
       </div>
     </section>
-    {{.Footer}}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
     <script type="text/javascript">
       document.addEventListener("DOMContentLoaded", function () {
         const lockCheckbox = document.getElementById("lock-voltages");

--- a/cmd/oceanbench/t/tv-overview.html
+++ b/cmd/oceanbench/t/tv-overview.html
@@ -10,6 +10,7 @@
     <script type="module" src="/s/lit/header-group.js"></script>
     <script type="module" src="/s/lit/tv-overview.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body>
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -35,6 +36,6 @@
       <h1 class="container-md">TV Overview</h1>
       <tv-overview></tv-overview>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/upload.html
+++ b/cmd/oceanbench/t/upload.html
@@ -110,6 +110,7 @@
         }
       }
     </script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="init();">
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -158,6 +159,6 @@
         <p class="fineprint">*If unsure, ask an AusOcean crew member to provide you one.</p>
       </div>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/t/utils.html
+++ b/cmd/oceanbench/t/utils.html
@@ -15,6 +15,7 @@
         encElem.value = encodeMAC(macElem.value).toString();
       }
     </script>
+      <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="history.pushState({}, '', '/admin/utils')">
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -108,6 +109,6 @@
         {{ end }}
       </div>
     </section>
-    {{ .Footer }}
+    <site-footer version="{{ .Version }}" commit="{{ .CommitHash }}" {{ if .SuperAdmin }}superadmin{{ end }}></site-footer>
   </body>
 </html>

--- a/cmd/oceanbench/ts/site-footer.ts
+++ b/cmd/oceanbench/ts/site-footer.ts
@@ -1,9 +1,10 @@
 // ts/site-footer.ts
 import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { TailwindElement } from "./shared/tailwind.element";
 
 @customElement("site-footer")
-export class SiteFooter extends LitElement {
+export class SiteFooter extends TailwindElement() {
   @property({ type: Number }) startYear = 2019;
   @property({ type: String }) orgName = "Australian Ocean Laboratory Limited (AusOcean)";
   @property({ type: String }) licenseHref = "https://www.ausocean.org/license";

--- a/cmd/oceanbench/ts/site-footer.ts
+++ b/cmd/oceanbench/ts/site-footer.ts
@@ -8,6 +8,10 @@ export class SiteFooter extends LitElement {
   @property({ type: String }) orgName = "Australian Ocean Laboratory Limited (AusOcean)";
   @property({ type: String }) licenseHref = "https://www.ausocean.org/license";
 
+  @property({ type: String }) version = "";
+  @property({ type: String }) commit = "";
+  @property({ type: Boolean }) superadmin = false;
+
   private yearRange(): string {
     const y = new Date().getFullYear();
     return this.startYear === y ? `${y}` : `${this.startYear}–${y}`;
@@ -22,6 +26,18 @@ export class SiteFooter extends LitElement {
             <a rel="license" class="underline hover:no-underline" href="${this.licenseHref}">License</a>
             )
           </p>
+          ${this.version ? html`
+          <p class="opacity-50 text-xs mt-1">
+            ${this.version}${this.commit ? ` (${this.commit})` : ""}
+          </p>
+          ` : ""}
+          ${this.superadmin ? html`
+          <div class="mt-4">
+            <a href="/admin/tv-overview" class="inline-flex items-center px-3 py-1 bg-neutral-200 hover:bg-neutral-300 rounded text-xs font-medium transition-colors text-neutral-700 hover:text-neutral-900 no-underline">
+              TV Overview
+            </a>
+          </div>
+          ` : ""}
           <slot name="extra"></slot>
         </div>
       </footer>


### PR DESCRIPTION
Added the commit version to the footer with the program (bench) version so it's easier to see what code is running (despite not bumping the version in main.go).

Applied the lit element footer to all pages and deleted html template footer for consistency.

Button to TV Overview is there temporarily, needs to be move to the nav bar.

<img width="2641" height="262" alt="image" src="https://github.com/user-attachments/assets/0d49dc17-237c-4c93-9f4d-bcb027859574" />
