### PR TITLE
Bench: Add site param to search submits

### DIFF
--- a/cmd/oceanbench/t/search.html
+++ b/cmd/oceanbench/t/search.html
@@ -260,8 +260,15 @@
           results.classList.add("flex-column")
         }
       }
+      function submitFormWithSiteParam(el) {
+        let form = el.closest('form');
+        if (form) {
+          form.action = window.location.href;
+          form.submit();
+        }
+      }
     </script>
-      <script type="module" src="/s/lit/site-footer.js"></script>
+    <script type="module" src="/s/lit/site-footer.js"></script>
   </head>
   <body onload="init()">
     <header-group id="header" class="header" version="{{ .Version }}" {{ if .Profile }}auth="true" {{ end }}>
@@ -291,7 +298,7 @@
           <legend>Input source</legend>
           <div class="d-flex align-items-center gap-2">
               <label style="width: 60px;">Device:</label>
-              <select class="form-select form-select-sm w-100" name="ma" onchange="this.form.submit();">
+              <select class="form-select form-select-sm w-100" name="ma" onchange="submitFormWithSiteParam(this);">
                 <option value="" selected>- Select device -</option>
                 {{ range .Devices }}
                 <option value="{{ .MAC }}" {{ if eq .MAC $.Ma }}selected{{ end }}>{{ .Name }}</option>
@@ -301,7 +308,7 @@
             {{ if .Device }}
             <div class="d-flex align-items-center gap-2">
               <label style="width: 60px;">Pin:</label>
-              <select class="form-select form-select-sm" name="pn" onchange="this.form.submit();">
+              <select class="form-select form-select-sm" name="pn" onchange="submitFormWithSiteParam(this);">
                 <option value="" selected>- Select pin -</option>
                 {{ range .Device.InputList }}
                 <option value="{{ . }}" {{ if eq . $.Pn }}selected{{ end }}>{{ . }} ({{ index $.PinNames . }})</option>
@@ -359,7 +366,7 @@
           {{- else if eq $pn "T0" -}}
           <div class="d-flex align-items-center">
             <label>Log level:</label>
-            <select class="form-select form-select-sm w-25" name="lv" onchange="this.form.submit()">
+            <select class="form-select form-select-sm w-25" name="lv" onchange="submitFormWithSiteParam(this)">
               {{$all := "all"}} {{$info := "info"}} {{$warning := "warning"}} {{$error := "error"}} {{$fatal := "fatal"}}
               <option value="all" {{if eq .Lv $all}}selected{{- end}}>All logs</option>
               <option value="info" {{if eq .Lv $info}}selected{{- end}}>Info level or above</option>
@@ -374,7 +381,7 @@
           <div class="d-flex flex-column">
             <div class="d-flex align-items-center mb-2">
               <label>Resolution:</label>
-              <input name="resolution" type="input" onchange="this.form.submit();" value="{{ if .Resolution }}{{ .Resolution }}{{ else }}60{{ end }}" />
+              <input name="resolution" type="input" onchange="submitFormWithSiteParam(this);" value="{{ if .Resolution }}{{ .Resolution }}{{ else }}60{{ end }}" />
               pts/hour
               <br />
             </div>


### PR DESCRIPTION
This change replaces direct form submissions to /search with a function which directs the form submission to the current URL. This will typically add the site key to allow the backend to correctly access the site when required.

fixes #763 