### PR TITLE
(Show) Bench/Search: Add site param to form submit

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -76,7 +76,7 @@ import (
 )
 
 const (
-	version     = "v0.36.4"
+	version     = "v0.36.5"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/t/search.html
+++ b/cmd/oceanbench/t/search.html
@@ -236,12 +236,14 @@
       function searchQuery(form) {
         presubmit();
         form.querySelector("input[name='search']").value = true;
+        form.action = window.location.href
         form.submit();
       }
       function exportQuery(form) {
         presubmit();
         form.querySelector("input[name='export']").value = true;
         document.getElementById("export-msg").innerHTML = "<p>Export may take several minutes...</p>";
+        form.action = window.location.href
         form.submit();
       }
       function viewJPEG(url){


### PR DESCRIPTION
This change uses the current URL as the action for the form when submitting a search for logs.

closes #763 