### PR TITLE
OTV: Add go routine start time log

### DIFF
--- a/cmd/oceantv/broadcast_manager.go
+++ b/cmd/oceantv/broadcast_manager.go
@@ -174,15 +174,18 @@ func (m *OceanBroadcastManager) StartBroadcast(
 	}
 
 	go func() {
+		startTime := time.Now()
 		err := svc.StartBroadcast(
 			cfg.Name,
 			cfg.BID,
 			cfg.SID,
 			saveLinkFunc(),
-			func() error { return nil }, // This is now handled by the hardware state machine.
-			func() error { return nil }, // This is now handled by the hardware state machine.
 			opsHealthNotifyFunc(ctx, cfg),
-			func() error { return nil }) // This is now handled by the hardware state machine.
+			func(s string, args ...any) {
+				// Append go routine start time to logs.
+				fmtString := fmt.Sprintf("[go-rout:%s] %s", startTime.Format(time.TimeOnly), s)
+				m.log(fmtString, args)
+			})
 		if err != nil {
 			onFailure(fmt.Errorf("could not start broadcast: %w", err))
 			return

--- a/cmd/oceantv/broadcast_service.go
+++ b/cmd/oceantv/broadcast_service.go
@@ -60,9 +60,8 @@ type BroadcastService interface {
 	StartBroadcast(
 		name, bID, sID string,
 		saveLink func(key, link string) error,
-		extStart, extStop func() error,
 		notify func(msg string) error,
-		onLiveActions func() error,
+		log func(string, ...any),
 	) error
 
 	BroadcastStatus(ctx Ctx, id string) (string, error)
@@ -170,21 +169,20 @@ func (s *YouTubeBroadcastService) CreateBroadcast(
 func (s *YouTubeBroadcastService) StartBroadcast(
 	name, bID, sID string,
 	saveLink func(key, link string) error,
-	extStart, extStop func() error,
 	notify func(msg string) error,
-	onLiveActions func() error,
+	log func(string, ...interface{}),
 ) error {
 	return yt.Start(
 		name,
 		bID,
 		sID,
 		saveLink,
-		extStart,
-		extStop,
+		func() error { return nil }, // This is now handled by the hardware state machine.,
+		func() error { return nil }, // This is now handled by the hardware state machine.,
 		notify,
-		onLiveActions,
+		func() error { return nil }, // This is now handled by the hardware state machine.,
 		s.tokenURI,
-		s.log,
+		log,
 	)
 }
 

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -271,9 +271,8 @@ func (d *dummyService) CreateBroadcast(
 func (d *dummyService) StartBroadcast(
 	name, bID, sID string,
 	saveLink func(key, link string) error,
-	extStart, extStop func() error,
 	notify func(msg string) error,
-	onLiveActions func() error,
+	log func(string, ...any),
 ) error {
 	return nil
 }


### PR DESCRIPTION
This change adds a prefix to logs from the start broadcast go routine. This should help debugging efforts in case the go routine is overlapping with the next /checkbroadcasts run.

This also adds an additional log method to the service interface, and removes unused methods that are now handled by the hardware machine.