### PR TITLE
OTV: Handle start failure in direct liveUnhealthy

### DIFF
--- a/cmd/oceantv/main.go
+++ b/cmd/oceantv/main.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	projectID             = "oceantv"
-	version               = "v0.13.6"
+	version               = "v0.13.7"
 	projectURL            = "https://tv.cloudblue.org"
 	cronServiceAccount    = "oceancron@appspot.gserviceaccount.com"
 	oceanTVServiceAccount = "oceantv@appspot.gserviceaccount.com"

--- a/cmd/oceantv/state_direct_live_unhealthy.go
+++ b/cmd/oceantv/state_direct_live_unhealthy.go
@@ -57,9 +57,11 @@ func (s *directLiveUnhealthy) handleEvent(sm *broadcastStateMachine, event event
 		sm.transition(newDirectLive(sm.ctx))
 	case fixFailureEvent:
 		sm.transition(newDirectFailure(sm.ctx, e))
+	case hardwareStartFailedEvent:
+		// This causes the hardware to go into failure mode, so we should go into failure mode for the broadcast state too.
+		sm.transition(newDirectFailure(sm.ctx, e.error))
 	case
 		criticalFailureEvent,
-		hardwareStartFailedEvent,
 		lowVoltageEvent,
 		startEvent,
 		startFailedEvent,


### PR DESCRIPTION
This change no longer treats start failure events as unexpected events in the direct live unhealthy state, and now transitions to directfailure, as the hardware is also entering a failure state.

closes #770 