### PR TITLE
datastore: apply field filters in GetAll

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -322,6 +322,8 @@ func TestFileFilterField(t *testing.T) {
 		{Name: "A", Value: "abalone"},
 		{Name: "B", Value: "bullseye"},
 		{Name: "C", Value: "abalone"},
+		{Name: "D", Value: "abalone"},
+		{Name: "E", Value: "abalone"},
 	}
 	for _, nv := range values {
 		_, err := store.Put(ctx, store.NameKey(typeNameValue, nv.Name), &nv)
@@ -335,12 +337,58 @@ func TestFileFilterField(t *testing.T) {
 	q.FilterField("Value", "=", "abalone")
 
 	var results []NameValue
-	_, err = store.GetAll(ctx, q, &results)
+	keys, err := store.GetAll(ctx, q, &results)
 	if err != nil {
 		t.Fatalf("FilterField query failed: %v", err)
 	}
+	if len(results) != 4 {
+		t.Errorf("expected 4 results for Value = 'abalone', got %d", len(results))
+	}
+	if len(keys) != 4 {
+		t.Errorf("expected 4 returned keys, got %d", len(keys))
+	}
+	for _, k := range keys {
+		if k.Name == "B" {
+			t.Errorf("expected key B to be filtered out, but it was returned")
+		}
+	}
+
+	// Filter by Value using keysOnly = true.
+	q = store.NewQuery(typeNameValue, true, "Name")
+	q.FilterField("Value", "=", "abalone")
+	keys, err = store.GetAll(ctx, q, nil)
+	if err != nil {
+		t.Fatalf("FilterField keysOnly query failed: %v", err)
+	}
+	if len(keys) != 4 {
+		t.Errorf("expected 4 returned keys for keysOnly query, got %d", len(keys))
+	}
+	for _, k := range keys {
+		if k.Name == "B" {
+			t.Errorf("expected key B to be filtered out in keysOnly, but it was returned")
+		}
+	}
+
+	// Offset and limit combo with non-matching elements interleaved.
+	q = store.NewQuery(typeNameValue, false, "Name")
+	q.FilterField("Value", "=", "abalone")
+	q.Order("Name")
+	q.Offset(1)
+	q.Limit(2)
+
+	results = nil
+	keys, err = store.GetAll(ctx, q, &results)
+	if err != nil {
+		t.Fatalf("FilterField query with limit/offset failed: %v", err)
+	}
 	if len(results) != 2 {
 		t.Errorf("expected 2 results for Value = 'abalone', got %d", len(results))
+	}
+	if results[0].Name != "C" || results[1].Name != "D" {
+		t.Errorf("expected names C and D, got %s and %s", results[0].Name, results[1].Name)
+	}
+	if len(keys) != 2 {
+		t.Errorf("expected 2 returned keys, got %d", len(keys))
 	}
 
 	// Filter by Name using FilterField (should fall back to Filter for efficiency).

--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -245,6 +245,31 @@ func (s *FileStore) GetAll(ctx context.Context, query Query, dst interface{}) ([
 		keys = filtered
 	}
 
+	// Apply field filters if any.
+	var matchedEntities map[string]Entity
+	if len(q.fieldFilters) > 0 {
+		entity := newEntity[q.kind]
+		if entity == nil {
+			return nil, ErrUnimplemented
+		}
+		matchedEntities = make(map[string]Entity)
+		var filtered []*Key
+		for _, k := range keys {
+			e := entity()
+			err := s.Get(ctx, k, e)
+			if err != nil {
+				return nil, err
+			}
+			if matchesFieldFilters(e, q.fieldFilters) {
+				filtered = append(filtered, k)
+				if !q.keysOnly {
+					matchedEntities[k.Name] = e
+				}
+			}
+		}
+		keys = filtered
+	}
+
 	// Sort the keys if ordering.
 	if q.order {
 		sort.Slice(keys, func(i, j int) bool {
@@ -257,7 +282,9 @@ func (s *FileStore) GetAll(ctx context.Context, query Query, dst interface{}) ([
 	}
 
 	// Apply query's limit and offset to the keys.
-	if q.offset+q.limit > len(keys) {
+	if q.offset > len(keys) {
+		keys = nil
+	} else if q.offset+q.limit > len(keys) {
 		keys = keys[q.offset:]
 	} else {
 		keys = keys[q.offset:(q.offset + q.limit)]
@@ -276,18 +303,17 @@ func (s *FileStore) GetAll(ctx context.Context, query Query, dst interface{}) ([
 	// Get each entity and append it to dst.
 	dv := reflect.ValueOf(dst).Elem()
 	for _, k := range keys {
-		e := entity()
-		err := s.Get(ctx, k, e)
-		if err != nil {
-			return nil, err
+		var e Entity
+		if matchedEntities != nil {
+			e = matchedEntities[k.Name]
 		}
-		// The underlying entity type is a pointer, so we need its indirect type.
-
-		// Apply field filters if needed.
-		if len(q.fieldFilters) > 0 && !matchesFieldFilters(e, q.fieldFilters) {
-			continue
+		if e == nil {
+			e = entity()
+			err := s.Get(ctx, k, e)
+			if err != nil {
+				return nil, err
+			}
 		}
-
 		ev := reflect.Indirect(reflect.ValueOf(e))
 		// As with the Cloud datastore, if the Key field is present we populate it.
 		fld := ev.FieldByName("Key")


### PR DESCRIPTION
This allows queries that filter by values and/or keys instead of just keys.
