### PR TITLE
(Show) OTV: Rename broadcast package

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -40,7 +40,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/gauth"
 	"github.com/ausocean/cloud/model"
@@ -352,7 +352,7 @@ func broadcastHandler(w http.ResponseWriter, r *http.Request) {
 	switch action {
 	case broadcastToken:
 		tokenURI := utils.TokenURIFromAccount(profile.Email)
-		err = broadcast.AuthChannel(ctx, w, r, youtube.YoutubeScope, tokenURI)
+		err = yt.AuthChannel(ctx, w, r, youtube.YoutubeScope, tokenURI)
 		if err != nil {
 			reportError(w, r, req, "could not authenticate channel: %v", err)
 			return

--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -34,7 +34,7 @@ import (
 	"time"
 
 	"github.com/ausocean/av/revid/config"
-	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/model"
 	"github.com/ausocean/utils/nmea"
@@ -200,7 +200,7 @@ func (m *OceanBroadcastManager) StopBroadcast(ctx Ctx, cfg *Cfg, store Store, sv
 		return fmt.Errorf("could not get broadcast status: %w", err)
 	}
 
-	if status != broadcast.StatusComplete && status != "" {
+	if status != yt.StatusComplete && status != "" {
 		err := svc.CompleteBroadcast(ctx, cfg.BID)
 		if err != nil {
 			return fmt.Errorf("could not complete broadcast: %w", err)
@@ -288,7 +288,7 @@ func (m *OceanBroadcastManager) HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc
 	m.log("handling status check")
 	status, err := svc.BroadcastStatus(ctx, cfg.BID)
 	if err != nil {
-		if !errors.Is(err, broadcast.ErrNoBroadcastItems) {
+		if !errors.Is(err, yt.ErrNoBroadcastItems) {
 			return fmt.Errorf("could not get broadcast status: %w", err)
 		}
 
@@ -299,7 +299,7 @@ func (m *OceanBroadcastManager) HandleStatus(ctx Ctx, cfg *Cfg, store Store, svc
 		}
 	}
 
-	if status != broadcast.StatusComplete && status != broadcast.StatusRevoked {
+	if status != yt.StatusComplete && status != yt.StatusRevoked {
 		return nil
 	}
 
@@ -495,5 +495,5 @@ func (m *OceanBroadcastManager) broadcastCanBeReused(cfg *Cfg, svc Svc) bool {
 		return false
 	}
 	m.log("today's broadcast has status: %s", status)
-	return cfg.BID != "" && cfg.SID != "" && status != "" && status != broadcast.StatusRevoked && status != broadcast.StatusComplete
+	return cfg.BID != "" && cfg.SID != "" && status != "" && status != yt.StatusRevoked && status != yt.StatusComplete
 }

--- a/cmd/oceantv/broadcast_service.go
+++ b/cmd/oceantv/broadcast_service.go
@@ -33,7 +33,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/youtube/v3"
 )
@@ -55,7 +55,7 @@ type BroadcastService interface {
 		broadcastName, description, streamName, privacy, resolution string,
 		start, end time.Time,
 		opts ...BroadcastOption,
-	) (ServerResponse, broadcast.IDs, string, error)
+	) (ServerResponse, yt.IDs, string, error)
 
 	StartBroadcast(
 		name, bID, sID string,
@@ -116,29 +116,29 @@ func (s *YouTubeBroadcastService) CreateBroadcast(
 	broadcastName, description, streamName, privacy, resolution string,
 	start, end time.Time,
 	opts ...BroadcastOption,
-) (ServerResponse, broadcast.IDs, string, error) {
+) (ServerResponse, yt.IDs, string, error) {
 	for _, opt := range opts {
 		if err := opt(s); err != nil {
-			return nil, broadcast.IDs{}, "", fmt.Errorf("could not apply option: %w", err)
+			return nil, yt.IDs{}, "", fmt.Errorf("could not apply option: %w", err)
 		}
 	}
 
 	if s.limiter != nil {
 		if !s.limiter.RequestOK() {
-			return nil, broadcast.IDs{}, "", ErrRequestLimitExceeded
+			return nil, yt.IDs{}, "", ErrRequestLimitExceeded
 		}
 	}
 
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
-		return YouTubeResponse{}, broadcast.IDs{}, "", fmt.Errorf("could not get service: %w", err)
+		return YouTubeResponse{}, yt.IDs{}, "", fmt.Errorf("could not get service: %w", err)
 	}
 
 	const (
 		typ       = "rtmp"
 		framerate = "30fps"
 	)
-	resp, ids, err := broadcast.BroadcastStream(
+	resp, ids, err := yt.BroadcastStream(
 		svc,
 		broadcastName,
 		description,
@@ -152,12 +152,12 @@ func (s *YouTubeBroadcastService) CreateBroadcast(
 		s.log,
 	)
 	if err != nil {
-		return YouTubeResponse{}, broadcast.IDs{}, "", fmt.Errorf("could not broadcast stream: %w response: %v", err, resp)
+		return YouTubeResponse{}, yt.IDs{}, "", fmt.Errorf("could not broadcast stream: %w response: %v", err, resp)
 	}
 
-	key, err := broadcast.RTMPKey(svc, streamName)
+	key, err := yt.RTMPKey(svc, streamName)
 	if err != nil {
-		return YouTubeResponse{}, broadcast.IDs{}, "", fmt.Errorf("could not get stream RTMP key: %w", err)
+		return YouTubeResponse{}, yt.IDs{}, "", fmt.Errorf("could not get stream RTMP key: %w", err)
 	}
 
 	return YouTubeResponse(resp), ids, key, nil
@@ -174,7 +174,7 @@ func (s *YouTubeBroadcastService) StartBroadcast(
 	notify func(msg string) error,
 	onLiveActions func() error,
 ) error {
-	return broadcast.Start(
+	return yt.Start(
 		name,
 		bID,
 		sID,
@@ -191,12 +191,12 @@ func (s *YouTubeBroadcastService) StartBroadcast(
 // BroadcastStatus gets the status of the broadcast identification id using the
 // YouTube API.
 func (s *YouTubeBroadcastService) BroadcastStatus(ctx Ctx, id string) (string, error) {
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("get service error: %w", err)
 	}
-	status, err := broadcast.GetBroadcastStatus(svc, id)
-	if err != nil && !errors.Is(err, broadcast.ErrNoBroadcastItems) {
+	status, err := yt.GetBroadcastStatus(svc, id)
+	if err != nil && !errors.Is(err, yt.ErrNoBroadcastItems) {
 		return "", fmt.Errorf("get broadcast status error: %w", err)
 	}
 	return status, nil
@@ -215,12 +215,12 @@ func (s *YouTubeBroadcastService) BroadcastStatus(ctx Ctx, id string) (string, e
 // Similarly, we don't consider configuration issues to be problematic,
 // unless they are of error severity. This may also need to be revisited.
 func (s *YouTubeBroadcastService) BroadcastHealth(ctx Ctx, sid string) (string, error) {
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("could not get youtube service: %w", err)
 	}
 
-	health, err := broadcast.GetHealthStatus(svc, sid)
+	health, err := yt.GetHealthStatus(svc, sid)
 	if err != nil {
 		return "", fmt.Errorf("could not get health status: %w", err)
 	}
@@ -250,12 +250,12 @@ func (s *YouTubeBroadcastService) BroadcastHealth(ctx Ctx, sid string) (string, 
 
 // BroadcastScheduledStartTime returns the scheduled start time of a broadcast.
 func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx Ctx, id string) (time.Time, error) {
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("get service error: %w", err)
 	}
-	start, err := broadcast.GetBroadcastScheduledStart(svc, id)
-	if err != nil && !errors.Is(err, broadcast.ErrNoBroadcastItems) {
+	start, err := yt.GetBroadcastScheduledStart(svc, id)
+	if err != nil && !errors.Is(err, yt.ErrNoBroadcastItems) {
 		return time.Time{}, fmt.Errorf("get broadcast status error: %w", err)
 	}
 	startTime, err := time.Parse(time.RFC3339, start)
@@ -268,11 +268,11 @@ func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx Ctx, id string
 // CompleteBroadcast transitions a broadcast with identification id to complete
 // status using the YouTube API.
 func (s *YouTubeBroadcastService) CompleteBroadcast(ctx Ctx, id string) error {
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return fmt.Errorf("get service error: %w", err)
 	}
-	err = broadcast.CompleteBroadcast(svc, id, s.log)
+	err = yt.CompleteBroadcast(svc, id, s.log)
 	if err != nil {
 		return fmt.Errorf("complete broadcast error: %w", err)
 	}
@@ -282,11 +282,11 @@ func (s *YouTubeBroadcastService) CompleteBroadcast(ctx Ctx, id string) error {
 // RTMPKey gets the broadcast RTMP key for the provided stream name using the
 // YouTube API.
 func (s *YouTubeBroadcastService) RTMPKey(ctx Ctx, streamName string) (string, error) {
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("get service error: %w", err)
 	}
-	key, err := broadcast.RTMPKey(svc, streamName)
+	key, err := yt.RTMPKey(svc, streamName)
 	if err != nil {
 		return "", fmt.Errorf("get RTMP key error: %w", err)
 	}
@@ -296,13 +296,13 @@ func (s *YouTubeBroadcastService) RTMPKey(ctx Ctx, streamName string) (string, e
 // PostChatMessage posts a chat message with the provided message and token URI
 // to the chat identification cID using the YouTube API.
 func (s *YouTubeBroadcastService) PostChatMessage(cID, msg string) error {
-	return broadcast.PostChatMessage(cID, s.tokenURI, msg)
+	return yt.PostChatMessage(cID, s.tokenURI, msg)
 }
 
 // SetBroadcastPrivacy sets the broadcast privacy of the broadcast with
 // identification ID to the provided privacy using the YouTube API.
 // The privacy can be one of "public", "unlisted", or "private".
-// This can be called before, during or after the broadcast.
+// This can be called before, during or after the yt.
 // The broadcast and resulting video share ID and privacy settings.
 func (s *YouTubeBroadcastService) SetBroadcastPrivacy(ctx Ctx, id, privacy string) error {
 	video := &youtube.Video{
@@ -313,7 +313,7 @@ func (s *YouTubeBroadcastService) SetBroadcastPrivacy(ctx Ctx, id, privacy strin
 		},
 	}
 
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return fmt.Errorf("could not get youtube service: %w", err)
 	}

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -34,7 +34,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/model"
 	"github.com/ausocean/cloud/notify"
@@ -264,8 +264,8 @@ func (d *dummyService) CreateBroadcast(
 	broadcastName, description, streamName, privacy, resolution string,
 	start, end time.Time,
 	opts ...BroadcastOption,
-) (ServerResponse, broadcast.IDs, string, error) {
-	return nil, broadcast.IDs{}, "", nil
+) (ServerResponse, yt.IDs, string, error) {
+	return nil, yt.IDs{}, "", nil
 }
 
 func (d *dummyService) StartBroadcast(

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/notify"
 	"github.com/ausocean/cloud/utils"
 )
@@ -200,7 +200,7 @@ func (bs *broadcastSystem) tick() error {
 			if err != nil {
 				bs.log("could not get broadcast status: %v", err)
 			} else {
-				if status == broadcast.StatusLive {
+				if status == yt.StatusLive {
 					err = bs.ctx.svc.CompleteBroadcast(context.Background(), bs.ctx.cfg.BID)
 					if err != nil {
 						bs.ctx.logAndNotify(broadcastService, "could not complete broadcast, please check this manually: %v", err)

--- a/cmd/oceantv/yt/auth.go
+++ b/cmd/oceantv/yt/auth.go
@@ -27,7 +27,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package broadcast
+package yt
 
 import (
 	"context"

--- a/cmd/oceantv/yt/storage.go
+++ b/cmd/oceantv/yt/storage.go
@@ -25,7 +25,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package broadcast
+package yt
 
 import (
 	"context"

--- a/cmd/oceantv/yt/storage_test.go
+++ b/cmd/oceantv/yt/storage_test.go
@@ -23,7 +23,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package broadcast
+package yt
 
 import "testing"
 

--- a/cmd/oceantv/yt/youtube-standalone.go
+++ b/cmd/oceantv/yt/youtube-standalone.go
@@ -27,9 +27,9 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Package broadcast provides functionality for setting up a YouTube livestream
+// package yt provides functionality for setting up a YouTube livestream
 // service and broadcast scheduling.
-package broadcast
+package yt
 
 import (
 	"log"

--- a/cmd/oceantv/yt/youtube.go
+++ b/cmd/oceantv/yt/youtube.go
@@ -29,9 +29,9 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-// Package broadcast provides functionality for setting up a YouTube livestream
+// package yt provides functionality for setting up a YouTube livestream
 // service and broadcast scheduling.
-package broadcast
+package yt
 
 import (
 	"context"

--- a/youtube/upload.go
+++ b/youtube/upload.go
@@ -32,7 +32,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/utils"
 	"google.golang.org/api/youtube/v3"
 )
@@ -195,7 +195,7 @@ func UploadVideo(ctx context.Context, media io.Reader, account string, opts ...V
 
 	// Force using the default account (AusOcean's account).
 	tokenURI := utils.TokenURIFromAccount(account)
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, tokenURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get YouTube service: %w", err)
 	}
@@ -220,7 +220,7 @@ func UploadVideo(ctx context.Context, media io.Reader, account string, opts ...V
 // is passed, the AusOcean channel will be used.
 func CheckUploadStatus(ctx context.Context, videoID string, account string) (string, error) {
 	tokenURI := utils.TokenURIFromAccount(account)
-	svc, err := broadcast.GetService(ctx, youtube.YoutubeScope, tokenURI)
+	svc, err := yt.GetService(ctx, youtube.YoutubeScope, tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("failed to get YouTube service: %w", err)
 	}


### PR DESCRIPTION
This change renames the broadcast package to yt in oceanTV. This is to make way for a more broadcast generic package, as opposed to the current youtube implementation specific code which was previously in the package.