### PR TITLE
filestore: apply field filters separately

### DIFF
--- a/datastore/datastore_test.go
+++ b/datastore/datastore_test.go
@@ -432,6 +432,7 @@ func TestFileFilterFieldVariants(t *testing.T) {
 		keyParts    []string
 		limit       int
 		offset      int
+		keysOnly    bool
 		expectNames []string
 	}{
 		{
@@ -492,11 +493,41 @@ func TestFileFilterFieldVariants(t *testing.T) {
 			offset:      1,
 			expectNames: []string{"b", "c"},
 		},
+		{
+			name:        "KeysOnly query with field filter",
+			field:       "Value",
+			operator:    "=",
+			value:       "apple",
+			keyParts:    []string{"Name"},
+			keysOnly:    true,
+			expectNames: []string{"a", "d"},
+		},
+		{
+			name:        "Limit and offset combo with filtered-out intermediate keys",
+			field:       "Value",
+			operator:    "=",
+			value:       "apple",
+			keyParts:    []string{"Name"},
+			limit:       1,
+			offset:      1,
+			expectNames: []string{"d"},
+		},
+		{
+			name:        "KeysOnly limit and offset combo with filtered-out intermediate keys",
+			field:       "Value",
+			operator:    "=",
+			value:       "apple",
+			keyParts:    []string{"Name"},
+			limit:       1,
+			offset:      1,
+			keysOnly:    true,
+			expectNames: []string{"d"},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			q := store.NewQuery(typeNameValue, false, tc.keyParts...)
+			q := store.NewQuery(typeNameValue, tc.keysOnly, tc.keyParts...)
 			q.FilterField(tc.field, tc.operator, tc.value)
 			q.Order(tc.field)
 			if tc.limit > 0 {
@@ -507,14 +538,30 @@ func TestFileFilterFieldVariants(t *testing.T) {
 			}
 
 			var results []NameValue
-			_, err := store.GetAll(ctx, q, &results)
+			keys, err := store.GetAll(ctx, q, &results)
 			if err != nil {
 				t.Fatalf("GetAll failed: %v", err)
 			}
 
 			var gotNames []string
-			for _, r := range results {
-				gotNames = append(gotNames, r.Name)
+			if tc.keysOnly {
+				if len(results) != 0 {
+					t.Errorf("expected no results loaded into dst for keysOnly query, got %+v", results)
+				}
+				for _, k := range keys {
+					gotNames = append(gotNames, k.Name)
+				}
+			} else {
+				for _, r := range results {
+					gotNames = append(gotNames, r.Name)
+				}
+				var gotKeyNames []string
+				for _, k := range keys {
+					gotKeyNames = append(gotKeyNames, k.Name)
+				}
+				if !equalUnordered(gotKeyNames, tc.expectNames) {
+					t.Errorf("unexpected key names returned: got %v, want %v", gotKeyNames, tc.expectNames)
+				}
 			}
 
 			if !equalUnordered(gotNames, tc.expectNames) {

--- a/datastore/filestore.go
+++ b/datastore/filestore.go
@@ -262,11 +262,71 @@ func (s *FileStore) GetAll(ctx context.Context, query Query, dst interface{}) ([
 		})
 	}
 
+	if len(q.fieldFilters) > 0 {
+		entity := newEntity[q.kind]
+		if entity == nil {
+			return nil, ErrUnimplemented
+		}
+
+		var filteredKeys []*Key
+		var filteredEntities []Entity
+		for _, k := range keys {
+			e := entity()
+			err := s.Get(ctx, k, e)
+			if err != nil {
+				return nil, err
+			}
+			if matchesFieldFilters(e, q.fieldFilters) {
+				filteredKeys = append(filteredKeys, k)
+				if !q.keysOnly {
+					filteredEntities = append(filteredEntities, e)
+				}
+			}
+		}
+		keys = filteredKeys
+
+		// Apply query's limit and offset.
+		if q.offset >= len(keys) {
+			keys = nil
+			filteredEntities = nil
+		} else {
+			end := q.offset + q.limit
+			if end > len(keys) {
+				end = len(keys)
+			}
+			keys = keys[q.offset:end]
+			if !q.keysOnly {
+				filteredEntities = filteredEntities[q.offset:end]
+			}
+		}
+
+		if q.keysOnly {
+			return keys, nil
+		}
+
+		// Populate dst.
+		dv := reflect.ValueOf(dst).Elem()
+		for i, k := range keys {
+			e := filteredEntities[i]
+			ev := reflect.Indirect(reflect.ValueOf(e))
+			fld := ev.FieldByName("Key")
+			if fld.IsValid() {
+				fld.Set(reflect.ValueOf(k))
+			}
+			dv.Set(reflect.Append(dv, ev))
+		}
+		return keys, nil
+	}
+
 	// Apply query's limit and offset to the keys.
-	if q.offset+q.limit > len(keys) {
-		keys = keys[q.offset:]
+	if q.offset >= len(keys) {
+		keys = nil
 	} else {
-		keys = keys[q.offset:(q.offset + q.limit)]
+		end := q.offset + q.limit
+		if end > len(keys) {
+			end = len(keys)
+		}
+		keys = keys[q.offset:end]
 	}
 
 	if q.keysOnly {
@@ -288,11 +348,6 @@ func (s *FileStore) GetAll(ctx context.Context, query Query, dst interface{}) ([
 			return nil, err
 		}
 		// The underlying entity type is a pointer, so we need its indirect type.
-
-		// Apply field filters if needed.
-		if len(q.fieldFilters) > 0 && !matchesFieldFilters(e, q.fieldFilters) {
-			continue
-		}
 
 		ev := reflect.Indirect(reflect.ValueOf(e))
 		// As with the Cloud datastore, if the Key field is present we populate it.


### PR DESCRIPTION
This change applies field filters separately rather than inside of the entity loading loop. This is because field filters need to be applied before limits and offsets in order to get the correct results. This also fixes key only queries on queries that have field filters. The limit and offset logic is also improved to prevent slicing past the length of the results. While this change does duplicate some code it is the cleanest way to do it as the logic is quite different in some places. Closes #703.
