### PR TITLE
(Show) OTV: Use type aliases

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -241,7 +241,7 @@ func (s *oceanTVService) checkBroadcastsHandler(w http.ResponseWriter, r *http.R
 }
 
 // checkBroadcastsForSites checks broadcasts for the given sites.
-func checkBroadcastsForSites(ctx context.Context, sites []model.Site, eventHooks []eventHook, stateHooks []stateHook) error {
+func checkBroadcastsForSites(ctx Ctx, sites []model.Site, eventHooks []eventHook, stateHooks []stateHook) error {
 	var cfgVars []model.Variable
 	for _, s := range sites {
 		vars, err := model.GetVariablesBySite(ctx, store, s.Skey, broadcastScope)
@@ -259,7 +259,7 @@ func checkBroadcastsForSites(ctx context.Context, sites []model.Site, eventHooks
 	}
 
 	// Unmarshal all the configs.
-	cfgs := make([]BroadcastConfig, len(cfgVars))
+	cfgs := make([]Cfg, len(cfgVars))
 	for i, v := range cfgVars {
 		err := json.Unmarshal([]byte(v.Value), &cfgs[i])
 		if err != nil {
@@ -281,10 +281,10 @@ func checkBroadcastsForSites(ctx context.Context, sites []model.Site, eventHooks
 // be used "internally", and parameterises several interfaces through which we can
 // inject test implementations.
 func performChecksInternalThroughStateMachine(
-	ctx context.Context,
-	cfg *BroadcastConfig,
+	ctx Ctx,
+	cfg *Cfg,
 	timeNow func() time.Time,
-	store datastore.Store,
+	store Store,
 	eventHooks []eventHook,
 	stateHooks []stateHook,
 ) error {
@@ -328,7 +328,7 @@ func performChecksInternalThroughStateMachine(
 // performChecks wraps performChecksInternal and provides implementations of the
 // broadcast operations. These broadcast implementations are built around the
 // broadcast package, which employs the YouTube Live API.
-func performChecks(ctx context.Context, cfg *BroadcastConfig, store datastore.Store, eventHooks []eventHook, stateHooks []stateHook) error {
+func performChecks(ctx Ctx, cfg *Cfg, store Store, eventHooks []eventHook, stateHooks []stateHook) error {
 	return performChecksInternalThroughStateMachine(
 		ctx,
 		cfg,
@@ -339,7 +339,7 @@ func performChecks(ctx context.Context, cfg *BroadcastConfig, store datastore.St
 	)
 }
 
-type BroadcastCallback func(context.Context, *BroadcastConfig, datastore.Store, BroadcastService) error
+type BroadcastCallback func(Ctx, *Cfg, Store, Svc) error
 
 type ErrInvalidEndTime struct {
 	start, end time.Time
@@ -361,7 +361,7 @@ func saveLinkFunc() func(string, string) error {
 // external streaming hardware startup. In addition, the RTMP key is obtained
 // from the broadcast's associated stream object and used to set the devices
 // RTMPKey variable.
-func extStart(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
+func extStart(ctx Ctx, cfg *Cfg, log func(string, ...interface{})) error {
 	if cfg.OnActions == "" {
 		return nil
 	}
@@ -384,7 +384,7 @@ var warnSkipShutdown = errors.New("shutdown set to skip")
 // SkipAction is the placeholder used to represent that the action step should be skipped.
 const SkipAction = "skip"
 
-func extShutdown(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
+func extShutdown(ctx Ctx, cfg *Cfg, log func(string, ...interface{})) error {
 	if cfg.ShutdownActions == SkipAction {
 		return warnSkipShutdown
 	}
@@ -402,7 +402,7 @@ func extShutdown(ctx context.Context, cfg *BroadcastConfig, log func(string, ...
 
 // extStop uses the OffActions in the provided broadcast config to perform
 // external streaming hardware shutdown.
-func extStop(ctx context.Context, cfg *BroadcastConfig, log func(string, ...interface{})) error {
+func extStop(ctx Ctx, cfg *Cfg, log func(string, ...interface{})) error {
 	if cfg.OffActions == "" {
 		return nil
 	}

--- a/cmd/oceantv/broadcast/youtube-standalone.go
+++ b/cmd/oceantv/broadcast/youtube-standalone.go
@@ -32,7 +32,6 @@ LICENSE
 package broadcast
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"time"
@@ -43,7 +42,7 @@ import (
 
 // GetService is a stub version of GetService in youtube.go. This logs the passed
 // scope and returns an empty youtube Service.
-func GetService(ctx context.Context, w http.ResponseWriter, r *http.Request, scope string) (*youtube.Service, error) {
+func GetService(ctx Ctx, w http.ResponseWriter, r *http.Request, scope string) (*youtube.Service, error) {
 	log.Printf("getting youtube service with, scope: %s", scope)
 	return &youtube.Service{}, nil
 }

--- a/cmd/oceantv/broadcast_events.go
+++ b/cmd/oceantv/broadcast_events.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"context"
-
 	"github.com/ausocean/cloud/cmd/oceantv/registry"
 	"github.com/ausocean/cloud/notify"
 )
@@ -429,7 +427,7 @@ type eventBus interface {
 // basicEventBus is a simple event bus that stores events when the context is
 // cancelled.
 type basicEventBus struct {
-	ctx        context.Context
+	ctx        Ctx
 	handlers   []handler
 	storeEvent func(event event)
 	log        func(string, ...interface{})
@@ -439,7 +437,7 @@ type basicEventBus struct {
 // The context must be cancellable.
 // The storeEventAfterCancel function is called on publish when the context
 // is cancelled.
-func newBasicEventBus(ctx context.Context, storeEventAfterCancel func(event event), log func(string, ...interface{})) *basicEventBus {
+func newBasicEventBus(ctx Ctx, storeEventAfterCancel func(event event), log func(string, ...interface{})) *basicEventBus {
 	return &basicEventBus{storeEvent: storeEventAfterCancel, ctx: ctx, log: log}
 }
 

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -29,7 +29,7 @@ func TestGetHardwareStateStorage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stateStr := hardwareStateToString(tt.initialState)
-			gotState := getHardwareState(&broadcastContext{cfg: &BroadcastConfig{HardwareState: stateStr}, logOutput: t.Log, notifier: newMockNotifier()})
+			gotState := getHardwareState(&broadcastContext{cfg: &Cfg{HardwareState: stateStr}, logOutput: t.Log, notifier: newMockNotifier()})
 			if reflect.TypeOf(gotState) != reflect.TypeOf(tt.initialState) {
 				t.Errorf("expected state %v, got %v", tt.initialState, gotState)
 			}
@@ -74,7 +74,7 @@ func TestHandleHardwareStoppedEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.fwd = newDummyForwardingService()
-			bCtx.cfg = &BroadcastConfig{}
+			bCtx.cfg = &Cfg{}
 			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
@@ -125,7 +125,7 @@ func TestHandleHardwareStopFailedEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.fwd = newDummyForwardingService()
-			bCtx.cfg = &BroadcastConfig{}
+			bCtx.cfg = &Cfg{}
 			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
@@ -178,7 +178,7 @@ func TestHandleHardwareStartFailedEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.fwd = newDummyForwardingService()
-			bCtx.cfg = &BroadcastConfig{}
+			bCtx.cfg = &Cfg{}
 			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
@@ -231,7 +231,7 @@ func TestHandleHardwareStartedEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.fwd = newDummyForwardingService()
-			bCtx.cfg = &BroadcastConfig{}
+			bCtx.cfg = &Cfg{}
 			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
@@ -292,7 +292,7 @@ func TestHandleHardwareResetRequestEvent(t *testing.T) {
 			bus := newBasicEventBus(ctx, nil, func(string, ...interface{}) {})
 
 			bCtx.fwd = newDummyForwardingService()
-			bCtx.cfg = &BroadcastConfig{}
+			bCtx.cfg = &Cfg{}
 			bCtx.man = newDummyManager(t, bCtx.cfg)
 			bCtx.bus = bus
 
@@ -327,7 +327,7 @@ func (hs *hardwareSystem) tick() error {
 	}
 
 	// Remove stored events we just published from the config.
-	err := hs.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.Events = nil })
+	err := hs.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Events = nil })
 	if err != nil {
 		return fmt.Errorf("could not clear config events: %w", err)
 	}
@@ -345,7 +345,7 @@ func (h hardwareSystem) withBroadcastManager(bm BroadcastManager) hardwareSystem
 	}
 }
 
-func (h hardwareSystem) withBroadcastService(bs BroadcastService) hardwareSystemOption {
+func (h hardwareSystem) withBroadcastService(bs Svc) hardwareSystemOption {
 	return func(b *hardwareSystem) error {
 		b.ctx.svc = bs
 		return nil
@@ -381,7 +381,7 @@ func (h hardwareSystem) withNotifier(n notify.Notifier) hardwareSystemOption {
 	}
 }
 
-func newHardwareOnlySystem(ctx context.Context, store Store, cfg *BroadcastConfig, logOutput func(v ...any), options ...hardwareSystemOption) (*hardwareSystem, error) {
+func newHardwareOnlySystem(ctx Ctx, store Store, cfg *Cfg, logOutput func(v ...any), options ...hardwareSystemOption) (*hardwareSystem, error) {
 	if ctx.Done() == nil {
 		return nil, errors.New("context must be cancellable")
 	}
@@ -402,7 +402,7 @@ func newHardwareOnlySystem(ctx context.Context, store Store, cfg *BroadcastConfi
 	storeEventsAfterCtx := func(event event) {
 		log("storing event after cancel: %s", event.String())
 		try(
-			man.Save(nil, func(_cfg *BroadcastConfig) {
+			man.Save(nil, func(_cfg *Cfg) {
 				_cfg.Events = append(_cfg.Events, event.String())
 			}),
 			"could not update config with callback",
@@ -448,11 +448,11 @@ func TestHardwareStopAndRestart(t *testing.T) {
 
 	tests := []struct {
 		desc               string
-		cfg                func(*BroadcastConfig)
+		cfg                func(*Cfg)
 		finalHardwareState state
 		initialEvent       event
 		hardwareMan        hardwareManager
-		newBroadcastMan    func(*testing.T, *BroadcastConfig) BroadcastManager
+		newBroadcastMan    func(*testing.T, *Cfg) BroadcastManager
 
 		// Leave unset to use default max ticks.
 		// Some tests may require more ticks to reach the final state.
@@ -464,7 +464,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 	}{
 		{
 			desc: "normal hardware stop, without shutdown actions",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -476,7 +476,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 			finalHardwareState: &hardwareOff{},
 			initialEvent:       hardwareStopRequestEvent{},
 			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{hardwareStopRequestEvent{},
@@ -490,7 +490,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 		},
 		{
 			desc: "normal hardware stop, with shutdown actions",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -503,7 +503,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 			finalHardwareState: &hardwareOff{},
 			initialEvent:       hardwareStopRequestEvent{},
 			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{hardwareStopRequestEvent{}, timeEvent{}, timeEvent{}, hardwareShutdownEvent{}, timeEvent{}, hardwareStoppedEvent{}},
@@ -512,7 +512,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 		},
 		{
 			desc: "hardware restart, without shutdown actions",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -524,7 +524,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 			finalHardwareState: &hardwareOn{},
 			initialEvent:       hardwareResetRequestEvent{},
 			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{
@@ -542,7 +542,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 		},
 		{
 			desc: "hardware restart, with shutdown actions",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -555,7 +555,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 			finalHardwareState: &hardwareOn{},
 			initialEvent:       hardwareResetRequestEvent{},
 			hardwareMan:        newDummyHardwareManager(withInitialCameraState(true)),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{
@@ -588,7 +588,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 
 			// Apply broadcast config modifications
 			// and update the broadcast state based on the initial state.
-			cfg := &BroadcastConfig{}
+			cfg := &Cfg{}
 			tt.cfg(cfg)
 
 			sys, err := newHardwareOnlySystem(

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -44,7 +44,7 @@ func getBroadcastStateMachine(ctx *broadcastContext) (*broadcastStateMachine, er
 	ctx.cfg.Start = ctx.cfg.Start.In(time.UTC)
 	ctx.cfg.End = ctx.cfg.End.In(time.UTC)
 
-	err = ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.Start = ctx.cfg.Start; _cfg.End = ctx.cfg.End })
+	err = ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Start = ctx.cfg.Start; _cfg.End = ctx.cfg.End })
 	if err != nil {
 		return nil, fmt.Errorf("could not update config start and end times in transaction: %w", err)
 	}
@@ -104,7 +104,7 @@ func (sm *broadcastStateMachine) handleEvent(event event) error {
 
 	// After handling of the event, we may have some changes in substates of the current state.
 	// So we need to update the config based on this state and possibly save some state data.
-	return sm.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { updateBroadcastBasedOnState(sm.currentState, _cfg) })
+	return sm.ctx.man.Save(nil, func(_cfg *Cfg) { updateBroadcastBasedOnState(sm.currentState, _cfg) })
 }
 
 func (sm *broadcastStateMachine) handleLowVoltageEvent(event lowVoltageEvent) error {
@@ -189,7 +189,7 @@ func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidCo
 		// TODO: rather than disabling transition to a failure state.
 		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", event.Error())
 		try(
-			sm.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.Enabled = false }),
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
 			"could not disable broadcast after invalid configuration",
 			sm.logAndNotifySoftware,
 		)
@@ -204,7 +204,7 @@ func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidCo
 		// TODO: rather than disabling transition to a failure state.
 		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", event.Error())
 		try(
-			sm.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.Enabled = false }),
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
 			"could not disable broadcast after invalid configuration",
 			sm.logAndNotifySoftware,
 		)
@@ -512,7 +512,7 @@ func (sm *broadcastStateMachine) handleStartedEvent(event startedEvent) error {
 
 func (sm *broadcastStateMachine) transition(newState state) {
 	if !try(
-		sm.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { updateBroadcastBasedOnState(newState, _cfg) }),
+		sm.ctx.man.Save(nil, func(_cfg *Cfg) { updateBroadcastBasedOnState(newState, _cfg) }),
 		"could not update config for transition",
 		sm.logAndNotifySoftware,
 	) {

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -22,7 +22,7 @@ func TestHandleTimeEvent(t *testing.T) {
 		event          event
 		expectedEvents []event
 		expectedState  state
-		cfg            *BroadcastConfig
+		cfg            *Cfg
 	}{
 		{
 			desc:           "vidforwardPermanentLive with time after End",
@@ -30,7 +30,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
 			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardPermanentTransitionLiveToSlate(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -41,7 +41,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
 			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -52,7 +52,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
 			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -63,7 +63,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
 			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardPermanentTransitionLiveToSlate(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -74,7 +74,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
 			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -85,7 +85,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(2 * time.Hour)}, // Assuming this is after cfg.End
 			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -98,7 +98,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: newVidforwardPermanentIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -111,7 +111,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -124,7 +124,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: newVidforwardPermanentSlate(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -137,7 +137,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: newVidforwardPermanentSlateUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -150,7 +150,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -163,7 +163,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: &vidforwardPermanentStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now.Add(67*time.Minute))},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -176,7 +176,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: &vidforwardSecondaryStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now.Add(67*time.Minute))},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -189,7 +189,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				timeEvent{},
 			},
 			expectedState: &directStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now.Add(67*time.Minute))},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -204,7 +204,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				chatMessageDueEvent{},
 			},
 			expectedState: newVidforwardPermanentLive(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -219,7 +219,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				chatMessageDueEvent{},
 			},
 			expectedState: newVidforwardSecondaryLive(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -234,7 +234,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				chatMessageDueEvent{},
 			},
 			expectedState: newDirectLive(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -250,7 +250,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				hardwareResetRequestEvent{},
 			},
 			expectedState: newVidforwardPermanentLiveUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -265,7 +265,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				chatMessageDueEvent{},
 			},
 			expectedState: newVidforwardSecondaryLiveUnhealthy(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -281,7 +281,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				hardwareResetRequestEvent{},
 			},
 			expectedState: newDirectLiveUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -296,7 +296,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				hardwareStartRequestEvent{},
 			},
 			expectedState: newVidforwardSecondaryStarting(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -311,7 +311,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				hardwareStartRequestEvent{},
 			},
 			expectedState: newVidforwardPermanentStarting(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -326,7 +326,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				hardwareStartRequestEvent{},
 			},
 			expectedState: newVidforwardPermanentTransitionSlateToLive(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -341,7 +341,7 @@ func TestHandleTimeEvent(t *testing.T) {
 				hardwareStartRequestEvent{},
 			},
 			expectedState: newDirectStarting(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -352,7 +352,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(14 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  &vidforwardPermanentStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now.Add(10*time.Minute))},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -363,7 +363,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(14 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  &vidforwardSecondaryStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now.Add(10*time.Minute))},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -374,7 +374,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(14 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  &directStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now.Add(10*time.Minute))},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -385,7 +385,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardPermanentTransitionLiveToSlate(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -396,7 +396,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -407,7 +407,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -418,7 +418,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardPermanentTransitionLiveToSlate(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -429,7 +429,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, finishEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -440,7 +440,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, finishEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -451,7 +451,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -462,7 +462,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  newVidforwardPermanentIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -473,7 +473,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  newVidforwardPermanentSlate(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -484,7 +484,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(5 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  newVidforwardPermanentSlateUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(10 * time.Minute),
 				End:   now.Add(1 * time.Hour),
 			},
@@ -495,7 +495,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(6 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, startFailedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardPermanentIdle(bCtx),
-			cfg:            &BroadcastConfig{},
+			cfg:            &Cfg{},
 		},
 		{
 			desc:           "vidforwardPermanentStarting not timed out",
@@ -503,7 +503,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(4 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  &vidforwardPermanentStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now)},
-			cfg:            &BroadcastConfig{},
+			cfg:            &Cfg{},
 		},
 		{
 			desc:           "vidforwardSecondaryStarting timed out",
@@ -511,7 +511,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(6 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newVidforwardSecondaryIdle(bCtx),
-			cfg:            &BroadcastConfig{},
+			cfg:            &Cfg{},
 		},
 		{
 			desc:           "vidforwardSecondaryStarting not timed out",
@@ -519,7 +519,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(4 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  &vidforwardSecondaryStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now)},
-			cfg:            &BroadcastConfig{},
+			cfg:            &Cfg{},
 		},
 		{
 			desc:           "directStarting timed out",
@@ -527,7 +527,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(11 * time.Minute)},
 			expectedEvents: []event{timeEvent{}, startFailedEvent{}, finishedEvent{}, hardwareStopRequestEvent{}},
 			expectedState:  newDirectIdle(bCtx),
-			cfg:            &BroadcastConfig{},
+			cfg:            &Cfg{},
 		},
 		{
 			desc:           "directStarting not timed out",
@@ -535,7 +535,7 @@ func TestHandleTimeEvent(t *testing.T) {
 			event:          timeEvent{now.Add(4 * time.Minute)},
 			expectedEvents: []event{timeEvent{}},
 			expectedState:  &directStarting{stateWithTimeoutFields: newStateWithTimeoutFieldsWithLastEntered(bCtx, now)},
-			cfg:            &BroadcastConfig{},
+			cfg:            &Cfg{},
 		},
 	}
 
@@ -617,13 +617,13 @@ func TestHandleStartFailedEvent(t *testing.T) {
 		desc          string
 		initialState  state
 		expectedState state
-		cfg           *BroadcastConfig
+		cfg           *Cfg
 	}{
 		{
 			desc:          "vidforwardPermanentStarting",
 			initialState:  newVidforwardPermanentStarting(bCtx),
 			expectedState: newVidforwardPermanentIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -632,7 +632,7 @@ func TestHandleStartFailedEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryStarting",
 			initialState:  newVidforwardSecondaryStarting(bCtx),
 			expectedState: newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -641,7 +641,7 @@ func TestHandleStartFailedEvent(t *testing.T) {
 			desc:          "directStarting",
 			initialState:  newDirectStarting(bCtx),
 			expectedState: newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -691,13 +691,13 @@ func TestHandleBadHealthEvent(t *testing.T) {
 		desc          string
 		initialState  state
 		expectedState state
-		cfg           *BroadcastConfig
+		cfg           *Cfg
 	}{
 		{
 			desc:          "vidforwardPermanentLive",
 			initialState:  newVidforwardPermanentLive(),
 			expectedState: newVidforwardPermanentLiveUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -706,7 +706,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "vidforwardPermanentSlate",
 			initialState:  newVidforwardPermanentSlate(),
 			expectedState: newVidforwardPermanentSlateUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -715,7 +715,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryLive",
 			initialState:  newVidforwardSecondaryLive(bCtx),
 			expectedState: newVidforwardSecondaryLiveUnhealthy(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -724,7 +724,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "directLive",
 			initialState:  newDirectLive(bCtx),
 			expectedState: newDirectLiveUnhealthy(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -733,7 +733,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "vidforwardPermanentLiveUnhealthy (no change)",
 			initialState:  newVidforwardPermanentLiveUnhealthy(bCtx),
 			expectedState: newVidforwardPermanentLiveUnhealthy(bCtx), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -742,7 +742,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "vidforwardPermanentSlateUnhealthy (no change)",
 			initialState:  newVidforwardPermanentSlateUnhealthy(bCtx),
 			expectedState: newVidforwardPermanentSlateUnhealthy(bCtx), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -751,7 +751,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryLiveUnhealthy (no change)",
 			initialState:  newVidforwardSecondaryLiveUnhealthy(),
 			expectedState: newVidforwardSecondaryLiveUnhealthy(), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -760,7 +760,7 @@ func TestHandleBadHealthEvent(t *testing.T) {
 			desc:          "directLiveUnhealthy (no change)",
 			initialState:  newDirectLiveUnhealthy(bCtx),
 			expectedState: newDirectLiveUnhealthy(bCtx), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -810,13 +810,13 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 		desc          string
 		initialState  state
 		expectedState state
-		cfg           *BroadcastConfig
+		cfg           *Cfg
 	}{
 		{
 			desc:          "vidforwardPermanentLiveUnhealthy",
 			initialState:  newVidforwardPermanentLiveUnhealthy(bCtx),
 			expectedState: newVidforwardPermanentLive(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -825,7 +825,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "vidforwardPermanentSlateUnhealthy",
 			initialState:  newVidforwardPermanentSlateUnhealthy(bCtx),
 			expectedState: newVidforwardPermanentSlate(),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -834,7 +834,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryLiveUnhealthy",
 			initialState:  newVidforwardSecondaryLiveUnhealthy(),
 			expectedState: newVidforwardSecondaryLive(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -843,7 +843,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "directLiveUnhealthy",
 			initialState:  newDirectLiveUnhealthy(bCtx),
 			expectedState: newDirectLive(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -852,7 +852,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "vidforwardPermanentLive (no change)",
 			initialState:  newVidforwardPermanentLive(),
 			expectedState: newVidforwardPermanentLive(), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -861,7 +861,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "vidforwardPermanentSlate (no change)",
 			initialState:  newVidforwardPermanentSlate(),
 			expectedState: newVidforwardPermanentSlate(), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -870,7 +870,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryLive (no change)",
 			initialState:  newVidforwardSecondaryLive(bCtx),
 			expectedState: newVidforwardSecondaryLive(bCtx), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -879,7 +879,7 @@ func TestHandleGoodHealthEvent(t *testing.T) {
 			desc:          "directLive (no change)",
 			initialState:  newDirectLive(bCtx),
 			expectedState: newDirectLive(bCtx), // No transition expected
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -926,13 +926,13 @@ func TestHandleFinishEvent(t *testing.T) {
 		desc          string
 		initialState  state
 		expectedState state
-		cfg           *BroadcastConfig
+		cfg           *Cfg
 	}{
 		{
 			desc:          "vidforwardPermanentLive transitions to vidforwardPermanentTransitionLiveToSlate",
 			initialState:  newVidforwardPermanentLive(),
 			expectedState: newVidforwardPermanentTransitionLiveToSlate(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -942,7 +942,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			desc:          "vidforwardPermanentLiveUnhealthy transitions to vidforwardPermanentTransitionLiveToSlate",
 			initialState:  newVidforwardPermanentLiveUnhealthy(bCtx),
 			expectedState: newVidforwardPermanentTransitionLiveToSlate(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -953,7 +953,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryLive transitions to vidforwardSecondaryIdle",
 			initialState:  newVidforwardSecondaryLive(bCtx),
 			expectedState: newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -962,7 +962,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryLiveUnhealthy transitions to vidforwardSecondaryIdle",
 			initialState:  newVidforwardSecondaryLiveUnhealthy(),
 			expectedState: newVidforwardSecondaryIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(3 * time.Hour),
 				End:   now.Add(4 * time.Hour),
 			},
@@ -971,7 +971,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			desc:          "directLive transitions to directIdle",
 			initialState:  newDirectLive(bCtx),
 			expectedState: newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(4 * time.Hour),
 				End:   now.Add(5 * time.Hour),
 			},
@@ -980,7 +980,7 @@ func TestHandleFinishEvent(t *testing.T) {
 			desc:          "directLiveUnhealthy transitions to directIdle",
 			initialState:  newDirectLiveUnhealthy(bCtx),
 			expectedState: newDirectIdle(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(5 * time.Hour),
 				End:   now.Add(6 * time.Hour),
 			},
@@ -1027,13 +1027,13 @@ func TestHandleStartEvent(t *testing.T) {
 		desc          string
 		initialState  state
 		expectedState state
-		cfg           *BroadcastConfig
+		cfg           *Cfg
 	}{
 		{
 			desc:          "vidforwardPermanentIdle transitions to vidforwardPermanentStarting",
 			initialState:  newVidforwardPermanentIdle(bCtx),
 			expectedState: newVidforwardPermanentStarting(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -1042,7 +1042,7 @@ func TestHandleStartEvent(t *testing.T) {
 			desc:          "vidforwardPermanentSlate transitions to vidforwardPermanentLive",
 			initialState:  newVidforwardPermanentSlate(),
 			expectedState: newVidforwardPermanentTransitionSlateToLive(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -1051,7 +1051,7 @@ func TestHandleStartEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryIdle transitions to vidforwardSecondaryStarting",
 			initialState:  newVidforwardSecondaryIdle(bCtx),
 			expectedState: newVidforwardSecondaryStarting(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -1060,7 +1060,7 @@ func TestHandleStartEvent(t *testing.T) {
 			desc:          "directIdle transitions to directStarting",
 			initialState:  newDirectIdle(bCtx),
 			expectedState: newDirectStarting(bCtx),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(3 * time.Hour),
 				End:   now.Add(4 * time.Hour),
 			},
@@ -1069,7 +1069,7 @@ func TestHandleStartEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryStarting remains vidforwardSecondaryStarting",
 			initialState:  newVidforwardSecondaryStarting(bCtx),
 			expectedState: newVidforwardSecondaryStarting(bCtx), // No change
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(4 * time.Hour),
 				End:   now.Add(5 * time.Hour),
 			},
@@ -1078,7 +1078,7 @@ func TestHandleStartEvent(t *testing.T) {
 			desc:          "vidforwardPermanentStarting remains vidforwardPermanentStarting",
 			initialState:  newVidforwardPermanentStarting(bCtx),
 			expectedState: newVidforwardPermanentStarting(bCtx), // No change
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(5 * time.Hour),
 				End:   now.Add(6 * time.Hour),
 			},
@@ -1087,7 +1087,7 @@ func TestHandleStartEvent(t *testing.T) {
 			desc:          "directStarting remains directStarting",
 			initialState:  newDirectStarting(bCtx),
 			expectedState: newDirectStarting(bCtx), // No change
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(6 * time.Hour),
 				End:   now.Add(7 * time.Hour),
 			},
@@ -1134,13 +1134,13 @@ func TestHandleStartedEvent(t *testing.T) {
 		desc          string
 		initialState  state
 		expectedState state
-		cfg           *BroadcastConfig
+		cfg           *Cfg
 	}{
 		{
 			desc:          "vidforwardPermanentStarting transitions to vidforwardPermanentLive",
 			initialState:  &vidforwardPermanentStarting{},
 			expectedState: &vidforwardPermanentLive{},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -1149,7 +1149,7 @@ func TestHandleStartedEvent(t *testing.T) {
 			desc:          "vidforwardSecondaryStarting transitions to vidforwardSecondaryLive",
 			initialState:  &vidforwardSecondaryStarting{},
 			expectedState: &vidforwardSecondaryLive{},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(1 * time.Hour),
 				End:   now.Add(2 * time.Hour),
 			},
@@ -1158,7 +1158,7 @@ func TestHandleStartedEvent(t *testing.T) {
 			desc:          "directStarting transitions to directLive",
 			initialState:  &directStarting{},
 			expectedState: &directLive{},
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now.Add(2 * time.Hour),
 				End:   now.Add(3 * time.Hour),
 			},
@@ -1208,7 +1208,7 @@ func TestBroadcastStart(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
 		desc                     string
-		cfg                      *BroadcastConfig
+		cfg                      *Cfg
 		initialState             state
 		finalState               state
 		hardwareMan              hardwareManager
@@ -1219,7 +1219,7 @@ func TestBroadcastStart(t *testing.T) {
 	}{
 		{
 			desc: "direct broadcast successful start",
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -1242,7 +1242,7 @@ func TestBroadcastStart(t *testing.T) {
 		},
 		{
 			desc: "direct broadcast failed hardware start",
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				Start: now,
 				End:   now.Add(1 * time.Hour),
 			},
@@ -1365,7 +1365,7 @@ func TestHandleCameraConfiguration(t *testing.T) {
 
 	tests := []struct {
 		desc           string
-		cfg            func(*BroadcastConfig)
+		cfg            func(*Cfg)
 		initialState   state
 		finalState     state
 		expectedEvents []event
@@ -1374,7 +1374,7 @@ func TestHandleCameraConfiguration(t *testing.T) {
 	}{
 		{
 			desc: "unset camera config",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1405,7 +1405,7 @@ func TestHandleCameraConfiguration(t *testing.T) {
 		},
 		{
 			desc: "set camera config",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1529,12 +1529,12 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 
 	tests := []struct {
 		desc                  string
-		cfg                   func(*BroadcastConfig)
+		cfg                   func(*Cfg)
 		initialBroadcastState state
 		finalBroadcastState   state
 		finalHardwareState    state
 		hardwareMan           hardwareManager
-		newBroadcastMan       func(*testing.T, *BroadcastConfig) BroadcastManager
+		newBroadcastMan       func(*testing.T, *Cfg) BroadcastManager
 
 		// Leave unset to use default max ticks.
 		// Some tests may require more ticks to reach the final state.
@@ -1548,7 +1548,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// that we correctly enter the recovery state.
 		{
 			desc: "direct broadcast; start with low voltage, then enter recovery",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1560,7 +1560,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &directStarting{},
 			finalHardwareState:    &hardwareRecoveringVoltage{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{timeEvent{}, startEvent{}, hardwareStartRequestEvent{}, lowVoltageEvent{}},
@@ -1571,7 +1571,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// Tests that we can recover from the voltage recovery state.
 		{
 			desc: "direct broadcast; successful voltage recovery",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1583,7 +1583,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &directStarting{},
 			finalHardwareState:    &hardwareStarting{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			requiredTicks: 60,
@@ -1604,7 +1604,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// Tests that we identify charging fault errors.
 		{
 			desc: "direct broadcast; charging fault",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1616,7 +1616,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &directIdle{},
 			finalHardwareState:    &hardwareOff{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withChargingFault()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			requiredTicks: 260,
@@ -1638,7 +1638,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// last reported is OK, but controller is not reporting.
 		{
 			desc: "direct broadcast; controller fault",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1650,7 +1650,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &directFailure{},
 			finalHardwareState:    &hardwareFailure{},
 			hardwareMan:           newDummyHardwareManager(withHardwareFault()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{
@@ -1669,7 +1669,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// recovery i.e. idle -> live
 		{
 			desc: "permanent broadcast; broadcast start, successful voltage recovery",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1681,7 +1681,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &vidforwardPermanentStarting{},
 			finalHardwareState:    &hardwareStarting{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			requiredTicks: 60,
@@ -1703,7 +1703,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// state.
 		{
 			desc: "permanent broadcast; voltage recovery slate",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1715,7 +1715,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &vidforwardPermanentVoltageRecoverySlate{},
 			finalHardwareState:    &hardwareRecoveringVoltage{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			requiredTicks: 60,
@@ -1733,7 +1733,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		// permanent broadcast.
 		{
 			desc: "permanent broadcast; successful voltage recovery",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1746,7 +1746,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &vidforwardPermanentLive{},
 			finalHardwareState:    &hardwareOn{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage()),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			requiredTicks: 60,
@@ -1779,7 +1779,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 
 		{
 			desc: "direct broadcast; start with low voltage alarm error, then enter recovery",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1791,7 +1791,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &directStarting{},
 			finalHardwareState:    &hardwareRecoveringVoltage{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withHardwareError(LowVoltageAlarm)),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			expectedEvents: []event{timeEvent{}, startEvent{}, hardwareStartRequestEvent{}, lowVoltageEvent{}},
@@ -1801,7 +1801,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 
 		{
 			desc: "direct broadcast; low voltage alarm error, successful voltage recovery",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.Enabled = true
 				c.SKey = testSiteKey
 				c.Start = time.Now().Add(-1 * time.Hour)
@@ -1813,7 +1813,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			finalBroadcastState:   &directStarting{},
 			finalHardwareState:    &hardwareStarting{},
 			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withHardwareError(LowVoltageAlarm)),
-			newBroadcastMan: func(t *testing.T, c *BroadcastConfig) BroadcastManager {
+			newBroadcastMan: func(t *testing.T, c *Cfg) BroadcastManager {
 				return newDummyManager(t, c)
 			},
 			requiredTicks: 60,
@@ -1936,8 +1936,8 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 	}
 }
 
-func prepopulatedConfig() *BroadcastConfig {
-	return &BroadcastConfig{
+func prepopulatedConfig() *Cfg {
+	return &Cfg{
 		ShutdownActions: "shutdown",
 		CameraMac:       2,
 	}

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -43,18 +43,18 @@ import (
 
 // BroadcastManager is an interface for managing broadcasts.
 type BroadcastManager interface {
-	CreateBroadcast(cfg *Cfg, store Store, svc BroadcastService) error
+	CreateBroadcast(cfg *Cfg, store Store, svc  Svc) error
 
-	StartBroadcast(ctx Ctx, cfg *Cfg, store Store, svc BroadcastService, extStart func() error,
+	StartBroadcast(ctx Ctx, cfg *Cfg, store Store, svc Svc, extStart func() error,
 		onSuccess func(),
 		onFailure func(error))
-	StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc BroadcastService) error
-	Save(ctx Ctx, update func(*BroadcastConfig)) error
+	StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc Svc) error
+	Save(ctx Ctx, update func(*Cfg)) error
 
 	// HandleStatus checks the status of a broadcast and would perform any
 	// necessary actions based on this status. For example, if the broadcast
 	// status is complete or revoked, it might stop the broadcast.
-	HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc BroadcastService, noBroadcastCallBack BroadcastCallback) error
+	HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc Svc, noBroadcastCallBack BroadcastCallback) error
 
 	// HandleChatMessage prepares and sends chat messages to the broadcast
 	// service's chat session. This might contain information such as
@@ -72,7 +72,7 @@ type BroadcastManager interface {
 // OceanBroadcastManager is an implementation of BroadcastManager with
 // a particular focus around ocean broadcasts and AusOcean's infrastructure.
 type OceanBroadcastManager struct {
-	svc   BroadcastService
+	svc   Svc
 	log   func(string, ...interface{})
 	cfg   *Cfg
 	store Store
@@ -80,14 +80,14 @@ type OceanBroadcastManager struct {
 
 // newOceanBroadcastManager creates a new OceanBroadcastManager.
 // svc may be nil, but any methods that require it will panic.
-func newOceanBroadcastManager(svc BroadcastService, cfg *Cfg, store Store, log func(string, ...interface{})) *OceanBroadcastManager {
+func newOceanBroadcastManager(svc Svc, cfg *Cfg, store Store, log func(string, ...interface{})) *OceanBroadcastManager {
 	return &OceanBroadcastManager{svc: svc, cfg: cfg, store: store, log: log}
 }
 
 func (m *OceanBroadcastManager) CreateBroadcast(
 	cfg *Cfg,
 	store Store,
-	svc BroadcastService,
+	svc Svc,
 ) error {
 	// Only create a new broadcast if a valid one doesn't already exist.
 	if m.broadcastCanBeReused(cfg, svc) {
@@ -159,7 +159,7 @@ func (m *OceanBroadcastManager) StartBroadcast(
 	ctx Ctx,
 	cfg *Cfg,
 	store Store,
-	svc BroadcastService,
+	svc Svc,
 	extStart func() error,
 	onSuccess func(),
 	onFailure func(error),
@@ -192,7 +192,7 @@ func (m *OceanBroadcastManager) StartBroadcast(
 
 // StopBroadcast stops a broadcast using the youtube live streaming API.
 // It uses AusOcean methods for saving and stopping external hardware.
-func (m *OceanBroadcastManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc BroadcastService) error {
+func (m *OceanBroadcastManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc Svc) error {
 	m.log("stopping broadcast")
 
 	status, err := svc.BroadcastStatus(ctx, cfg.BID)
@@ -233,7 +233,7 @@ func (m *OceanBroadcastManager) Save(ctx Ctx, update func(_cfg *Cfg)) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	_update := func(_cfg *BroadcastConfig) { *_cfg = *m.cfg }
+	_update := func(_cfg *Cfg) { *_cfg = *m.cfg }
 	if update != nil {
 		_update = func(_cfg *Cfg) {
 			update(_cfg)
@@ -284,7 +284,7 @@ func (m *OceanBroadcastManager) Save(ctx Ctx, update func(_cfg *Cfg)) error {
 
 // HandleStatus checks the status of a broadcast and stops it if it has
 // complete or revoked status.
-func (m *OceanBroadcastManager) HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc BroadcastService, noBroadcastCallBack BroadcastCallback) error {
+func (m *OceanBroadcastManager) HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc Svc, noBroadcastCallBack BroadcastCallback) error {
 	m.log("handling status check")
 	status, err := svc.BroadcastStatus(ctx, cfg.BID)
 	if err != nil {
@@ -422,7 +422,7 @@ func (m *OceanBroadcastManager) SetupSecondary(ctx Ctx, cfg *Cfg, store Store) e
 	// Check if secondary broadcast already exists.
 	secondaryName := cfg.Name + secondaryBroadcastPostfix
 
-	populateFields := func(_cfg *BroadcastConfig) {
+	populateFields := func(_cfg *Cfg) {
 		// The secondary broadcast will for the most part copy the long term broadcast
 		// configuration, except for a few of the fields.
 		_cfg.Name = secondaryName
@@ -467,7 +467,7 @@ func (m *OceanBroadcastManager) SetupSecondary(ctx Ctx, cfg *Cfg, store Store) e
 
 // opsHealthNotifyFunc returns a closure of notifier.Send given to the
 // broadcast.BroadcastStream function for notifications.
-func opsHealthNotifyFunc(ctx context.Context, cfg *BroadcastConfig) func(string) error {
+func opsHealthNotifyFunc(ctx Ctx, cfg *Cfg) func(string) error {
 	return func(msg string) error {
 		return notifier.Send(ctx, cfg.SKey, broadcastGeneric, msg)
 	}
@@ -475,7 +475,7 @@ func opsHealthNotifyFunc(ctx context.Context, cfg *BroadcastConfig) func(string)
 
 // broadcastCanBeReused checks if a broadcast can be reused based on how old it
 // is, if it has been revoked or completed, and if its IDs have been set.
-func (m *OceanBroadcastManager) broadcastCanBeReused(cfg *BroadcastConfig, svc BroadcastService) bool {
+func (m *OceanBroadcastManager) broadcastCanBeReused(cfg *Cfg, svc Svc) bool {
 	// Check if the broadcast was created today. Don't reuse an old broadcast.
 	startTime, err := svc.BroadcastScheduledStartTime(context.Background(), cfg.BID)
 	if err != nil {

--- a/cmd/oceantv/broadcast_manager_test.go
+++ b/cmd/oceantv/broadcast_manager_test.go
@@ -16,14 +16,14 @@ func TestBroadcastCanBeReused(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		svc           BroadcastService
-		cfg           *BroadcastConfig
+		svc           Svc
+		cfg           *Cfg
 		expectedReuse bool
 	}{
 		{
 			name: "empty status",
 			svc:  newDummyService(WithStart(time.Now())), // DummyService always returns an empty status.
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				BID: "1",
 				SID: "2",
 			},
@@ -32,7 +32,7 @@ func TestBroadcastCanBeReused(t *testing.T) {
 		{
 			name: "good status",
 			svc:  newDummyService(WithStart(time.Now()), WithStatus("upcoming")),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				BID: "1",
 				SID: "2",
 			},
@@ -41,7 +41,7 @@ func TestBroadcastCanBeReused(t *testing.T) {
 		{
 			name: "empty ID, good status",
 			svc:  newDummyService(WithStart(time.Now()), WithStatus("upcoming")),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				BID: "",
 				SID: "2",
 			},
@@ -50,7 +50,7 @@ func TestBroadcastCanBeReused(t *testing.T) {
 		{
 			name: "good status, old broadcast",
 			svc:  newDummyService(WithStart(time.Now().Add(-24*time.Hour)), WithStatus("upcoming")),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				BID: "1",
 				SID: "2",
 			},
@@ -59,7 +59,7 @@ func TestBroadcastCanBeReused(t *testing.T) {
 		{
 			name: "good status, today's broadcast",
 			svc:  newDummyService(WithStart(time.Now()), WithStatus("upcoming")),
-			cfg: &BroadcastConfig{
+			cfg: &Cfg{
 				BID: "1",
 				SID: "2",
 			},
@@ -88,7 +88,7 @@ func TestCreateBroadcast(t *testing.T) {
 
 	tests := []struct {
 		desc           string
-		cfg            func(*BroadcastConfig)
+		cfg            func(*Cfg)
 		initialState   state
 		finalState     state
 		expectedEvents []event
@@ -97,7 +97,7 @@ func TestCreateBroadcast(t *testing.T) {
 	}{
 		{
 			desc: "create broadcast",
-			cfg: func(c *BroadcastConfig) {
+			cfg: func(c *Cfg) {
 				c.CameraMac = 2
 				c.Enabled = true
 				c.SKey = testSiteKey
@@ -122,7 +122,7 @@ func TestCreateBroadcast(t *testing.T) {
 
 			// Apply broadcast config modifications
 			// and update the broadcast state based on the initial state.
-			cfg := &BroadcastConfig{}
+			cfg := &Cfg{}
 			tt.cfg(cfg)
 			updateBroadcastBasedOnState(tt.initialState, cfg)
 

--- a/cmd/oceantv/broadcast_permanent.go
+++ b/cmd/oceantv/broadcast_permanent.go
@@ -38,12 +38,12 @@ import (
 	"github.com/ausocean/cloud/model"
 )
 
-type SlateOption func(*BroadcastConfig) error
+type SlateOption func(*Cfg) error
 
 type ForwardingService interface {
-	Stream(cfg *BroadcastConfig) error
-	Slate(cfg *BroadcastConfig, opts ...SlateOption) error
-	UploadSlate(cfg *BroadcastConfig, name string, file io.Reader) error
+	Stream(cfg *Cfg) error
+	Slate(cfg *Cfg, opts ...SlateOption) error
+	UploadSlate(cfg *Cfg, name string, file io.Reader) error
 }
 
 type vidforwardStatus string
@@ -61,7 +61,7 @@ func NewVidforwardService(log func(string, ...interface{})) *VidforwardService {
 	return &VidforwardService{log}
 }
 
-func (v *VidforwardService) Stream(cfg *BroadcastConfig) error {
+func (v *VidforwardService) Stream(cfg *Cfg) error {
 	return vidforwardRequest(cfg, vidforwardStatusPlay, v.log)
 }
 
@@ -76,16 +76,16 @@ const (
 // the type of slate to display.
 // This is currently just a stub.
 func WithType(slate SlateType) SlateOption {
-	return func(cfg *BroadcastConfig) error {
+	return func(cfg *Cfg) error {
 		return nil
 	}
 }
 
-func (v *VidforwardService) Slate(cfg *BroadcastConfig, opts ...SlateOption) error {
+func (v *VidforwardService) Slate(cfg *Cfg, opts ...SlateOption) error {
 	return vidforwardRequest(cfg, vidforwardStatusSlate, v.log)
 }
 
-func (v *VidforwardService) UploadSlate(cfg *BroadcastConfig, name string, file io.Reader) error {
+func (v *VidforwardService) UploadSlate(cfg *Cfg, name string, file io.Reader) error {
 	body := &bytes.Buffer{}
 
 	// Not closing this just yet, see close below.
@@ -124,7 +124,7 @@ func (v *VidforwardService) UploadSlate(cfg *BroadcastConfig, name string, file 
 	return nil
 }
 
-func vidforwardRequest(cfg *BroadcastConfig, status vidforwardStatus, log func(string, ...interface{})) error {
+func vidforwardRequest(cfg *Cfg, status vidforwardStatus, log func(string, ...interface{})) error {
 	primary, secondary := cfg, cfg
 	var err error
 

--- a/cmd/oceantv/broadcast_service.go
+++ b/cmd/oceantv/broadcast_service.go
@@ -28,7 +28,6 @@ LICENSE
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -52,7 +51,7 @@ type BroadcastOption func(interface{}) error
 // can be streamed to and then viewed by users.
 type BroadcastService interface {
 	CreateBroadcast(
-		ctx context.Context,
+		ctx Ctx,
 		broadcastName, description, streamName, privacy, resolution string,
 		start, end time.Time,
 		opts ...BroadcastOption,
@@ -66,13 +65,13 @@ type BroadcastService interface {
 		onLiveActions func() error,
 	) error
 
-	BroadcastStatus(ctx context.Context, id string) (string, error)
-	BroadcastScheduledStartTime(ctx context.Context, id string) (time.Time, error)
-	BroadcastHealth(ctx context.Context, sid string) (string, error)
-	RTMPKey(ctx context.Context, streamName string) (string, error)
-	CompleteBroadcast(ctx context.Context, id string) error
+	BroadcastStatus(ctx Ctx, id string) (string, error)
+	BroadcastScheduledStartTime(ctx Ctx, id string) (time.Time, error)
+	BroadcastHealth(ctx Ctx, sid string) (string, error)
+	RTMPKey(ctx Ctx, streamName string) (string, error)
+	CompleteBroadcast(ctx Ctx, id string) error
 	PostChatMessage(cID, msg string) error
-	SetBroadcastPrivacy(ctx context.Context, id, privacy string) error
+	SetBroadcastPrivacy(ctx Ctx, id, privacy string) error
 }
 
 // YouTubeResponse implements the ServerResponse interface for YouTube.
@@ -113,7 +112,7 @@ var ErrRequestLimitExceeded = errors.New("request limit exceeded")
 // CreateBroadcast creates a broadcast with the given parameters using the
 // YouTube API.
 func (s *YouTubeBroadcastService) CreateBroadcast(
-	ctx context.Context,
+	ctx Ctx,
 	broadcastName, description, streamName, privacy, resolution string,
 	start, end time.Time,
 	opts ...BroadcastOption,
@@ -191,7 +190,7 @@ func (s *YouTubeBroadcastService) StartBroadcast(
 
 // BroadcastStatus gets the status of the broadcast identification id using the
 // YouTube API.
-func (s *YouTubeBroadcastService) BroadcastStatus(ctx context.Context, id string) (string, error) {
+func (s *YouTubeBroadcastService) BroadcastStatus(ctx Ctx, id string) (string, error) {
 	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("get service error: %w", err)
@@ -215,7 +214,7 @@ func (s *YouTubeBroadcastService) BroadcastStatus(ctx context.Context, id string
 //
 // Similarly, we don't consider configuration issues to be problematic,
 // unless they are of error severity. This may also need to be revisited.
-func (s *YouTubeBroadcastService) BroadcastHealth(ctx context.Context, sid string) (string, error) {
+func (s *YouTubeBroadcastService) BroadcastHealth(ctx Ctx, sid string) (string, error) {
 	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("could not get youtube service: %w", err)
@@ -250,7 +249,7 @@ func (s *YouTubeBroadcastService) BroadcastHealth(ctx context.Context, sid strin
 }
 
 // BroadcastScheduledStartTime returns the scheduled start time of a broadcast.
-func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx context.Context, id string) (time.Time, error) {
+func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx Ctx, id string) (time.Time, error) {
 	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("get service error: %w", err)
@@ -268,7 +267,7 @@ func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx context.Contex
 
 // CompleteBroadcast transitions a broadcast with identification id to complete
 // status using the YouTube API.
-func (s *YouTubeBroadcastService) CompleteBroadcast(ctx context.Context, id string) error {
+func (s *YouTubeBroadcastService) CompleteBroadcast(ctx Ctx, id string) error {
 	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return fmt.Errorf("get service error: %w", err)
@@ -282,7 +281,7 @@ func (s *YouTubeBroadcastService) CompleteBroadcast(ctx context.Context, id stri
 
 // RTMPKey gets the broadcast RTMP key for the provided stream name using the
 // YouTube API.
-func (s *YouTubeBroadcastService) RTMPKey(ctx context.Context, streamName string) (string, error) {
+func (s *YouTubeBroadcastService) RTMPKey(ctx Ctx, streamName string) (string, error) {
 	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("get service error: %w", err)
@@ -305,7 +304,7 @@ func (s *YouTubeBroadcastService) PostChatMessage(cID, msg string) error {
 // The privacy can be one of "public", "unlisted", or "private".
 // This can be called before, during or after the broadcast.
 // The broadcast and resulting video share ID and privacy settings.
-func (s *YouTubeBroadcastService) SetBroadcastPrivacy(ctx context.Context, id, privacy string) error {
+func (s *YouTubeBroadcastService) SetBroadcastPrivacy(ctx Ctx, id, privacy string) error {
 	video := &youtube.Video{
 		Id: id,
 		Status: &youtube.VideoStatus{

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -14,10 +14,10 @@ import (
 )
 
 type broadcastContext struct {
-	cfg      *BroadcastConfig
+	cfg      *Cfg
 	man      BroadcastManager
 	store    Store
-	svc      BroadcastService
+	svc      Svc
 	fwd      ForwardingService
 	bus      eventBus
 	hardware hardwareManager
@@ -192,7 +192,7 @@ func (s *liveStateFields) lastChatMsg() time.Time         { return s.LastChatMsg
 func (s *liveStateFields) setLastStatusCheck(t time.Time) { s.LastStatusCheck = t }
 func (s *liveStateFields) setLastChatMsg(t time.Time)     { s.LastChatMsg = t }
 
-func updateBroadcastBasedOnState(state state, cfg *BroadcastConfig) {
+func updateBroadcastBasedOnState(state state, cfg *Cfg) {
 	switch state.(type) {
 	case *vidforwardPermanentLive:
 		cfg.Active = true
@@ -433,7 +433,7 @@ func broadcastCfgToState(ctx *broadcastContext) state {
 	return newState
 }
 
-func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *BroadcastConfig, onCreation func() error) {
+func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *Cfg, onCreation func() error) {
 	err := ctx.man.CreateBroadcast(
 		cfg,
 		ctx.store,
@@ -457,10 +457,10 @@ func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *BroadcastConf
 	ctx.bus.publish(hardwareStartRequestEvent{})
 }
 
-func startBroadcast(ctx *broadcastContext, cfg *BroadcastConfig) {
+func startBroadcast(ctx *broadcastContext, cfg *Cfg) {
 	onSuccess := func() {
 		ctx.bus.publish(startedEvent{})
-		err := ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.StartFailures = 0; *cfg = *_cfg })
+		err := ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.StartFailures = 0; *cfg = *_cfg })
 		if err != nil {
 			ctx.log("could not update config after successful start: %v", err)
 		}
@@ -477,11 +477,11 @@ func startBroadcast(ctx *broadcastContext, cfg *BroadcastConfig) {
 	)
 }
 
-func onFailureClosure(ctx *broadcastContext, cfg *BroadcastConfig, disableOnFirstFail bool) func(err error) {
+func onFailureClosure(ctx *broadcastContext, cfg *Cfg, disableOnFirstFail bool) func(err error) {
 	return func(err error) {
 		ctx.log("failed to start broadcast: %v", err)
 		var e event
-		try(ctx.man.Save(nil, func(_cfg *BroadcastConfig) {
+		try(ctx.man.Save(nil, func(_cfg *Cfg) {
 			const maxStartFailures = 3
 			_cfg.StartFailures++
 			if disableOnFirstFail || _cfg.StartFailures > maxStartFailures {

--- a/cmd/oceantv/broadcast_states_test.go
+++ b/cmd/oceantv/broadcast_states_test.go
@@ -21,12 +21,12 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 	tests := []struct {
 		name        string
 		state       state
-		expectedCfg BroadcastConfig
+		expectedCfg Cfg
 	}{
 		{
 			name:  "vidforwardPermanentLive",
 			state: &vidforwardPermanentLive{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -39,7 +39,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardPermanentLiveUnhealthy",
 			state: &vidforwardPermanentLiveUnhealthy{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -52,7 +52,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardPermanentSlate",
 			state: &vidforwardPermanentSlate{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             true,
 				UsingVidforward:   true,
@@ -65,7 +65,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardPermanentSlateUnhealthy",
 			state: &vidforwardPermanentSlateUnhealthy{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             true,
 				UsingVidforward:   true,
@@ -78,7 +78,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardPermanentIdle",
 			state: &vidforwardPermanentIdle{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            false,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -91,7 +91,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardPermanentStarting",
 			state: &vidforwardPermanentStarting{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            false,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -104,7 +104,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardSecondaryLive",
 			state: &vidforwardSecondaryLive{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -117,7 +117,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardSecondaryLiveUnhealthy",
 			state: &vidforwardSecondaryLiveUnhealthy{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -130,7 +130,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardSecondaryIdle",
 			state: &vidforwardSecondaryIdle{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            false,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -143,7 +143,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "vidforwardSecondaryStarting",
 			state: &vidforwardSecondaryStarting{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            false,
 				Slate:             false,
 				UsingVidforward:   true,
@@ -156,7 +156,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "directLive",
 			state: &directLive{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             false,
 				UsingVidforward:   false,
@@ -169,7 +169,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "directLiveUnhealthy",
 			state: &directLiveUnhealthy{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            true,
 				Slate:             false,
 				UsingVidforward:   false,
@@ -182,7 +182,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "directIdle",
 			state: &directIdle{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            false,
 				Slate:             false,
 				UsingVidforward:   false,
@@ -195,7 +195,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 		{
 			name:  "directStarting",
 			state: &directStarting{},
-			expectedCfg: BroadcastConfig{
+			expectedCfg: Cfg{
 				Active:            false,
 				Slate:             false,
 				UsingVidforward:   false,
@@ -209,7 +209,7 @@ func TestUpdateBroadcastBasedOnState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &BroadcastConfig{}
+			cfg := &Cfg{}
 			updateBroadcastBasedOnState(tt.state, cfg)
 			if !reflect.DeepEqual(*cfg, tt.expectedCfg) {
 				t.Errorf("for state %v, expected cfg %v, got %v", tt.name, tt.expectedCfg, *cfg)
@@ -222,97 +222,97 @@ func TestBroadcastCfgToState(t *testing.T) {
 	ctx := minimalMockBroadcastContext(t)
 	tests := []struct {
 		name string
-		cfg  BroadcastConfig
+		cfg  Cfg
 		want state
 	}{
 		{
 			name: "Vidforward Permanent Live",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardPermanentLive(),
 		},
 		{
 			name: "Vidforward Permanent Transition Live To Slate",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: true},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: true},
 			want: newVidforwardPermanentTransitionLiveToSlate(ctx),
 		},
 		{
 			name: "Vidforward Permanent Live Unhealthy",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: false, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: false, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardPermanentLiveUnhealthy(ctx),
 		},
 		{
 			name: "Vidforward Permanent Failure",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: false, InFailure: true},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: false, InFailure: true},
 			want: newVidforwardPermanentFailure(ctx),
 		},
 		{
 			name: "Vidforward Permanent Slate",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardPermanentSlate(),
 		},
 		{
 			name: "Vidforward Permanent Transition Slate To Live",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: true},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: false, AttemptingToStart: false, Transitioning: true},
 			want: newVidforwardPermanentTransitionSlateToLive(ctx),
 		},
 		{
 			name: "Vidforward Permanent Slate Unhealthy",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: true, Slate: true, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardPermanentSlateUnhealthy(ctx),
 		},
 		{
 			name: "Vidforward Permanent Idle",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardPermanentIdle(ctx),
 		},
 		{
 			name: "Vidforward Permanent Starting",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
 			want: newVidforwardPermanentStarting(ctx),
 		},
 		{
 			name: "Vidforward Secondary Live",
-			cfg:  BroadcastConfig{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardSecondaryLive(ctx),
 		},
 		{
 			name: "Vidforward Secondary Live Unhealthy",
-			cfg:  BroadcastConfig{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: true, Slate: false, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: true, Slate: false, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardSecondaryLiveUnhealthy(),
 		},
 		{
 			name: "Vidforward Secondary Idle",
-			cfg:  BroadcastConfig{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newVidforwardSecondaryIdle(ctx),
 		},
 		{
 			name: "Vidforward Secondary Starting",
-			cfg:  BroadcastConfig{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
+			cfg:  Cfg{Name: "Broadcast" + secondaryBroadcastPostfix, UsingVidforward: true, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
 			want: newVidforwardSecondaryStarting(ctx),
 		},
 		{
 			name: "Direct Live",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newDirectLive(ctx),
 		},
 		{
 			name: "Direct Live Unhealthy",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: true, AttemptingToStart: false, Transitioning: false},
 			want: newDirectLiveUnhealthy(ctx),
 		},
 		{
 			name: "Direct Idle",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: false, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false},
 			want: newDirectIdle(ctx),
 		},
 		{
 			name: "Direct Starting",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
+			cfg:  Cfg{Name: "", UsingVidforward: false, Active: false, Slate: false, Unhealthy: false, AttemptingToStart: true, Transitioning: false},
 			want: newDirectStarting(ctx),
 		},
 		{
 			name: "Direct Failure",
-			cfg:  BroadcastConfig{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false, InFailure: true},
+			cfg:  Cfg{Name: "", UsingVidforward: false, Active: true, Slate: false, Unhealthy: false, AttemptingToStart: false, Transitioning: false, InFailure: true},
 			want: newDirectFailure(ctx, nil),
 		},
 	}
@@ -465,7 +465,7 @@ func TestStateMarshalUnmarshal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			var cfg BroadcastConfig
+			var cfg Cfg
 			updateBroadcastBasedOnState(tt.s, &cfg)
 			state := broadcastCfgToState(&broadcastContext{cfg: &cfg, logOutput: t.Log, notifier: newMockNotifier()})
 			if !tt.equal(tt.s, state) {
@@ -498,7 +498,7 @@ func TestRateLimited(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			limiter := newMockLimiter(tt.limited)
-			cfg := &BroadcastConfig{}
+			cfg := &Cfg{}
 			bus := newMockEventBus(t.Logf)
 			ctx := broadcastContext{
 				cfg, newDummyManager(t, cfg, withRateLimiter(limiter)),

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -106,7 +106,7 @@ func newDummyManager(t *testing.T, cfg *Cfg, options ...dummyManagerOption) *dum
 func (d *dummyManager) CreateBroadcast(
 	cfg *Cfg,
 	store Store,
-	svc BroadcastService,
+	svc Svc,
 ) error {
 	if d.Limiter != nil && !d.Limiter.RequestOK() {
 		return ErrRequestLimitExceeded
@@ -141,7 +141,7 @@ func (d *dummyManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, svc Svc) er
 	d.stopped = true
 	return nil
 }
-func (d *dummyManager) Save(ctx Ctx, update func(*BroadcastConfig)) error {
+func (d *dummyManager) Save(ctx Ctx, update func(*Cfg)) error {
 	d.saved = true
 	if update != nil {
 		update(d.cfg)
@@ -228,7 +228,7 @@ func (d *dummyStore) Create(ctx Ctx, key *Key, src Ety) error               { re
 func (d *dummyStore) Update(ctx Ctx, key *Key, fn func(Ety), dst Ety) error { return nil }
 func (d *dummyStore) Delete(ctx Ctx, key *Key) error                        { return nil }
 
-// dummyService is a dummy implementation of the BroadcastService interface.
+// dummyService is a dummy implementation of the Svc interface.
 // It does nothing and is used to test the broadcast functions.
 type dummyService struct {
 	status string

--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -226,7 +226,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 
 // setup executes per-instance one-time initialization. Any errors are
 // considered fatal.
-func setup(ctx context.Context) {
+func setup(ctx Ctx) {
 	setupMutex.Lock()
 	defer setupMutex.Unlock()
 
@@ -326,7 +326,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var cfg BroadcastConfig
+	var cfg Cfg
 	err = json.Unmarshal(data, &cfg)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -338,7 +338,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Use the broadcast manager to save the broadcast.
-	// We can provide a nil BroadcastService given that Save
+	// We can provide a nil Svc given that Save
 	// won't need this.
 	err = newOceanBroadcastManager(nil, &cfg, store, log).Save(ctx, func(_cfg *Cfg) {
 		// Update only the fields that can be updated via the UI.

--- a/cmd/oceantv/store.go
+++ b/cmd/oceantv/store.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -13,7 +12,7 @@ import (
 // appropriate store based on the kind of the entity. This tries to fix the
 // awkwardness of selecting the right store based on the kind of the entity
 // you're dealing with.
-func ausOceanCompositeStore(settingsStore, mediaStore datastore.Store) *CompositeStore {
+func ausOceanCompositeStore(settingsStore, mediaStore Store) *CompositeStore {
 	getKindFromQuery := func(query datastore.Query) string {
 		getKindField := func(v reflect.Value) string {
 			const kindField = "kind"
@@ -42,7 +41,7 @@ func ausOceanCompositeStore(settingsStore, mediaStore datastore.Store) *Composit
 	}
 
 	return NewCompositeStore(
-		map[string]datastore.Store{
+		map[string]Store{
 			"Scalar":     mediaStore,
 			"Text":       mediaStore,
 			"MtsMedia":   mediaStore,
@@ -68,10 +67,10 @@ func ausOceanCompositeStore(settingsStore, mediaStore datastore.Store) *Composit
 // CompositeStore is a datastore "facade" that delegates to the appropriate
 // store based on the kind of the entity. This is useful when you have multiple
 // stores that you want to treat as a single store.
-// CompositeStore implements the datastore.Store interface and can therefore
+// CompositeStore implements the Store interface and can therefore
 // substitute for any particular store instance.
 type CompositeStore struct {
-	stores        map[string]datastore.Store
+	stores        map[string]Store
 	kindFromQuery KindFromQuery
 }
 
@@ -84,7 +83,7 @@ type KindFromQuery func(datastore.Query) string
 
 // NewCompositeStore returns a new CompositeStore with the given stores.
 // The stores map should be keyed by the kind of the entity.
-func NewCompositeStore(stores map[string]datastore.Store, kindFromQuery KindFromQuery) *CompositeStore {
+func NewCompositeStore(stores map[string]Store, kindFromQuery KindFromQuery) *CompositeStore {
 	return &CompositeStore{stores, kindFromQuery}
 }
 
@@ -114,7 +113,7 @@ func (s *CompositeStore) NewQuery(kind string, keysOnly bool, keyParts ...string
 
 // Get implements the Store.Get by calling Get on the appropriate store based
 // on the kind.
-func (s *CompositeStore) Get(ctx context.Context, key *Key, dst datastore.Entity) error {
+func (s *CompositeStore) Get(ctx Ctx, key *Key, dst Ety) error {
 	return s.getStore(key.Kind).Get(ctx, key, dst)
 }
 
@@ -122,41 +121,41 @@ func (s *CompositeStore) Get(ctx context.Context, key *Key, dst datastore.Entity
 // We find the appropriate store through trial and error given that the query
 // does not contain the kind. We look at possible stores and try to find the matching
 // one.
-func (s *CompositeStore) GetAll(ctx context.Context, query datastore.Query, dst interface{}) ([]*Key, error) {
+func (s *CompositeStore) GetAll(ctx Ctx, query datastore.Query, dst interface{}) ([]*Key, error) {
 	return s.getStore(s.kindFromQuery(query)).GetAll(ctx, query, dst)
 }
 
 // Create implements the Store.Create by calling Create on the appropriate store
 // based on the kind.
-func (s *CompositeStore) Create(ctx context.Context, key *Key, src datastore.Entity) error {
+func (s *CompositeStore) Create(ctx Ctx, key *Key, src Ety) error {
 	return s.getStore(key.Kind).Create(ctx, key, src)
 }
 
 // Put implements the Store.Put by calling Put on the appropriate store
 // based on the kind.
-func (s *CompositeStore) Put(ctx context.Context, key *Key, src datastore.Entity) (*Key, error) {
+func (s *CompositeStore) Put(ctx Ctx, key *Key, src Ety) (*Key, error) {
 	return s.getStore(key.Kind).Put(ctx, key, src)
 }
 
 // Update implements the Store.Update by calling Update on the appropriate store
 // based on the kind.
-func (s *CompositeStore) Update(ctx context.Context, key *Key, fn func(datastore.Entity), dst datastore.Entity) error {
+func (s *CompositeStore) Update(ctx Ctx, key *Key, fn func(Ety), dst Ety) error {
 	return s.getStore(key.Kind).Update(ctx, key, fn, dst)
 }
 
 // DeleteMulti implements the Store.DeleteMulti by calling DeleteMulti on the
 // appropriate store based on the kind.
-func (s *CompositeStore) DeleteMulti(ctx context.Context, keys []*Key) error {
+func (s *CompositeStore) DeleteMulti(ctx Ctx, keys []*Key) error {
 	return s.getStore(keys[0].Kind).DeleteMulti(ctx, keys)
 }
 
 // Delete implements the Store.Delete by calling Delete on the appropriate store
 // based on the kind.
-func (s *CompositeStore) Delete(ctx context.Context, key *Key) error {
+func (s *CompositeStore) Delete(ctx Ctx, key *Key) error {
 	return s.getStore(key.Kind).Delete(ctx, key)
 }
 
-func (s *CompositeStore) getStore(kind string) datastore.Store {
+func (s *CompositeStore) getStore(kind string) Store {
 	store, ok := s.stores[kind]
 	if !ok {
 		panic(fmt.Sprintf("store not found for kind: %q, ensure this kind is mapped to a store", kind))

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -30,7 +30,7 @@ func withBroadcastManager(bm BroadcastManager) broadcastSystemOption {
 	}
 }
 
-func withBroadcastService(bs BroadcastService) broadcastSystemOption {
+func withBroadcastService(bs Svc) broadcastSystemOption {
 	return func(b *broadcastSystem) error {
 		b.ctx.svc = bs
 		return nil
@@ -98,7 +98,7 @@ func withStateHandlers(h ...func(state)) broadcastSystemOption {
 // newBroadcastSystem creates a new broadcast system.
 // Default implementations for the various components are used, but can be overridden
 // by passing options to this function.
-func newBroadcastSystem(ctx context.Context, store Store, cfg *BroadcastConfig, logOutput func(v ...any), options ...broadcastSystemOption) (*broadcastSystem, error) {
+func newBroadcastSystem(ctx Ctx, store Store, cfg *Cfg, logOutput func(v ...any), options ...broadcastSystemOption) (*broadcastSystem, error) {
 	if ctx.Done() == nil {
 		return nil, errors.New("context must be cancellable")
 	}
@@ -126,7 +126,7 @@ func newBroadcastSystem(ctx context.Context, store Store, cfg *BroadcastConfig, 
 		log("storing event after cancel: %s", event.String())
 		eventData := marshalEvent(event)
 		try(
-			man.Save(nil, func(_cfg *BroadcastConfig) {
+			man.Save(nil, func(_cfg *Cfg) {
 				_cfg.Events = append(_cfg.Events, string(eventData))
 			}),
 			"could not update config with callback",
@@ -185,7 +185,7 @@ func (bs *broadcastSystem) tick() error {
 	if !bs.ctx.cfg.Enabled {
 		// Make sure it's in the idle state when not enabled, so we're not starting, transitioning or active.
 		try(
-			bs.ctx.man.Save(nil, func(_cfg *BroadcastConfig) {
+			bs.ctx.man.Save(nil, func(_cfg *Cfg) {
 				_cfg.AttemptingToStart = false
 				_cfg.Transitioning = false
 				_cfg.Active = false
@@ -207,7 +207,7 @@ func (bs *broadcastSystem) tick() error {
 					}
 				}
 			}
-			try(bs.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.BID = "" }), "could not clear broadcast ID", bs.log)
+			try(bs.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.BID = "" }), "could not clear broadcast ID", bs.log)
 		}
 
 		bs.log("broadcast not enabled, not doing anything")
@@ -222,7 +222,7 @@ func (bs *broadcastSystem) tick() error {
 	}
 
 	// Remove stored events we just published from the config.
-	err := bs.ctx.man.Save(nil, func(_cfg *BroadcastConfig) { _cfg.Events = nil })
+	err := bs.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Events = nil })
 	if err != nil {
 		return fmt.Errorf("could not clear config events: %w", err)
 	}

--- a/cmd/oceantv/utils.go
+++ b/cmd/oceantv/utils.go
@@ -42,11 +42,11 @@ import (
 
 // logForBroadcast logs a message with the broadcast name and ID.
 // This is useful to keep track of logs for different broadcasts.
-func logForBroadcast(cfg *BroadcastConfig, output func(v ...any), msg string, args ...interface{}) {
+func logForBroadcast(cfg *Cfg, output func(v ...any), msg string, args ...interface{}) {
 	output(fmtForBroadcastLog(cfg, msg, args...))
 }
 
-func fmtForBroadcastLog(cfg *BroadcastConfig, msg string, args ...interface{}) string {
+func fmtForBroadcastLog(cfg *Cfg, msg string, args ...interface{}) string {
 	idArgs := []interface{}{cfg.Name, cfg.BroadcastState, cfg.HardwareState, cfg.BID}
 	idArgs = append(idArgs, args...)
 	return fmt.Sprintf("(name: %s, broadcast state: %s, hardware state: %s, id: %s) "+msg, idArgs...)
@@ -72,7 +72,7 @@ func removeDate(s string) string {
 // acts is of form: <device.varname>=<value>,<device.varname>=<value>. For example,
 // if we need to turn on a camera and set its mode to normal:
 // ESP.CamPower=true,Camera.mode=Normal.
-func setActionVars(ctx context.Context, sKey int64, acts string, store datastore.Store, log func(string, ...interface{})) error {
+func setActionVars(ctx Ctx, sKey int64, acts string, store Store, log func(string, ...interface{})) error {
 	vars := strings.Split(acts, ",")
 	if len(vars) == 0 {
 		return errors.New("no var actions to perform")
@@ -93,7 +93,7 @@ func setActionVars(ctx context.Context, sKey int64, acts string, store datastore
 }
 
 // setVar sets cloud variables. These variable are only set if they already exist.
-func setVar(ctx context.Context, store datastore.Store, name, value string, sKey int64, log func(string, ...interface{})) error {
+func setVar(ctx Ctx, store Store, name, value string, sKey int64, log func(string, ...interface{})) error {
 	log("checking %s variable exists", name)
 	_, err := model.GetVariable(ctx, store, sKey, name)
 	if err != nil {
@@ -110,7 +110,7 @@ func setVar(ctx context.Context, store datastore.Store, name, value string, sKey
 
 // broadcastByName gets the broadcast configuration with the provided name from
 // the datastore. An error is returned if there's no match or for other issues.
-func broadcastByName(sKey int64, name string) (*BroadcastConfig, error) {
+func broadcastByName(sKey int64, name string) (*Cfg, error) {
 	// Load config information for any prior broadcasts that have been saved.
 	vars, err := model.GetVariablesBySite(context.Background(), store, sKey, broadcastScope)
 	if err != nil {
@@ -124,7 +124,7 @@ func broadcastByName(sKey int64, name string) (*BroadcastConfig, error) {
 }
 
 // TODO: document this.
-func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, broadcast string, update func(cfg *BroadcastConfig)) error {
+func updateConfigWithTransaction(ctx Ctx, store Store, skey int64, broadcast string, update func(cfg *Cfg)) error {
 	name := broadcastScope + "." + broadcast
 	sep := strings.Index(name, ".")
 	if sep >= 0 {
@@ -134,14 +134,14 @@ func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, b
 	key := store.NameKey(typeVariable, strconv.FormatInt(skey, 10)+"."+name)
 
 	var callBackErr error
-	updateConfig := func(ety datastore.Entity) {
+	updateConfig := func(ety Ety) {
 		v, ok := ety.(*model.Variable)
 		if !ok {
 			callBackErr = errors.New("could not cast entity to type Variable")
 			return
 		}
 
-		var cfg BroadcastConfig
+		var cfg Cfg
 		err := json.Unmarshal([]byte(v.Value), &cfg)
 		if err != nil {
 			callBackErr = fmt.Errorf("could not unmarshal selected broadcast config: %v", err)
@@ -169,14 +169,14 @@ func updateConfigWithTransaction(ctx context.Context, store Store, skey int64, b
 
 		// Since the entity doesn't already exist, we need to change the updateConfig function to update
 		// a blank config.
-		updateConfig = func(ety datastore.Entity) {
+		updateConfig = func(ety Ety) {
 			v, ok := ety.(*model.Variable)
 			if !ok {
 				callBackErr = errors.New("could not cast entity to type Variable")
 				return
 			}
 
-			cfg := &BroadcastConfig{}
+			cfg := &Cfg{}
 			update(cfg)
 
 			v.Skey = skey
@@ -222,10 +222,10 @@ func (e ErrBroadcastNotFound) Is(target error) bool {
 // broadcastFromVars searches a slice of broadcast variables for a broadcast
 // config with the provided name and returns if found, otherwise an error is
 // returned.
-func broadcastFromVars(broadcasts []model.Variable, name string) (*BroadcastConfig, error) {
+func broadcastFromVars(broadcasts []model.Variable, name string) (*Cfg, error) {
 	for _, v := range broadcasts {
 		if name == v.Name || name == strings.TrimPrefix(v.Name, broadcastScope+".") {
-			var cfg BroadcastConfig
+			var cfg Cfg
 			err := json.Unmarshal([]byte(v.Value), &cfg)
 			if err != nil {
 				return nil, fmt.Errorf("could not unmarshal selected broadcast config: %v", err)
@@ -238,14 +238,14 @@ func broadcastFromVars(broadcasts []model.Variable, name string) (*BroadcastConf
 
 var logConfigs = false
 
-func provideConfig(cfg *BroadcastConfig) string {
+func provideConfig(cfg *Cfg) string {
 	if logConfigs {
 		return fmt.Sprintf("%v", trimDescriptionFromConfig(cfg))
 	}
 	return fmt.Sprintf("(config logging disabled) Events: %v, HardwareState: %v", cfg.Events, cfg.HardwareState)
 }
 
-func trimDescriptionFromConfig(cfg *BroadcastConfig) string {
+func trimDescriptionFromConfig(cfg *Cfg) string {
 	trimmedConfig := *cfg
 	cfg.Description = trimDescriptionChars(trimmedConfig.Description)
 	trimmedData, err := json.Marshal(trimmedConfig)


### PR DESCRIPTION
This change replaces many places where the type alias was not used where it could have been used. This should help improve refactoring, as less instances should need to be updated.