### PR TITLE
(Show) OTV: Add state based event handling for remaining broadcast states

### DIFF
--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -110,15 +109,13 @@ func (sm *broadcastStateMachine) handleEvent(event event) error {
 func (sm *broadcastStateMachine) handleLowVoltageEvent(event lowVoltageEvent) error {
 	sm.log("handling low voltage event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardSecondaryStarting:
 		// If we're in the starting state we need to reset the timeout to allow for
 		// hardware voltage recovery (remembering that this is not our primary timeout
 		// mechanism, which is handled by the hardware SM but a rather a contingency that
 		// we shouldn't hit with normal behaviour).
 		const broadcastVoltageRecoveryOffset = 10 * time.Minute
 		sm.currentState.(stateWithTimeout).reset(time.Duration(sanatisedVoltageRecoveryTimeout(sm.ctx))*time.Hour + broadcastVoltageRecoveryOffset)
-	case *vidforwardPermanentTransitionSlateToLive:
-		sm.transition(newVidforwardPermanentVoltageRecoverySlate(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}
@@ -128,7 +125,7 @@ func (sm *broadcastStateMachine) handleLowVoltageEvent(event lowVoltageEvent) er
 func (sm *broadcastStateMachine) handleVoltageRecoveredEvent(event voltageRecoveredEvent) error {
 	sm.log("handling voltage recovered event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardSecondaryStarting:
 		sm.currentState.(stateWithTimeout).reset(5 * time.Minute)
 	case *vidforwardPermanentVoltageRecoverySlate:
 		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
@@ -177,26 +174,6 @@ func (sm *broadcastStateMachine) handleChatMessageDueEvent(event chatMessageDueE
 func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidConfigurationEvent) {
 	switch sm.currentState.(type) {
 	case
-		*vidforwardPermanentStarting,
-		*vidforwardPermanentLive,
-		*vidforwardPermanentLiveUnhealthy,
-		*vidforwardPermanentSlate,
-		*vidforwardPermanentSlateUnhealthy,
-		*vidforwardPermanentTransitionLiveToSlate,
-		*vidforwardPermanentTransitionSlateToLive,
-		*vidforwardPermanentFailure:
-
-		// TODO: rather than disabling transition to a failure state.
-		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", event.Error())
-		try(
-			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
-			"could not disable broadcast after invalid configuration",
-			sm.logAndNotifySoftware,
-		)
-
-		sm.transition(newVidforwardPermanentIdle(sm.ctx))
-
-	case
 		*vidforwardSecondaryStarting,
 		*vidforwardSecondaryLive,
 		*vidforwardSecondaryLiveUnhealthy:
@@ -219,8 +196,6 @@ func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidCo
 func (sm *broadcastStateMachine) handleStartFailedEvent(event startFailedEvent) error {
 	sm.log("handling start failed event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting:
-		sm.transition(newVidforwardPermanentIdle(sm.ctx))
 	case *vidforwardSecondaryStarting:
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
 	default:
@@ -232,8 +207,6 @@ func (sm *broadcastStateMachine) handleStartFailedEvent(event startFailedEvent) 
 func (sm *broadcastStateMachine) handleCriticalFailureEvent(event criticalFailureEvent) error {
 	sm.log("handling critical failure event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting:
-		sm.transition(newVidforwardPermanentFailure(sm.ctx))
 	case *vidforwardSecondaryStarting:
 		// There might need to be a secondary failure state, but we're not sure
 		// yet. For now, we'll just transition to idle. Most failures will occur
@@ -249,14 +222,8 @@ func (sm *broadcastStateMachine) handleCriticalFailureEvent(event criticalFailur
 func (sm *broadcastStateMachine) handleHardwareStartFailedEvent(event hardwareStartFailedEvent) error {
 	sm.log("handling hardware start failed event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardSecondaryStarting:
 		onFailureClosure(sm.ctx, sm.ctx.cfg, false)(event)
-	case *vidforwardPermanentLive, *vidforwardPermanentLiveUnhealthy:
-		sm.logAndNotify(broadcastHardware, "hardware failure event in permanent live state, moving to failure slate state")
-		sm.transition(newVidforwardPermanentFailure(sm.ctx))
-	case *vidforwardPermanentTransitionSlateToLive:
-		sm.logAndNotify(broadcastHardware, "hardware failure event in transition from slate to live, moving to failure slate state")
-		sm.transition(newVidforwardPermanentFailure(sm.ctx))
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
 	}
@@ -266,15 +233,9 @@ func (sm *broadcastStateMachine) handleHardwareStartFailedEvent(event hardwareSt
 func (sm *broadcastStateMachine) handleBadHealthEvent(event badHealthEvent) error {
 	sm.log("handling bad health event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentLive:
-		sm.transition(newVidforwardPermanentLiveUnhealthy(sm.ctx))
-	case *vidforwardPermanentSlate:
-		sm.transition(newVidforwardPermanentSlateUnhealthy(sm.ctx))
 	case *vidforwardSecondaryLive:
 		sm.transition(newVidforwardSecondaryLiveUnhealthy())
-	case *vidforwardPermanentFailure:
-		sm.logAndNotify(broadcastNetwork, "getting bad health event in permanent failure state")
-	case *vidforwardPermanentLiveUnhealthy, *vidforwardPermanentSlateUnhealthy, *vidforwardSecondaryLiveUnhealthy:
+	case *vidforwardSecondaryLiveUnhealthy:
 		// Do nothing.
 	default:
 		sm.unexpectedEvent(event, sm.currentState)
@@ -285,20 +246,8 @@ func (sm *broadcastStateMachine) handleBadHealthEvent(event badHealthEvent) erro
 func (sm *broadcastStateMachine) handleGoodHealthEvent(event goodHealthEvent) error {
 	sm.log("handling good health event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentLiveUnhealthy:
-		sm.transition(newVidforwardPermanentLive())
-	case *vidforwardPermanentSlateUnhealthy:
-		sm.transition(newVidforwardPermanentSlate())
 	case *vidforwardSecondaryLiveUnhealthy:
 		sm.transition(newVidforwardSecondaryLive(sm.ctx))
-	case *vidforwardPermanentTransitionLiveToSlate:
-		if sm.currentState.(*vidforwardPermanentTransitionLiveToSlate).isHardwareStopped() {
-			sm.transition(newVidforwardPermanentSlate())
-		}
-	case *vidforwardPermanentTransitionSlateToLive:
-		if sm.currentState.(*vidforwardPermanentTransitionSlateToLive).isHardwareStarted() {
-			sm.transition(newVidforwardPermanentLive())
-		}
 	default:
 		// Do nothing.
 	}
@@ -308,9 +257,6 @@ func (sm *broadcastStateMachine) handleGoodHealthEvent(event goodHealthEvent) er
 func (sm *broadcastStateMachine) handleControllerFailureEvent(event controllerFailureEvent) error {
 	sm.log("handling controller failure event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting:
-		onFailureClosure(sm.ctx, sm.ctx.cfg, true)(event)
-		sm.transition(newVidforwardPermanentIdle(sm.ctx))
 	case *vidforwardSecondaryStarting:
 		onFailureClosure(sm.ctx, sm.ctx.cfg, true)(event)
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
@@ -323,13 +269,13 @@ func (sm *broadcastStateMachine) handleControllerFailureEvent(event controllerFa
 func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 	sm.log("handling time event: %v", event.Time)
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentLive, *vidforwardSecondaryLive:
+	case *vidforwardSecondaryLive:
 		if sm.finishIsDue(event) {
 			sm.ctx.bus.publish(finishEvent{})
 			return
 		}
 		sm.publishHealthStatusOrChatEvents(event)
-	case *vidforwardPermanentLiveUnhealthy, *vidforwardSecondaryLiveUnhealthy:
+	case *vidforwardSecondaryLiveUnhealthy:
 		if sm.finishIsDue(event) {
 			sm.ctx.bus.publish(finishEvent{})
 			return
@@ -337,41 +283,15 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 		sm.publishHealthStatusOrChatEvents(event)
 		sm.tryToFixCurrentState()
 
-	case *vidforwardPermanentSlateUnhealthy:
-		if sm.startIsDue(event) {
-			sm.ctx.bus.publish(startEvent{})
-			return
-		}
-		sm.tryToFixCurrentState()
-
-	case *vidforwardSecondaryIdle, *vidforwardPermanentIdle, *vidforwardPermanentSlate:
+	case *vidforwardSecondaryIdle:
 		if sm.startIsDue(event) {
 			sm.ctx.bus.publish(startEvent{})
 			return
 		} else {
 			sm.log("start is not due, Start: %v, End: %v, time of event: %v", sm.ctx.cfg.Start.Format("15:04"), sm.ctx.cfg.End.Format("15:04"), event.Time.Format("15:04"))
 		}
-	case *vidforwardPermanentTransitionLiveToSlate:
-		withTimeout := sm.currentState.(stateWithTimeout)
-		if withTimeout.timedOut(event.Time) {
-			sm.logAndNotify(broadcastForwarder, "transition from live to slate timed out, staying in live state, check forwarding service")
-			sm.transition(newVidforwardPermanentLive())
-		}
-		sm.publishHealthEvent(event)
 	case *vidforwardSecondaryStarting:
 		sm.transitionIfTimedOut(sm.currentState, newVidforwardSecondaryIdle(sm.ctx), event)
-	case *vidforwardPermanentStarting:
-		withTimeout := sm.currentState.(stateWithTimeout)
-		if withTimeout.timedOut(event.Time) {
-			onFailureClosure(sm.ctx, sm.ctx.cfg, false)(errors.New("permanent starting timed out"))
-		}
-	case *vidforwardPermanentTransitionSlateToLive:
-		withTimeout := sm.currentState.(stateWithTimeout)
-		if withTimeout.timedOut(event.Time) {
-			sm.ctx.logAndNotify(broadcastGeneric, "transition from slate to live timed out, transitioning to failure slate state")
-			sm.transition(newVidforwardPermanentFailure(sm.ctx))
-		}
-		sm.publishHealthStatusOrChatEvents(event)
 	case *vidforwardPermanentVoltageRecoverySlate:
 		withTimeout := sm.currentState.(stateWithTimeout)
 		if withTimeout.timedOut(event.Time) {
@@ -387,8 +307,6 @@ func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
 func (sm *broadcastStateMachine) handleFixFailureEvent(event fixFailureEvent) error {
 	sm.log("handling fix failure event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentLiveUnhealthy:
-		sm.transition(newVidforwardPermanentFailure(sm.ctx))
 	default:
 		sm.log("unhandled event %s in current state %s", event.String(), stateToString(sm.currentState))
 	}
@@ -454,8 +372,6 @@ func (sm *broadcastStateMachine) publishHealthEvent(event timeEvent) {
 func (sm *broadcastStateMachine) handleFinishEvent(event finishEvent) error {
 	sm.log("handling finish event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentLive, *vidforwardPermanentLiveUnhealthy:
-		sm.transition(newVidforwardPermanentTransitionLiveToSlate(sm.ctx))
 	case *vidforwardSecondaryLive, *vidforwardSecondaryLiveUnhealthy:
 		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
 	default:
@@ -467,10 +383,6 @@ func (sm *broadcastStateMachine) handleFinishEvent(event finishEvent) error {
 func (sm *broadcastStateMachine) handleStartEvent(event startEvent) error {
 	sm.log("handling start event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentIdle:
-		sm.transition(newVidforwardPermanentStarting(sm.ctx))
-	case *vidforwardPermanentSlate:
-		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
 	case *vidforwardSecondaryIdle:
 		sm.transition(newVidforwardSecondaryStarting(sm.ctx))
 	default:
@@ -482,7 +394,7 @@ func (sm *broadcastStateMachine) handleStartEvent(event startEvent) error {
 func (sm *broadcastStateMachine) handleHardwareStartedEvent(event hardwareStartedEvent) error {
 	sm.log("handling hardware started event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting, *vidforwardSecondaryStarting:
+	case *vidforwardSecondaryStarting:
 		startBroadcast(sm.ctx, sm.ctx.cfg)
 	default: // Do nothing.
 	}
@@ -500,8 +412,6 @@ func (sm *broadcastStateMachine) handleHardwareStoppedEvent(event hardwareStoppe
 func (sm *broadcastStateMachine) handleStartedEvent(event startedEvent) error {
 	sm.log("handling started event")
 	switch sm.currentState.(type) {
-	case *vidforwardPermanentStarting:
-		sm.transition(newVidforwardPermanentLive())
 	case *vidforwardSecondaryStarting:
 		sm.transition(newVidforwardSecondaryLive(sm.ctx))
 	default:

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -54,85 +54,17 @@ func getBroadcastStateMachine(ctx *broadcastContext) (*broadcastStateMachine, er
 }
 
 func (sm *broadcastStateMachine) handleEvent(event event) error {
-	switch state := sm.currentState.(type) {
-	case stateWithBroadcastEventHandler:
-		state.handleEvent(sm, event)
-	default:
-		// We default for states that are not yet converted to state based event handling.
-		switch event.(type) {
-		case timeEvent:
-			sm.handleTimeEvent(event.(timeEvent))
-		case finishEvent:
-			sm.handleFinishEvent(event.(finishEvent))
-		case startEvent:
-			sm.handleStartEvent(event.(startEvent))
-		case hardwareStartedEvent:
-			sm.handleHardwareStartedEvent(event.(hardwareStartedEvent))
-		case hardwareStoppedEvent:
-			sm.handleHardwareStoppedEvent(event.(hardwareStoppedEvent))
-		case startedEvent:
-			sm.handleStartedEvent(event.(startedEvent))
-		case startFailedEvent:
-			sm.handleStartFailedEvent(event.(startFailedEvent))
-		case criticalFailureEvent:
-			sm.handleCriticalFailureEvent(event.(criticalFailureEvent))
-		case hardwareStartFailedEvent:
-			sm.handleHardwareStartFailedEvent(event.(hardwareStartFailedEvent))
-		case badHealthEvent:
-			sm.handleBadHealthEvent(event.(badHealthEvent))
-		case goodHealthEvent:
-			sm.handleGoodHealthEvent(event.(goodHealthEvent))
-		case fixFailureEvent:
-			sm.handleFixFailureEvent(event.(fixFailureEvent))
-		case controllerFailureEvent:
-			sm.handleControllerFailureEvent(event.(controllerFailureEvent))
-		case invalidConfigurationEvent:
-			sm.handleInvalidConfigurationEvent(event.(invalidConfigurationEvent))
-		case healthCheckDueEvent:
-			sm.handleHealthCheckDueEvent(event.(healthCheckDueEvent))
-		case statusCheckDueEvent:
-			sm.handleStatusCheckDueEvent(event.(statusCheckDueEvent))
-		case chatMessageDueEvent:
-			sm.handleChatMessageDueEvent(event.(chatMessageDueEvent))
-		case lowVoltageEvent:
-			sm.handleLowVoltageEvent(event.(lowVoltageEvent))
-		case voltageRecoveredEvent:
-			sm.handleVoltageRecoveredEvent(event.(voltageRecoveredEvent))
-		}
+
+	s, ok := sm.currentState.(stateWithBroadcastEventHandler)
+	if !ok {
+		panic(fmt.Sprintf("(bsm) current state (%T) does not implement stateWithBroadcastEventHandler", sm.currentState))
 	}
+	s.handleGlobalEvents(sm, event)
+	s.handleEvent(sm, event)
 
 	// After handling of the event, we may have some changes in substates of the current state.
 	// So we need to update the config based on this state and possibly save some state data.
 	return sm.ctx.man.Save(nil, func(_cfg *Cfg) { updateBroadcastBasedOnState(sm.currentState, _cfg) })
-}
-
-func (sm *broadcastStateMachine) handleLowVoltageEvent(event lowVoltageEvent) error {
-	sm.log("handling low voltage event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		// If we're in the starting state we need to reset the timeout to allow for
-		// hardware voltage recovery (remembering that this is not our primary timeout
-		// mechanism, which is handled by the hardware SM but a rather a contingency that
-		// we shouldn't hit with normal behaviour).
-		const broadcastVoltageRecoveryOffset = 10 * time.Minute
-		sm.currentState.(stateWithTimeout).reset(time.Duration(sanatisedVoltageRecoveryTimeout(sm.ctx))*time.Hour + broadcastVoltageRecoveryOffset)
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleVoltageRecoveredEvent(event voltageRecoveredEvent) error {
-	sm.log("handling voltage recovered event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		sm.currentState.(stateWithTimeout).reset(5 * time.Minute)
-	case *vidforwardPermanentVoltageRecoverySlate:
-		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
 }
 
 func (sm *broadcastStateMachine) handleStatusCheckDueEvent(event statusCheckDueEvent) {
@@ -169,148 +101,6 @@ func (sm *broadcastStateMachine) handleHealthCheckDueEvent(event healthCheckDueE
 
 func (sm *broadcastStateMachine) handleChatMessageDueEvent(event chatMessageDueEvent) {
 	sm.ctx.man.HandleChatMessage(context.Background(), sm.ctx.cfg)
-}
-
-func (sm *broadcastStateMachine) handleInvalidConfigurationEvent(event invalidConfigurationEvent) {
-	switch sm.currentState.(type) {
-	case
-		*vidforwardSecondaryStarting,
-		*vidforwardSecondaryLive,
-		*vidforwardSecondaryLiveUnhealthy:
-
-		// TODO: rather than disabling transition to a failure state.
-		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", event.Error())
-		try(
-			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
-			"could not disable broadcast after invalid configuration",
-			sm.logAndNotifySoftware,
-		)
-
-		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-}
-
-func (sm *broadcastStateMachine) handleStartFailedEvent(event startFailedEvent) error {
-	sm.log("handling start failed event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleCriticalFailureEvent(event criticalFailureEvent) error {
-	sm.log("handling critical failure event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		// There might need to be a secondary failure state, but we're not sure
-		// yet. For now, we'll just transition to idle. Most failures will occur
-		// as a result of a hardware failure, for which the primary broadcast
-		// will subsequently be in a failure state.
-		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleHardwareStartFailedEvent(event hardwareStartFailedEvent) error {
-	sm.log("handling hardware start failed event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		onFailureClosure(sm.ctx, sm.ctx.cfg, false)(event)
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleBadHealthEvent(event badHealthEvent) error {
-	sm.log("handling bad health event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryLive:
-		sm.transition(newVidforwardSecondaryLiveUnhealthy())
-	case *vidforwardSecondaryLiveUnhealthy:
-		// Do nothing.
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleGoodHealthEvent(event goodHealthEvent) error {
-	sm.log("handling good health event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryLiveUnhealthy:
-		sm.transition(newVidforwardSecondaryLive(sm.ctx))
-	default:
-		// Do nothing.
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleControllerFailureEvent(event controllerFailureEvent) error {
-	sm.log("handling controller failure event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		onFailureClosure(sm.ctx, sm.ctx.cfg, true)(event)
-		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	default:
-		// Do nothing.
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleTimeEvent(event timeEvent) {
-	sm.log("handling time event: %v", event.Time)
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryLive:
-		if sm.finishIsDue(event) {
-			sm.ctx.bus.publish(finishEvent{})
-			return
-		}
-		sm.publishHealthStatusOrChatEvents(event)
-	case *vidforwardSecondaryLiveUnhealthy:
-		if sm.finishIsDue(event) {
-			sm.ctx.bus.publish(finishEvent{})
-			return
-		}
-		sm.publishHealthStatusOrChatEvents(event)
-		sm.tryToFixCurrentState()
-
-	case *vidforwardSecondaryIdle:
-		if sm.startIsDue(event) {
-			sm.ctx.bus.publish(startEvent{})
-			return
-		} else {
-			sm.log("start is not due, Start: %v, End: %v, time of event: %v", sm.ctx.cfg.Start.Format("15:04"), sm.ctx.cfg.End.Format("15:04"), event.Time.Format("15:04"))
-		}
-	case *vidforwardSecondaryStarting:
-		sm.transitionIfTimedOut(sm.currentState, newVidforwardSecondaryIdle(sm.ctx), event)
-	case *vidforwardPermanentVoltageRecoverySlate:
-		withTimeout := sm.currentState.(stateWithTimeout)
-		if withTimeout.timedOut(event.Time) {
-			sm.transition(newVidforwardPermanentFailure(sm.ctx))
-		}
-	case *directFailure:
-		// Do nothing.
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-}
-
-func (sm *broadcastStateMachine) handleFixFailureEvent(event fixFailureEvent) error {
-	sm.log("handling fix failure event")
-	switch sm.currentState.(type) {
-	default:
-		sm.log("unhandled event %s in current state %s", event.String(), stateToString(sm.currentState))
-	}
-	return nil
 }
 
 func (sm *broadcastStateMachine) transitionIfTimedOut(s state, to state, t timeEvent) {
@@ -367,57 +157,6 @@ func (sm *broadcastStateMachine) publishHealthEvent(event timeEvent) {
 		stateWithHealth.setLastHealthCheck(now)
 		sm.ctx.bus.publish(healthCheckDueEvent{})
 	}
-}
-
-func (sm *broadcastStateMachine) handleFinishEvent(event finishEvent) error {
-	sm.log("handling finish event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryLive, *vidforwardSecondaryLiveUnhealthy:
-		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleStartEvent(event startEvent) error {
-	sm.log("handling start event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryIdle:
-		sm.transition(newVidforwardSecondaryStarting(sm.ctx))
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleHardwareStartedEvent(event hardwareStartedEvent) error {
-	sm.log("handling hardware started event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		startBroadcast(sm.ctx, sm.ctx.cfg)
-	default: // Do nothing.
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleHardwareStoppedEvent(event hardwareStoppedEvent) error {
-	sm.log("handling hardware stopped event")
-	switch sm.currentState.(type) {
-	default: // Do nothing.
-	}
-	return nil
-}
-
-func (sm *broadcastStateMachine) handleStartedEvent(event startedEvent) error {
-	sm.log("handling started event")
-	switch sm.currentState.(type) {
-	case *vidforwardSecondaryStarting:
-		sm.transition(newVidforwardSecondaryLive(sm.ctx))
-	default:
-		sm.unexpectedEvent(event, sm.currentState)
-	}
-	return nil
 }
 
 func (sm *broadcastStateMachine) transition(newState state) {

--- a/cmd/oceantv/broadcast_machine.go
+++ b/cmd/oceantv/broadcast_machine.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -65,42 +64,6 @@ func (sm *broadcastStateMachine) handleEvent(event event) error {
 	// After handling of the event, we may have some changes in substates of the current state.
 	// So we need to update the config based on this state and possibly save some state data.
 	return sm.ctx.man.Save(nil, func(_cfg *Cfg) { updateBroadcastBasedOnState(sm.currentState, _cfg) })
-}
-
-func (sm *broadcastStateMachine) handleStatusCheckDueEvent(event statusCheckDueEvent) {
-	err := sm.ctx.man.HandleStatus(
-		context.Background(),
-		sm.ctx.cfg,
-		sm.ctx.store,
-		sm.ctx.svc,
-		func(Ctx, *Cfg, Store, Svc) error {
-			sm.ctx.bus.publish(finishEvent{})
-			return nil
-		},
-	)
-	if err != nil {
-		sm.logAndNotifySoftware("could not handle health check: %v", err)
-	}
-}
-
-func (sm *broadcastStateMachine) handleHealthCheckDueEvent(event healthCheckDueEvent) {
-	err := sm.ctx.man.HandleHealth(
-		context.Background(),
-		sm.ctx.cfg,
-		sm.ctx.store,
-		func() { sm.ctx.bus.publish(goodHealthEvent{}) },
-		func(issue string) {
-			sm.ctx.bus.publish(badHealthEvent{})
-			sm.ctx.logAndNotify(broadcastNetwork, "poor stream health, status: %s", issue)
-		},
-	)
-	if err != nil {
-		sm.logAndNotifySoftware("could not handle health check: %v", err)
-	}
-}
-
-func (sm *broadcastStateMachine) handleChatMessageDueEvent(event chatMessageDueEvent) {
-	sm.ctx.man.HandleChatMessage(context.Background(), sm.ctx.cfg)
 }
 
 func (sm *broadcastStateMachine) transitionIfTimedOut(s state, to state, t timeEvent) {

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -111,7 +111,43 @@ func (s *stateFields) enter() {}
 func (s *stateFields) exit()  {}
 
 type stateWithBroadcastEventHandler interface {
+	handleGlobalEvents(sm *broadcastStateMachine, event event)
 	handleEvent(sm *broadcastStateMachine, event event)
+}
+
+func (b *stateFields) handleGlobalEvents(sm *broadcastStateMachine, event event) {
+	switch event.(type) {
+	case statusCheckDueEvent:
+		err := sm.ctx.man.HandleStatus(
+			context.Background(),
+			sm.ctx.cfg,
+			sm.ctx.store,
+			sm.ctx.svc,
+			func(Ctx, *Cfg, Store, Svc) error {
+				sm.ctx.bus.publish(finishEvent{})
+				return nil
+			},
+		)
+		if err != nil {
+			sm.logAndNotifySoftware("could not handle health check: %v", err)
+		}
+	case healthCheckDueEvent:
+		err := sm.ctx.man.HandleHealth(
+			context.Background(),
+			sm.ctx.cfg,
+			sm.ctx.store,
+			func() { sm.ctx.bus.publish(goodHealthEvent{}) },
+			func(issue string) {
+				sm.ctx.bus.publish(badHealthEvent{})
+				sm.ctx.logAndNotify(broadcastNetwork, "poor stream health, status: %s", issue)
+			},
+		)
+		if err != nil {
+			sm.logAndNotifySoftware("could not handle health check: %v", err)
+		}
+	case chatMessageDueEvent:
+		sm.ctx.man.HandleChatMessage(context.Background(), sm.ctx.cfg)
+	}
 }
 
 type fixableState interface {

--- a/cmd/oceantv/state_vf_permanent_failure.go
+++ b/cmd/oceantv/state_vf_permanent_failure.go
@@ -31,8 +31,27 @@ type vidforwardPermanentFailure struct {
 func newVidforwardPermanentFailure(ctx *broadcastContext) *vidforwardPermanentFailure {
 	return &vidforwardPermanentFailure{stateFields{}, ctx}
 }
+
 func (s *vidforwardPermanentFailure) enter() { s.requestSlate() }
-func (s *vidforwardPermanentFailure) fix()   { s.requestSlate() }
+
+func (s *vidforwardPermanentFailure) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case badHealthEvent:
+		sm.logAndNotify(broadcastNetwork, "getting bad health event in permanent failure state")
+	}
+}
+
+func (s *vidforwardPermanentFailure) fix() { s.requestSlate() }
+
 func (s *vidforwardPermanentFailure) requestSlate() {
 	s.bus.publish(hardwareStopRequestEvent{})
 	try(s.fwd.Slate(s.cfg), "could not set vidforward mode to slate", s.log)

--- a/cmd/oceantv/state_vf_permanent_idle.go
+++ b/cmd/oceantv/state_vf_permanent_idle.go
@@ -31,6 +31,21 @@ type vidforwardPermanentIdle struct {
 func newVidforwardPermanentIdle(ctx *broadcastContext) *vidforwardPermanentIdle {
 	return &vidforwardPermanentIdle{stateFields{}, ctx}
 }
+
 func (s *vidforwardPermanentIdle) enter() {
 	s.bus.publish(hardwareStopRequestEvent{})
+}
+
+func (s *vidforwardPermanentIdle) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case timeEvent:
+		if sm.startIsDue(e) {
+			sm.ctx.bus.publish(startEvent{})
+			return
+		} else {
+			sm.log("start is not due, Start: %v, End: %v, time of event: %v", sm.ctx.cfg.Start.Format("15:04"), sm.ctx.cfg.End.Format("15:04"), e.Time.Format("15:04"))
+		}
+	case startEvent:
+		sm.transition(newVidforwardPermanentStarting(sm.ctx))
+	}
 }

--- a/cmd/oceantv/state_vf_permanent_live.go
+++ b/cmd/oceantv/state_vf_permanent_live.go
@@ -29,3 +29,30 @@ type vidforwardPermanentLive struct {
 }
 
 func newVidforwardPermanentLive() *vidforwardPermanentLive { return &vidforwardPermanentLive{} }
+
+func (s *vidforwardPermanentLive) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case hardwareStartFailedEvent:
+		sm.logAndNotify(broadcastHardware, "hardware failure event in permanent live state, moving to failure slate state")
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
+	case badHealthEvent:
+		sm.transition(newVidforwardPermanentLiveUnhealthy(sm.ctx))
+	case timeEvent:
+		if sm.finishIsDue(e) {
+			sm.ctx.bus.publish(finishEvent{})
+			return
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+	case finishEvent:
+		sm.transition(newVidforwardPermanentTransitionLiveToSlate(sm.ctx))
+	}
+}

--- a/cmd/oceantv/state_vf_permanent_live_unhealthy.go
+++ b/cmd/oceantv/state_vf_permanent_live_unhealthy.go
@@ -36,6 +36,7 @@ type vidforwardPermanentLiveUnhealthy struct {
 func newVidforwardPermanentLiveUnhealthy(ctx *broadcastContext) *vidforwardPermanentLiveUnhealthy {
 	return &vidforwardPermanentLiveUnhealthy{broadcastContext: ctx}
 }
+
 func (s *vidforwardPermanentLiveUnhealthy) fix() {
 	const resetInterval = 5 * time.Minute
 	if time.Since(s.LastResetAttempt) <= resetInterval {
@@ -62,4 +63,34 @@ func (s *vidforwardPermanentLiveUnhealthy) fix() {
 	s.logAndNotify(broadcastGeneric, msg, s.Attempts, maxAttempts)
 	s.bus.publish(e)
 	s.LastResetAttempt = time.Now()
+}
+
+func (s *vidforwardPermanentLiveUnhealthy) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case hardwareStartFailedEvent:
+		sm.logAndNotify(broadcastHardware, "hardware failure event in permanent live state, moving to failure slate state")
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
+	case goodHealthEvent:
+		sm.transition(newVidforwardPermanentLive())
+	case timeEvent:
+		if sm.finishIsDue(e) {
+			sm.ctx.bus.publish(finishEvent{})
+			return
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+		sm.tryToFixCurrentState()
+	case fixFailureEvent:
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
+	case finishEvent:
+		sm.transition(newVidforwardPermanentTransitionLiveToSlate(sm.ctx))
+	}
 }

--- a/cmd/oceantv/state_vf_permanent_slate.go
+++ b/cmd/oceantv/state_vf_permanent_slate.go
@@ -26,3 +26,28 @@ package main
 type vidforwardPermanentSlate struct{ stateFields }
 
 func newVidforwardPermanentSlate() *vidforwardPermanentSlate { return &vidforwardPermanentSlate{} }
+
+func (s *vidforwardPermanentSlate) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case badHealthEvent:
+		sm.transition(newVidforwardPermanentSlateUnhealthy(sm.ctx))
+	case timeEvent:
+		if sm.startIsDue(e) {
+			sm.ctx.bus.publish(startEvent{})
+			return
+		} else {
+			sm.log("start is not due, Start: %v, End: %v, time of event: %v", sm.ctx.cfg.Start.Format("15:04"), sm.ctx.cfg.End.Format("15:04"), e.Time.Format("15:04"))
+		}
+	case startEvent:
+		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
+	}
+}

--- a/cmd/oceantv/state_vf_permanent_slate_unhealthy.go
+++ b/cmd/oceantv/state_vf_permanent_slate_unhealthy.go
@@ -34,11 +34,34 @@ type vidforwardPermanentSlateUnhealthy struct {
 func newVidforwardPermanentSlateUnhealthy(ctx *broadcastContext) *vidforwardPermanentSlateUnhealthy {
 	return &vidforwardPermanentSlateUnhealthy{stateFields{}, ctx, time.Now()}
 }
+
 func (s *vidforwardPermanentSlateUnhealthy) fix() {
 	const resetInterval = 5 * time.Minute
 	if time.Since(s.LastResetAttempt) > resetInterval {
 		s.logAndNotify(broadcastForwarder, "slate is unhealthy, requesting vidforward reconfiguration")
 		try(s.fwd.Slate(s.cfg), "could not set vidforward mode to slate", s.log)
 		s.LastResetAttempt = time.Now()
+	}
+}
+
+func (s *vidforwardPermanentSlateUnhealthy) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case goodHealthEvent:
+		sm.transition(newVidforwardPermanentSlate())
+	case timeEvent:
+		if sm.startIsDue(e) {
+			sm.ctx.bus.publish(startEvent{})
+			return
+		}
+		sm.tryToFixCurrentState()
 	}
 }

--- a/cmd/oceantv/state_vf_permanent_starting.go
+++ b/cmd/oceantv/state_vf_permanent_starting.go
@@ -25,6 +25,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -66,4 +67,45 @@ func (s *vidforwardPermanentStarting) enter() {
 		&cfg,
 		onBroadcastCreation,
 	)
+}
+
+func (s *vidforwardPermanentStarting) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case lowVoltageEvent:
+		// If we're in the starting state we need to reset the timeout to allow for
+		// hardware voltage recovery (remembering that this is not our primary timeout
+		// mechanism, which is handled by the hardware SM but a rather a contingency that
+		// we shouldn't hit with normal behaviour).
+		const broadcastVoltageRecoveryOffset = 10 * time.Minute
+		sm.currentState.(stateWithTimeout).reset(time.Duration(sanatisedVoltageRecoveryTimeout(sm.ctx))*time.Hour + broadcastVoltageRecoveryOffset)
+	case voltageRecoveredEvent:
+		sm.currentState.(stateWithTimeout).reset(5 * time.Minute)
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case startFailedEvent:
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case criticalFailureEvent:
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
+	case hardwareStartFailedEvent:
+		onFailureClosure(sm.ctx, sm.ctx.cfg, false)(e)
+	case controllerFailureEvent:
+		onFailureClosure(sm.ctx, sm.ctx.cfg, true)(e)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case timeEvent:
+		withTimeout := sm.currentState.(stateWithTimeout)
+		if withTimeout.timedOut(e.Time) {
+			onFailureClosure(sm.ctx, sm.ctx.cfg, false)(errors.New("permanent starting timed out"))
+		}
+	case hardwareStartedEvent:
+		startBroadcast(sm.ctx, sm.ctx.cfg)
+	case startedEvent:
+		sm.transition(newVidforwardPermanentLive())
+	}
 }

--- a/cmd/oceantv/state_vf_permanent_transition_live_to_slate.go
+++ b/cmd/oceantv/state_vf_permanent_transition_live_to_slate.go
@@ -42,6 +42,32 @@ func (s *vidforwardPermanentTransitionLiveToSlate) enter() {
 	s.bus.publish(hardwareStopRequestEvent{})
 	try(s.fwd.Slate(s.cfg), "could not set vidforward mode to slate", s.log)
 }
+
+func (s *vidforwardPermanentTransitionLiveToSlate) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case goodHealthEvent:
+		if sm.currentState.(*vidforwardPermanentTransitionLiveToSlate).isHardwareStopped() {
+			sm.transition(newVidforwardPermanentSlate())
+		}
+	case timeEvent:
+		withTimeout := sm.currentState.(stateWithTimeout)
+		if withTimeout.timedOut(e.Time) {
+			sm.logAndNotify(broadcastForwarder, "transition from live to slate timed out, staying in live state, check forwarding service")
+			sm.transition(newVidforwardPermanentLive())
+		}
+		sm.publishHealthEvent(e)
+	}
+}
+
 func (s *vidforwardPermanentTransitionLiveToSlate) isHardwareStopped() bool {
 	return s.cfg.HardwareState == hardwareStateToString(&hardwareOff{})
 }

--- a/cmd/oceantv/state_vf_permanent_transition_slate_to_live.go
+++ b/cmd/oceantv/state_vf_permanent_transition_slate_to_live.go
@@ -35,11 +35,42 @@ type vidforwardPermanentTransitionSlateToLive struct {
 func newVidforwardPermanentTransitionSlateToLive(ctx *broadcastContext) *vidforwardPermanentTransitionSlateToLive {
 	return &vidforwardPermanentTransitionSlateToLive{stateWithTimeoutFields: newStateWithTimeoutFields(ctx)}
 }
+
 func (s *vidforwardPermanentTransitionSlateToLive) enter() {
 	s.LastEntered = time.Now()
 	s.bus.publish(hardwareStartRequestEvent{})
 	try(s.fwd.Stream(s.cfg), "could not set vidforward mode to stream", s.log)
 }
+
+func (s *vidforwardPermanentTransitionSlateToLive) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case lowVoltageEvent:
+		sm.transition(newVidforwardPermanentVoltageRecoverySlate(sm.ctx))
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardPermanentIdle(sm.ctx))
+	case hardwareStartFailedEvent:
+		sm.logAndNotify(broadcastHardware, "hardware failure event in transition from slate to live, moving to failure slate state")
+		sm.transition(newVidforwardPermanentFailure(sm.ctx))
+	case goodHealthEvent:
+		if s.isHardwareStarted() {
+			sm.transition(newVidforwardPermanentLive())
+		}
+	case timeEvent:
+		if s.timedOut(e.Time) {
+			sm.ctx.logAndNotify(broadcastGeneric, "transition from slate to live timed out, transitioning to failure slate state")
+			sm.transition(newVidforwardPermanentFailure(sm.ctx))
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+	}
+}
+
 func (s *vidforwardPermanentTransitionSlateToLive) isHardwareStarted() bool {
 	return s.cfg.HardwareState == hardwareStateToString(&hardwareOn{})
 }

--- a/cmd/oceantv/state_vf_permanent_voltage_recovery_slate.go
+++ b/cmd/oceantv/state_vf_permanent_voltage_recovery_slate.go
@@ -42,7 +42,21 @@ func (s *vidforwardPermanentVoltageRecoverySlate) enter() {
 	s.LastEntered = time.Now()
 	s.requestSlate()
 }
+
+func (s *vidforwardPermanentVoltageRecoverySlate) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case voltageRecoveredEvent:
+		sm.transition(newVidforwardPermanentTransitionSlateToLive(sm.ctx))
+	case timeEvent:
+		withTimeout := sm.currentState.(stateWithTimeout)
+		if withTimeout.timedOut(e.Time) {
+			sm.transition(newVidforwardPermanentFailure(sm.ctx))
+		}
+	}
+}
+
 func (s *vidforwardPermanentVoltageRecoverySlate) fix() { s.requestSlate() }
+
 func (s *vidforwardPermanentVoltageRecoverySlate) requestSlate() {
 	try(s.fwd.Slate(s.cfg, WithType(LowVoltage)), "could not set vidforward mode to low voltage slate", s.log)
 }

--- a/cmd/oceantv/state_vf_secondary_idle.go
+++ b/cmd/oceantv/state_vf_secondary_idle.go
@@ -31,6 +31,21 @@ type vidforwardSecondaryIdle struct {
 func newVidforwardSecondaryIdle(ctx *broadcastContext) *vidforwardSecondaryIdle {
 	return &vidforwardSecondaryIdle{broadcastContext: ctx}
 }
+
 func (s *vidforwardSecondaryIdle) enter() {
 	s.bus.publish(hardwareStopRequestEvent{})
+}
+
+func (s *vidforwardSecondaryIdle) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case timeEvent:
+		if sm.startIsDue(e) {
+			sm.ctx.bus.publish(startEvent{})
+			return
+		} else {
+			sm.log("start is not due, Start: %v, End: %v, time of event: %v", sm.ctx.cfg.Start.Format("15:04"), sm.ctx.cfg.End.Format("15:04"), e.Time.Format("15:04"))
+		}
+	case startEvent:
+		sm.transition(newVidforwardSecondaryStarting(sm.ctx))
+	}
 }

--- a/cmd/oceantv/state_vf_secondary_live.go
+++ b/cmd/oceantv/state_vf_secondary_live.go
@@ -34,6 +34,7 @@ type vidforwardSecondaryLive struct {
 func newVidforwardSecondaryLive(ctx *broadcastContext) *vidforwardSecondaryLive {
 	return &vidforwardSecondaryLive{broadcastContext: ctx}
 }
+
 func (s *vidforwardSecondaryLive) exit() {
 	err := s.man.StopBroadcast(context.Background(), s.cfg, s.store, s.svc)
 	if err != nil {
@@ -41,4 +42,28 @@ func (s *vidforwardSecondaryLive) exit() {
 		return
 	}
 	s.bus.publish(finishedEvent{})
+}
+
+func (s *vidforwardSecondaryLive) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	case badHealthEvent:
+		sm.transition(newVidforwardSecondaryLiveUnhealthy())
+	case timeEvent:
+		if sm.finishIsDue(e) {
+			sm.ctx.bus.publish(finishEvent{})
+			return
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+	case finishEvent:
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	}
 }

--- a/cmd/oceantv/state_vf_secondary_live_unhealthy.go
+++ b/cmd/oceantv/state_vf_secondary_live_unhealthy.go
@@ -31,3 +31,29 @@ type vidforwardSecondaryLiveUnhealthy struct {
 func newVidforwardSecondaryLiveUnhealthy() *vidforwardSecondaryLiveUnhealthy {
 	return &vidforwardSecondaryLiveUnhealthy{}
 }
+
+func (s *vidforwardSecondaryLiveUnhealthy) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	case goodHealthEvent:
+		sm.transition(newVidforwardSecondaryLive(sm.ctx))
+	case timeEvent:
+		if sm.finishIsDue(e) {
+			sm.ctx.bus.publish(finishEvent{})
+			return
+		}
+		sm.publishHealthStatusOrChatEvents(e)
+		sm.tryToFixCurrentState()
+	case finishEvent:
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	}
+
+}

--- a/cmd/oceantv/state_vf_secondary_starting.go
+++ b/cmd/oceantv/state_vf_secondary_starting.go
@@ -55,3 +55,45 @@ func (s *vidforwardSecondaryStarting) enter() {
 		onBroadcastCreation,
 	)
 }
+
+func (s *vidforwardSecondaryStarting) handleEvent(sm *broadcastStateMachine, event event) {
+	switch e := event.(type) {
+	case lowVoltageEvent:
+		// If we're in the starting state we need to reset the timeout to allow for
+		// hardware voltage recovery (remembering that this is not our primary timeout
+		// mechanism, which is handled by the hardware SM but a rather a contingency that
+		// we shouldn't hit with normal behaviour).
+		const broadcastVoltageRecoveryOffset = 10 * time.Minute
+		sm.currentState.(stateWithTimeout).reset(time.Duration(sanatisedVoltageRecoveryTimeout(sm.ctx))*time.Hour + broadcastVoltageRecoveryOffset)
+	case voltageRecoveredEvent:
+		sm.currentState.(stateWithTimeout).reset(5 * time.Minute)
+	case invalidConfigurationEvent:
+		// TODO: rather than disabling transition to a failure state.
+		sm.logAndNotifyConfiguration("got invalid configuration event, disabling broadcast: %v", e.Error())
+		try(
+			sm.ctx.man.Save(nil, func(_cfg *Cfg) { _cfg.Enabled = false }),
+			"could not disable broadcast after invalid configuration",
+			sm.logAndNotifySoftware,
+		)
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	case startFailedEvent:
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	case criticalFailureEvent:
+		// There might need to be a secondary failure state, but we're not sure
+		// yet. For now, we'll just transition to idle. Most failures will occur
+		// as a result of a hardware failure, for which the primary broadcast
+		// will subsequently be in a failure state.
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	case hardwareStartFailedEvent:
+		onFailureClosure(sm.ctx, sm.ctx.cfg, false)(e)
+	case controllerFailureEvent:
+		onFailureClosure(sm.ctx, sm.ctx.cfg, true)(e)
+		sm.transition(newVidforwardSecondaryIdle(sm.ctx))
+	case timeEvent:
+		sm.transitionIfTimedOut(sm.currentState, newVidforwardSecondaryIdle(sm.ctx), e)
+	case hardwareStartedEvent:
+		startBroadcast(sm.ctx, sm.ctx.cfg)
+	case startedEvent:
+		sm.transition(newVidforwardSecondaryLive(sm.ctx))
+	}
+}


### PR DESCRIPTION
This change implements the `stateWithBroadcastEventHandler` interface for all remaining broadcast states. This allows us to remove the default handle event switch statement as all behaviour has been factored out. 

To handle global events that had no state based switch, an additional method has been added to `stateFields` to avoid additional boilerplate.