### PR TITLE
OTV: Refactor direct broadcast event handling

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -212,8 +212,7 @@ func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidCo
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
 
 	case
-		*directStarting,
-		*directLiveUnhealthy:
+		*directStarting:
 
 		sm.transition(newDirectFailure(sm.ctx, event))
 
@@ -284,7 +283,7 @@ func (sm *broadcastStateMachine) handleBadHealthEvent(event badHealthEvent) erro
 		sm.transition(newVidforwardSecondaryLiveUnhealthy())
 	case *vidforwardPermanentFailure:
 		sm.logAndNotify(broadcastNetwork, "getting bad health event in permanent failure state")
-	case *vidforwardPermanentLiveUnhealthy, *vidforwardPermanentSlateUnhealthy, *vidforwardSecondaryLiveUnhealthy, *directLiveUnhealthy:
+	case *vidforwardPermanentLiveUnhealthy, *vidforwardPermanentSlateUnhealthy, *vidforwardSecondaryLiveUnhealthy:
 		// Do nothing.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
@@ -301,8 +300,6 @@ func (sm *broadcastStateMachine) handleGoodHealthEvent(event goodHealthEvent) er
 		sm.transition(newVidforwardPermanentSlate())
 	case *vidforwardSecondaryLiveUnhealthy:
 		sm.transition(newVidforwardSecondaryLive(sm.ctx))
-	case *directLiveUnhealthy:
-		sm.transition(newDirectLive(sm.ctx))
 	case *vidforwardPermanentTransitionLiveToSlate:
 		if sm.currentState.(*vidforwardPermanentTransitionLiveToSlate).isHardwareStopped() {
 			sm.transition(newVidforwardPermanentSlate())
@@ -343,7 +340,7 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 			return
 		}
 		sm.publishHealthStatusOrChatEvents(event)
-	case *vidforwardPermanentLiveUnhealthy, *vidforwardSecondaryLiveUnhealthy, *directLiveUnhealthy:
+	case *vidforwardPermanentLiveUnhealthy, *vidforwardSecondaryLiveUnhealthy:
 		if sm.finishIsDue(event) {
 			sm.ctx.bus.publish(finishEvent{})
 			return
@@ -408,8 +405,6 @@ func (sm *broadcastStateMachine) handleFixFailureEvent(event fixFailureEvent) er
 	switch sm.currentState.(type) {
 	case *vidforwardPermanentLiveUnhealthy:
 		sm.transition(newVidforwardPermanentFailure(sm.ctx))
-	case *directLiveUnhealthy:
-		sm.transition(newDirectFailure(sm.ctx, event))
 	default:
 		sm.log("unhandled event %s in current state %s", event.String(), stateToString(sm.currentState))
 	}
@@ -479,8 +474,6 @@ func (sm *broadcastStateMachine) handleFinishEvent(event finishEvent) error {
 		sm.transition(newVidforwardPermanentTransitionLiveToSlate(sm.ctx))
 	case *vidforwardSecondaryLive, *vidforwardSecondaryLiveUnhealthy:
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	case *directLiveUnhealthy:
-		sm.transition(newDirectIdle(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -361,7 +361,7 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 		}
 		sm.tryToFixCurrentState()
 
-	case *vidforwardSecondaryIdle, *vidforwardPermanentIdle, *vidforwardPermanentSlate, *directIdle:
+	case *vidforwardSecondaryIdle, *vidforwardPermanentIdle, *vidforwardPermanentSlate:
 		if sm.startIsDue(event) {
 			sm.ctx.bus.publish(startEvent{})
 			return
@@ -499,8 +499,6 @@ func (sm *broadcastStateMachine) handleStartEvent(event startEvent) error {
 		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
 	case *vidforwardSecondaryIdle:
 		sm.transition(newVidforwardSecondaryStarting(sm.ctx))
-	case *directIdle:
-		sm.transition(newDirectStarting(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -110,7 +110,7 @@ func (sm *broadcastStateMachine) handleEvent(event event) error {
 func (sm *broadcastStateMachine) handleLowVoltageEvent(event lowVoltageEvent) error {
 	sm.log("handling low voltage event")
 	switch sm.currentState.(type) {
-	case *directStarting, *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
 		// If we're in the starting state we need to reset the timeout to allow for
 		// hardware voltage recovery (remembering that this is not our primary timeout
 		// mechanism, which is handled by the hardware SM but a rather a contingency that
@@ -128,7 +128,7 @@ func (sm *broadcastStateMachine) handleLowVoltageEvent(event lowVoltageEvent) er
 func (sm *broadcastStateMachine) handleVoltageRecoveredEvent(event voltageRecoveredEvent) error {
 	sm.log("handling voltage recovered event")
 	switch sm.currentState.(type) {
-	case *directStarting, *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
 		sm.currentState.(stateWithTimeout).reset(5 * time.Minute)
 	case *vidforwardPermanentVoltageRecoverySlate:
 		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
@@ -211,11 +211,6 @@ func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidCo
 
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
 
-	case
-		*directStarting:
-
-		sm.transition(newDirectFailure(sm.ctx, event))
-
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}
@@ -228,8 +223,6 @@ func (sm *broadcastStateMachine) handleStartFailedEvent(event startFailedEvent) 
 		sm.transition(newVidforwardPermanentIdle(sm.ctx))
 	case *vidforwardSecondaryStarting:
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	case *directStarting:
-		sm.transition(newDirectIdle(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}
@@ -247,8 +240,6 @@ func (sm *broadcastStateMachine) handleCriticalFailureEvent(event criticalFailur
 		// as a result of a hardware failure, for which the primary broadcast
 		// will subsequently be in a failure state.
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	case *directStarting:
-		sm.transition(newDirectFailure(sm.ctx, event))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}
@@ -258,7 +249,7 @@ func (sm *broadcastStateMachine) handleCriticalFailureEvent(event criticalFailur
 func (sm *broadcastStateMachine) handleHardwareStartFailedEvent(event hardwareStartFailedEvent) error {
 	sm.log("handling hardware start failed event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting, *directStarting:
+	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
 		onFailureClosure(sm.ctx, sm.ctx.cfg, false)(event)
 	case *vidforwardPermanentLive, *vidforwardPermanentLiveUnhealthy:
 		sm.logAndNotify(broadcastHardware, "hardware failure event in permanent live state, moving to failure slate state")
@@ -317,8 +308,6 @@ func (sm *broadcastStateMachine) handleGoodHealthEvent(event goodHealthEvent) er
 func (sm *broadcastStateMachine) handleControllerFailureEvent(event controllerFailureEvent) error {
 	sm.log("handling controller failure event")
 	switch sm.currentState.(type) {
-	case *directStarting:
-		sm.transition(newDirectFailure(sm.ctx, event))
 	case *vidforwardPermanentStarting:
 		onFailureClosure(sm.ctx, sm.ctx.cfg, true)(event)
 		sm.transition(newVidforwardPermanentIdle(sm.ctx))
@@ -371,11 +360,6 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 		sm.publishHealthEvent(event)
 	case *vidforwardSecondaryStarting:
 		sm.transitionIfTimedOut(sm.currentState, newVidforwardSecondaryIdle(sm.ctx), event)
-	case *directStarting:
-		withTimeout := sm.currentState.(stateWithTimeout)
-		if withTimeout.timedOut(event.Time) {
-			onFailureClosure(sm.ctx, sm.ctx.cfg, false)(errors.New("direct starting timed out"))
-		}
 	case *vidforwardPermanentStarting:
 		withTimeout := sm.currentState.(stateWithTimeout)
 		if withTimeout.timedOut(event.Time) {
@@ -498,7 +482,7 @@ func (sm *broadcastStateMachine) handleStartEvent(event startEvent) error {
 func (sm *broadcastStateMachine) handleHardwareStartedEvent(event hardwareStartedEvent) error {
 	sm.log("handling hardware started event")
 	switch sm.currentState.(type) {
-	case *directStarting, *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
 		startBroadcast(sm.ctx, sm.ctx.cfg)
 	default: // Do nothing.
 	}
@@ -520,8 +504,6 @@ func (sm *broadcastStateMachine) handleStartedEvent(event startedEvent) error {
 		sm.transition(newVidforwardPermanentLive())
 	case *vidforwardSecondaryStarting:
 		sm.transition(newVidforwardSecondaryLive(sm.ctx))
-	case *directStarting:
-		sm.transition(&directLive{})
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -213,7 +213,6 @@ func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidCo
 
 	case
 		*directStarting,
-		*directLive,
 		*directLiveUnhealthy:
 
 		sm.transition(newDirectFailure(sm.ctx, event))
@@ -283,8 +282,6 @@ func (sm *broadcastStateMachine) handleBadHealthEvent(event badHealthEvent) erro
 		sm.transition(newVidforwardPermanentSlateUnhealthy(sm.ctx))
 	case *vidforwardSecondaryLive:
 		sm.transition(newVidforwardSecondaryLiveUnhealthy())
-	case *directLive:
-		sm.transition(newDirectLiveUnhealthy(sm.ctx))
 	case *vidforwardPermanentFailure:
 		sm.logAndNotify(broadcastNetwork, "getting bad health event in permanent failure state")
 	case *vidforwardPermanentLiveUnhealthy, *vidforwardPermanentSlateUnhealthy, *vidforwardSecondaryLiveUnhealthy, *directLiveUnhealthy:
@@ -340,7 +337,7 @@ func (sm *broadcastStateMachine) handleControllerFailureEvent(event controllerFa
 func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 	sm.log("handling time event: %v", event.Time)
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentLive, *vidforwardSecondaryLive, *directLive:
+	case *vidforwardPermanentLive, *vidforwardSecondaryLive:
 		if sm.finishIsDue(event) {
 			sm.ctx.bus.publish(finishEvent{})
 			return
@@ -482,7 +479,7 @@ func (sm *broadcastStateMachine) handleFinishEvent(event finishEvent) error {
 		sm.transition(newVidforwardPermanentTransitionLiveToSlate(sm.ctx))
 	case *vidforwardSecondaryLive, *vidforwardSecondaryLiveUnhealthy:
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	case *directLive, *directLiveUnhealthy:
+	case *directLiveUnhealthy:
 		sm.transition(newDirectIdle(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -55,45 +55,51 @@ func getBroadcastStateMachine(ctx *broadcastContext) (*broadcastStateMachine, er
 }
 
 func (sm *broadcastStateMachine) handleEvent(event event) error {
-	switch event.(type) {
-	case timeEvent:
-		sm.handleTimeEvent(event.(timeEvent))
-	case finishEvent:
-		sm.handleFinishEvent(event.(finishEvent))
-	case startEvent:
-		sm.handleStartEvent(event.(startEvent))
-	case hardwareStartedEvent:
-		sm.handleHardwareStartedEvent(event.(hardwareStartedEvent))
-	case hardwareStoppedEvent:
-		sm.handleHardwareStoppedEvent(event.(hardwareStoppedEvent))
-	case startedEvent:
-		sm.handleStartedEvent(event.(startedEvent))
-	case startFailedEvent:
-		sm.handleStartFailedEvent(event.(startFailedEvent))
-	case criticalFailureEvent:
-		sm.handleCriticalFailureEvent(event.(criticalFailureEvent))
-	case hardwareStartFailedEvent:
-		sm.handleHardwareStartFailedEvent(event.(hardwareStartFailedEvent))
-	case badHealthEvent:
-		sm.handleBadHealthEvent(event.(badHealthEvent))
-	case goodHealthEvent:
-		sm.handleGoodHealthEvent(event.(goodHealthEvent))
-	case fixFailureEvent:
-		sm.handleFixFailureEvent(event.(fixFailureEvent))
-	case controllerFailureEvent:
-		sm.handleControllerFailureEvent(event.(controllerFailureEvent))
-	case invalidConfigurationEvent:
-		sm.handleInvalidConfigurationEvent(event.(invalidConfigurationEvent))
-	case healthCheckDueEvent:
-		sm.handleHealthCheckDueEvent(event.(healthCheckDueEvent))
-	case statusCheckDueEvent:
-		sm.handleStatusCheckDueEvent(event.(statusCheckDueEvent))
-	case chatMessageDueEvent:
-		sm.handleChatMessageDueEvent(event.(chatMessageDueEvent))
-	case lowVoltageEvent:
-		sm.handleLowVoltageEvent(event.(lowVoltageEvent))
-	case voltageRecoveredEvent:
-		sm.handleVoltageRecoveredEvent(event.(voltageRecoveredEvent))
+	switch state := sm.currentState.(type) {
+	case stateWithBroadcastEventHandler:
+		state.handleEvent(sm, event)
+	default:
+		// We default for states that are not yet converted to state based event handling.
+		switch event.(type) {
+		case timeEvent:
+			sm.handleTimeEvent(event.(timeEvent))
+		case finishEvent:
+			sm.handleFinishEvent(event.(finishEvent))
+		case startEvent:
+			sm.handleStartEvent(event.(startEvent))
+		case hardwareStartedEvent:
+			sm.handleHardwareStartedEvent(event.(hardwareStartedEvent))
+		case hardwareStoppedEvent:
+			sm.handleHardwareStoppedEvent(event.(hardwareStoppedEvent))
+		case startedEvent:
+			sm.handleStartedEvent(event.(startedEvent))
+		case startFailedEvent:
+			sm.handleStartFailedEvent(event.(startFailedEvent))
+		case criticalFailureEvent:
+			sm.handleCriticalFailureEvent(event.(criticalFailureEvent))
+		case hardwareStartFailedEvent:
+			sm.handleHardwareStartFailedEvent(event.(hardwareStartFailedEvent))
+		case badHealthEvent:
+			sm.handleBadHealthEvent(event.(badHealthEvent))
+		case goodHealthEvent:
+			sm.handleGoodHealthEvent(event.(goodHealthEvent))
+		case fixFailureEvent:
+			sm.handleFixFailureEvent(event.(fixFailureEvent))
+		case controllerFailureEvent:
+			sm.handleControllerFailureEvent(event.(controllerFailureEvent))
+		case invalidConfigurationEvent:
+			sm.handleInvalidConfigurationEvent(event.(invalidConfigurationEvent))
+		case healthCheckDueEvent:
+			sm.handleHealthCheckDueEvent(event.(healthCheckDueEvent))
+		case statusCheckDueEvent:
+			sm.handleStatusCheckDueEvent(event.(statusCheckDueEvent))
+		case chatMessageDueEvent:
+			sm.handleChatMessageDueEvent(event.(chatMessageDueEvent))
+		case lowVoltageEvent:
+			sm.handleLowVoltageEvent(event.(lowVoltageEvent))
+		case voltageRecoveredEvent:
+			sm.handleVoltageRecoveredEvent(event.(voltageRecoveredEvent))
+		}
 	}
 
 	// After handling of the event, we may have some changes in substates of the current state.

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -75,6 +75,10 @@ type stateFields struct{}
 func (s *stateFields) enter() {}
 func (s *stateFields) exit()  {}
 
+type stateWithBroadcastEventHandler interface {
+	handleEvent(sm *broadcastStateMachine, event event)
+}
+
 type fixableState interface {
 	state
 	fix()

--- a/cmd/oceantv/state_direct_failure.go
+++ b/cmd/oceantv/state_direct_failure.go
@@ -59,6 +59,10 @@ func (s *directFailure) enter() {
 	s.bus.publish(hardwareStopRequestEvent{})
 }
 
+func (s *directFailure) handleEvent(sm *broadcastStateMachine, event event) {
+	// Do nothing.
+}
+
 func (s *directFailure) MarshalJSON() ([]byte, error) {
 	if s.err != nil {
 		return json.Marshal(struct{ Err string }{Err: s.err.Error()})

--- a/cmd/oceantv/state_direct_idle.go
+++ b/cmd/oceantv/state_direct_idle.go
@@ -31,6 +31,7 @@ type directIdle struct {
 }
 
 func newDirectIdle(ctx *broadcastContext) *directIdle { return &directIdle{broadcastContext: ctx} }
+
 func (s *directIdle) enter() {
 	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
 	if err != nil {
@@ -39,4 +40,18 @@ func (s *directIdle) enter() {
 		s.bus.publish(finishedEvent{})
 	}
 	s.bus.publish(hardwareStopRequestEvent{})
+}
+
+func (s *directIdle) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case timeEvent:
+		if sm.startIsDue(e) {
+			sm.ctx.bus.publish(startEvent{})
+			return
+		} else {
+			sm.log("start is not due, Start: %v, End: %v, time of event: %v", sm.ctx.cfg.Start.Format("15:04"), sm.ctx.cfg.End.Format("15:04"), e.Time.Format("15:04"))
+		}
+	case startEvent:
+		sm.transition(newDirectStarting(sm.ctx))
+	}
 }

--- a/cmd/oceantv/state_direct_live.go
+++ b/cmd/oceantv/state_direct_live.go
@@ -32,3 +32,20 @@ type directLive struct {
 func newDirectLive(ctx *broadcastContext) *directLive {
 	return &directLive{broadcastContext: ctx}
 }
+
+func (s *directLive) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		sm.transition(newDirectFailure(sm.ctx, e))
+	case badHealthEvent:
+		sm.transition(newDirectLiveUnhealthy(sm.ctx))
+	case timeEvent:
+		if sm.finishIsDue(e) {
+			sm.ctx.bus.publish(finishEvent{})
+			return
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+	case finishEvent:
+		sm.transition(newDirectIdle(sm.ctx))
+	}
+}

--- a/cmd/oceantv/state_direct_live_unhealthy.go
+++ b/cmd/oceantv/state_direct_live_unhealthy.go
@@ -39,6 +39,27 @@ type directLiveUnhealthy struct {
 func newDirectLiveUnhealthy(ctx *broadcastContext) *directLiveUnhealthy {
 	return &directLiveUnhealthy{broadcastContext: ctx}
 }
+
+func (s *directLiveUnhealthy) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case timeEvent:
+		if sm.finishIsDue(e) {
+			sm.ctx.bus.publish(finishEvent{})
+			return
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+		sm.tryToFixCurrentState()
+	case finishEvent:
+		sm.transition(newDirectIdle(sm.ctx))
+	case invalidConfigurationEvent:
+		sm.transition(newDirectFailure(sm.ctx, e))
+	case goodHealthEvent:
+		sm.transition(newDirectLive(sm.ctx))
+	case fixFailureEvent:
+		sm.transition(newDirectFailure(sm.ctx, e))
+	}
+}
+
 func (s *directLiveUnhealthy) fix() {
 	const directLiveFixTimeout = 8 * time.Minute
 	if time.Since(s.LastResetAttempt) <= directLiveFixTimeout {

--- a/cmd/oceantv/state_direct_starting.go
+++ b/cmd/oceantv/state_direct_starting.go
@@ -23,7 +23,10 @@ LICENSE
 
 package main
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 type directStarting struct {
 	stateFields
@@ -33,7 +36,41 @@ type directStarting struct {
 func newDirectStarting(ctx *broadcastContext) *directStarting {
 	return &directStarting{stateWithTimeoutFields: newStateWithTimeoutFields(ctx)}
 }
+
 func (s *directStarting) enter() {
 	s.LastEntered = time.Now()
 	createBroadcastAndRequestHardware(s.broadcastContext, s.cfg, nil)
+}
+
+func (s *directStarting) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case timeEvent:
+		withTimeout := sm.currentState.(stateWithTimeout)
+		if withTimeout.timedOut(e.Time) {
+			onFailureClosure(sm.ctx, sm.ctx.cfg, false)(errors.New("direct starting timed out"))
+		}
+	case hardwareStartedEvent:
+		startBroadcast(sm.ctx, sm.ctx.cfg)
+	case startedEvent:
+		sm.transition(&directLive{})
+	case lowVoltageEvent:
+		// If we're in the starting state we need to reset the timeout to allow for
+		// hardware voltage recovery (remembering that this is not our primary timeout
+		// mechanism, which is handled by the hardware SM but a rather a contingency that
+		// we shouldn't hit with normal behaviour).
+		const broadcastVoltageRecoveryOffset = 10 * time.Minute
+		sm.currentState.(stateWithTimeout).reset(time.Duration(sanatisedVoltageRecoveryTimeout(sm.ctx))*time.Hour + broadcastVoltageRecoveryOffset)
+	case voltageRecoveredEvent:
+		sm.currentState.(stateWithTimeout).reset(5 * time.Minute)
+	case invalidConfigurationEvent:
+		sm.transition(newDirectFailure(sm.ctx, e))
+	case startFailedEvent:
+		sm.transition(newDirectIdle(sm.ctx))
+	case criticalFailureEvent:
+		sm.transition(newDirectFailure(sm.ctx, e))
+	case hardwareStartFailedEvent:
+		onFailureClosure(sm.ctx, sm.ctx.cfg, false)(e)
+	case controllerFailureEvent:
+		sm.transition(newDirectFailure(sm.ctx, e))
+	}
 }


### PR DESCRIPTION
This change factors out event handling into state member functions. This makes it easier to trace all possible transitions out of states for all events.

There has been a stateWithBroadcastEventHandler interface added to allow for a partial refactor.