### PR TITLE
filestore: add boolean comparison

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -74,6 +74,7 @@ type Mixed struct {
 	Int     int64     // test integer comparisons
 	Float   float64   // test float comparisons
 	Created time.Time // test time comparisons if needed
+	Bool    bool      // test boolean comparisons
 	cache   Cache
 }
 
@@ -497,10 +498,10 @@ func TestFileFilterFieldMixedTypes(t *testing.T) {
 
 	now := time.Now().UTC()
 	entities := []Mixed{
-		{ID: "1", Str: "alpha", Int: 10, Float: 1.1, Created: now.Add(-10 * time.Hour)},
-		{ID: "2", Str: "bravo", Int: 20, Float: 2.2, Created: now.Add(-5 * time.Hour)},
-		{ID: "3", Str: "charlie", Int: 30, Float: 3.3, Created: now.Add(-1 * time.Hour)},
-		{ID: "4", Str: "delta", Int: 40, Float: 4.4, Created: now},
+		{ID: "1", Str: "alpha", Int: 10, Float: 1.1, Created: now.Add(-10 * time.Hour), Bool: true},
+		{ID: "2", Str: "bravo", Int: 20, Float: 2.2, Created: now.Add(-5 * time.Hour), Bool: false},
+		{ID: "3", Str: "charlie", Int: 30, Float: 3.3, Created: now.Add(-1 * time.Hour), Bool: true},
+		{ID: "4", Str: "delta", Int: 40, Float: 4.4, Created: now, Bool: false},
 	}
 
 	for _, e := range entities {
@@ -549,6 +550,86 @@ func TestFileFilterFieldMixedTypes(t *testing.T) {
 			value:     now,
 			keyParts:  []string{"ID"},
 			expectIDs: []string{"1", "2", "3"},
+		},
+		{
+			name:      "Bool = true",
+			field:     "Bool",
+			operator:  "=",
+			value:     true,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "3"},
+		},
+		{
+			name:      "Bool = false",
+			field:     "Bool",
+			operator:  "=",
+			value:     false,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"2", "4"},
+		},
+		{
+			name:      "Bool < false",
+			field:     "Bool",
+			operator:  "<",
+			value:     false,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{}, // This should never return any results.
+		},
+		{
+			name:      "Bool < true",
+			field:     "Bool",
+			operator:  "<",
+			value:     true,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"2", "4"}, // This should only return results where Bool = false.
+		},
+		{
+			name:      "Bool > false",
+			field:     "Bool",
+			operator:  ">",
+			value:     false,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "3"}, // This should only return results where Bool = true.
+		},
+		{
+			name:      "Bool > true",
+			field:     "Bool",
+			operator:  ">",
+			value:     true,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{}, // This should never return any results.
+		},
+		{
+			name:      "Bool <= false",
+			field:     "Bool",
+			operator:  "<=",
+			value:     false,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"2", "4"}, // This should only return results where Bool = false.
+		},
+		{
+			name:      "Bool <= true",
+			field:     "Bool",
+			operator:  "<=",
+			value:     true,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "2", "3", "4"}, // This should return everything.
+		},
+		{
+			name:      "Bool >= false",
+			field:     "Bool",
+			operator:  ">=",
+			value:     false,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "2", "3", "4"}, // This should return everything.
+		},
+		{
+			name:      "Bool >= true",
+			field:     "Bool",
+			operator:  ">=",
+			value:     true,
+			keyParts:  []string{"ID"},
+			expectIDs: []string{"1", "3"}, // This should only return results where Bool = true.
 		},
 	}
 

--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -372,6 +372,27 @@ func compare(a, b interface{}, op string) bool {
 		return false
 	}
 
+	// Try boolean comparison.
+	abool, aok := a.(bool)
+	bbool, bok := b.(bool)
+	if aok && bok {
+		switch op {
+		case "=":
+			return abool == bbool
+		case "<":
+			// The only true case is false < true.
+			return !abool && bbool
+		case ">":
+			// The only true case is true > false.
+			return abool && !bbool
+		case "<=":
+			return abool == bbool || (!abool && bbool)
+		case ">=":
+			return abool == bbool || (abool && !bbool)
+		}
+		return false
+	}
+
 	// Compare as integers if both values are int-compatible.
 	ai, aok := toInt64Strict(a)
 	bi, bok := toInt64Strict(b)


### PR DESCRIPTION
This change adds boolean comparisons to the filestore compare function. This allows booleans to be used in queries. Greater than and less than operators are included even though they are kind of silly as they are valid in the cloudstore.
