### PR TITLE
Bench: Add current location to broadcast form

### DIFF
--- a/cmd/oceanbench/s/broadcast.js
+++ b/cmd/oceanbench/s/broadcast.js
@@ -156,6 +156,7 @@ function uncheckAll(form) {
 }
 
 function buttonClick(button) {
+  button.form.action = window.location.href
   button.form.querySelector("input[name='action']").value = button.value;
   button.form.submit();
 }


### PR DESCRIPTION
This change uses the current location as the form action which ensures that the skey param is passed to the backend on the request.

requires #762 