### PR TITLE
bench,tv,cron,datablue,center (show): deploy injecting commit hash for display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ ehthumbs.db # Windows specific
 /out/
 /target/
 /tmp/
+/datastore/store/
 
 # Dependency directories
 node_modules/

--- a/cmd/datablue/main.go
+++ b/cmd/datablue/main.go
@@ -28,6 +28,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	rtdebug "runtime/debug"
 	"strconv"
 	"sync"
 
@@ -47,7 +48,25 @@ var (
 	debug         bool
 	standalone    bool
 	storePath     string
+	commitHash    string
 )
+
+func init() {
+	if info, ok := rtdebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commitHash = setting.Value
+				if len(commitHash) > 7 {
+					commitHash = commitHash[:7]
+				}
+				break
+			}
+		}
+	}
+	if commitHash == "" {
+		commitHash = os.Getenv("COMMIT_HASH")
+	}
+}
 
 func main() {
 	defaultPort := 8083
@@ -98,7 +117,11 @@ func warmupHandler(w http.ResponseWriter, r *http.Request) {
 // test that the service is running. Devices do not use this endpoint.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	logRequest(r)
-	w.Write([]byte(projectID + " " + version))
+	if commitHash != "" {
+		w.Write([]byte(projectID + " " + version + " (" + commitHash + ")"))
+	} else {
+		w.Write([]byte(projectID + " " + version))
+	}
 }
 
 // setup executes per-instance one-time warmup and is used to

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -164,6 +164,9 @@ func init() {
 			}
 		}
 	}
+	if commitHash == "" {
+		commitHash = os.Getenv("COMMIT_HASH")
+	}
 }
 
 // templateFuncs defines custom template functions.

--- a/cmd/oceancenter/main.go
+++ b/cmd/oceancenter/main.go
@@ -36,6 +36,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	rtdebug "runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -93,6 +94,24 @@ type service struct {
 
 // app is an instance of our service.
 var app *service = &service{}
+var commitHash string
+
+func init() {
+	if info, ok := rtdebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commitHash = setting.Value
+				if len(commitHash) > 7 {
+					commitHash = commitHash[:7]
+				}
+				break
+			}
+		}
+	}
+	if commitHash == "" {
+		commitHash = os.Getenv("COMMIT_HASH")
+	}
+}
 
 func main() {
 	defaultPort := 8084
@@ -132,7 +151,11 @@ func main() {
 // test that the service is running. Devices do not use this endpoint.
 func (svc *service) indexHandler(w http.ResponseWriter, r *http.Request) {
 	svc.logRequest(r)
-	w.Write([]byte(projectID + " " + version))
+	if commitHash != "" {
+		w.Write([]byte(projectID + " " + version + " (" + commitHash + ")"))
+	} else {
+		w.Write([]byte(projectID + " " + version))
+	}
 }
 
 // setup executes per-instance one-time warmup and is used to

--- a/cmd/oceancron/main.go
+++ b/cmd/oceancron/main.go
@@ -28,6 +28,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	rtdebug "runtime/debug"
 	"strconv"
 	"sync"
 	"time"
@@ -55,7 +56,25 @@ var (
 	cronSecret    []byte
 	notifier      notify.Notifier
 	storePath     string
+	commitHash    string
 )
+
+func init() {
+	if info, ok := rtdebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commitHash = setting.Value
+				if len(commitHash) > 7 {
+					commitHash = commitHash[:7]
+				}
+				break
+			}
+		}
+	}
+	if commitHash == "" {
+		commitHash = os.Getenv("COMMIT_HASH")
+	}
+}
 
 func main() {
 	defaultPort := 8081
@@ -97,7 +116,11 @@ func warmupHandler(w http.ResponseWriter, r *http.Request) {
 // test that the service is running. Devices do not use this endpoint.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	logRequest(r)
-	w.Write([]byte(projectID + " " + version))
+	if commitHash != "" {
+		w.Write([]byte(projectID + " " + version + " (" + commitHash + ")"))
+	} else {
+		w.Write([]byte(projectID + " " + version))
+	}
 }
 
 // setup executes per-instance one-time warmup and is used to

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -31,6 +31,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	rtdebug "runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -62,7 +63,25 @@ var (
 	tvSecret   []byte
 	storePath  string
 	aotvURL    = AusOceanTVServiceURL
+	commitHash string
 )
+
+func init() {
+	if info, ok := rtdebug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				commitHash = setting.Value
+				if len(commitHash) > 7 {
+					commitHash = commitHash[:7]
+				}
+				break
+			}
+		}
+	}
+	if commitHash == "" {
+		commitHash = os.Getenv("COMMIT_HASH")
+	}
+}
 
 func main() {
 	defaultPort := 8082
@@ -198,7 +217,11 @@ func warmupHandler(w http.ResponseWriter, r *http.Request) {
 // test that the service is running. Clients do not use this endpoint.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	logRequest(r)
-	w.Write([]byte(projectID + " " + version))
+	if commitHash != "" {
+		w.Write([]byte(projectID + " " + version + " (" + commitHash + ")"))
+	} else {
+		w.Write([]byte(projectID + " " + version))
+	}
 }
 
 // setup executes per-instance one-time initialization. Any errors are

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -111,16 +111,21 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+# Always use a temporary YAML file to safely inject dynamic env variables.
+TEMP="$(dirname "$YAML")/temp_$(basename "$YAML")"
+cp "$YAML" "$TEMP"
+YAML="$TEMP"
+
+# Inject COMMIT_HASH into env_variables
+COMMIT_HASH=$(git rev-parse --short HEAD)
+sed -i "/^env_variables:/a \ \ COMMIT_HASH: '$COMMIT_HASH'" "$YAML"
+
 if $DEVELOPMENT; then
     PROMOTE="--no-promote"
     DEPLOYMENT_VERSION="dev"
 
-    TEMP="$(dirname "$YAML")/temp_$(basename "$YAML")"
-    cp $YAML $TEMP
-    YAML=$TEMP
-
-    sed -i "/^  OAUTH2_CALLBACK/d" $YAML
-    sed -i "s/# OAUTH2_CALLBACK/\OAUTH2_CALLBACK/g; s/# DEVELOPMENT/\DEVELOPMENT/g" $YAML
+    sed -i "/^  OAUTH2_CALLBACK/d" "$YAML"
+    sed -i "s/# OAUTH2_CALLBACK/\OAUTH2_CALLBACK/g; s/# DEVELOPMENT/\DEVELOPMENT/g" "$YAML"
 else
     # Get the version from main.go in the local directory.
     # Traverse up the directory tree until main.go is found.
@@ -159,6 +164,5 @@ echo "Deploying to version: $DEPLOYMENT_VERSION"
 # Deploy using app.yaml file in cloud/ directory.
 gcloud "app" "deploy" "--project=$1" "--version=$DEPLOYMENT_VERSION" "$PROMOTE" "--no-cache" "$YAML"
 
-if $DEVELOPMENT; then
-  rm $YAML
-fi
+# Always clean up the temporary YAML file
+rm "$YAML"


### PR DESCRIPTION
Added the commit hash as an environment variable that can be injected up deployment. This way all major service versions can be easily identified. The env var is required because .git is not uploaded to appengine which is what go build uses I believe to get commit info.