### PR TITLE
Bench/Broadcast: Add state progress bar

### DIFF
--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -76,7 +76,7 @@ import (
 )
 
 const (
-	version     = "v0.36.5"
+	version     = "v0.37.0"
 	localSite   = "localhost"
 	localDevice = "localdevice"
 	localEmail  = "localuser@localhost"

--- a/cmd/oceanbench/package-lock.json
+++ b/cmd/oceanbench/package-lock.json
@@ -7175,6 +7175,7 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/cmd/oceanbench/s/broadcast.js
+++ b/cmd/oceanbench/s/broadcast.js
@@ -388,6 +388,10 @@ function populateForm(data) {
       syncDateTime("end-time", "end-timestamp", "time-zone", false);
   }
 
+  // Update states element.
+  const broadcastStatesEl = document.getElementById("broadcast-state-disp");
+  broadcastStatesEl.setAttribute("broadcast-id", data.UUID)
+
   // Check sensor config dynamically
   if (data.SensorList && Array.isArray(data.SensorList)) {
     // Uncheck all first

--- a/cmd/oceanbench/t/broadcast.html
+++ b/cmd/oceanbench/t/broadcast.html
@@ -12,6 +12,7 @@
       }
     </style>
     <script type="module" src="/s/lit/header-group.js"></script>
+    <script type="module" src="/s/lit/broadcast-states.js"></script>
     <script type="text/javascript" src="/s/main.js"></script>
     <script type="text/javascript" src="/s/broadcast.js"></script>
     <script type="module" src="/s/lit/site-footer.js"></script>
@@ -40,6 +41,7 @@
 
       <h1 class="container-md">Broadcast</h1>
       <div class="border rounded p-4 container-md bg-white position-relative">
+        <broadcast-states id="broadcast-state-disp"></broadcast-states>
         <div id="loading-overlay" class="d-none position-absolute top-0 start-0 w-100 h-100 bg-white d-flex justify-content-center align-items-center" style="z-index: 10; opacity: 0.7">
           <div class="spinner-border text-primary" role="status">
             <span class="visually-hidden">Loading...</span>

--- a/cmd/oceanbench/ts/broadcast-states.ts
+++ b/cmd/oceanbench/ts/broadcast-states.ts
@@ -1,0 +1,168 @@
+import { html, PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { TailwindElement } from "./shared/tailwind.element";
+import { type Broadcast } from "./types/broadcast";
+
+enum DirectState {
+  IDLE = "main.directIdle",
+  STARTING = "main.directStarting",
+  LIVE = "main.directLive",
+  UNHEALTHY = "main.directLiveUnhealthy",
+}
+
+// Maps the state to the progress amount.
+const progressMap: Record<DirectState, number> = {
+  [DirectState.IDLE]: 0,
+  [DirectState.STARTING]: 34,
+  [DirectState.LIVE]: 68,
+  [DirectState.UNHEALTHY]: 84,
+} as const;
+
+// Displays a stepped progress bar showing the current state
+// of a broadcast.
+@customElement("broadcast-states")
+export class BroadcastStates extends TailwindElement() {
+  // UUID of the currently selected broadcast.
+  @property({ attribute: "broadcast-id", type: "string" })
+  UUID = "";
+
+  // Broadcast config of currently selected broadcast.
+  @state()
+  config: Broadcast | null = null;
+
+  // Current progress %.
+  @state()
+  progress: number = 0;
+
+  // Interval ID.
+  @state()
+  intervalID: ReturnType<typeof setInterval> | undefined = undefined;
+
+  // Handle updates to the state.
+  protected updated(_changedProperties: PropertyValues): void {
+    if (_changedProperties.has("UUID") && this.UUID != "") {
+      if (this.intervalID != undefined) {
+        clearInterval(this.intervalID);
+        this.intervalID = undefined;
+      }
+
+      this.poll();
+      this.intervalID = setInterval(() => this.poll(), 2000);
+    }
+  }
+
+  // Poll makes a request to update the current broadcast config.
+  async poll(): Promise<void> {
+    try {
+      const urlParams = new URLSearchParams(window.location.search);
+      const site = urlParams.get("site");
+      const url = site
+        ? `/api/v1/broadcasts/${this.UUID}?site=${site}`
+        : `/api/v1/broadcasts/${this.UUID}`;
+
+      const res = await fetch(url);
+      if (!res.ok) {
+        throw new Error(`Failed to fetch broadcast config: ${res.statusText}`);
+      }
+      this.config = await res.json();
+    } catch (err) {
+      console.error(`Error fetching broadcast config:`, err);
+      this.config = null;
+      return;
+    }
+
+    this.updateProgression();
+  }
+
+  // Updates the current progress based on the current broadcast state from the config.
+  private updateProgression() {
+    if (!this.config) return;
+
+    this.progress = progressMap[this.config.BroadcastState as DirectState] ?? 0;
+  }
+
+  render() {
+    if (this.config === null) {
+      // Don't render when a broadcast isn't selected.
+      return;
+    }
+
+    return html`
+      <div class="flex gap-2 relative mb-8">
+        <!--Failure badge-->
+        <div class="${!this.config.InFailure ? "hidden" : "flex"} ">
+          <div class="bg-red-400 rounded-full px-4 py-2 text-red-900 w-fit">
+            Failed
+          </div>
+        </div>
+
+        <div class="relative flex w-full">
+          <!--Progress Bar-->
+          <div
+            class="flex h-2 w-full content-center overflow-hidden rounded-full mt-1.5"
+          >
+            <div
+              class="h-full bg-green-600 ease-out transition-all"
+              style="width: ${this.progress}%"
+            ></div>
+            <div
+              class="h-full ${this.progress == 84
+                ? "bg-red-600"
+                : "bg-slate-600"} ease-out transition-all"
+              style="width: ${100 - this.progress}%"
+            ></div>
+          </div>
+
+          <!--Idle Milestone-->
+          <div class="absolute left-0 flex flex-col size-fit items-start">
+            <div class="h-5 w-5 rounded-full bg-green-600"></div>
+            <label>Idle</label>
+          </div>
+
+          <!--Starting Milestone-->
+          <div
+            class="absolute left-1/3 -translate-x-1/2 flex flex-col size-fit items-center w-0"
+          >
+            <div
+              class="h-5 w-5 rounded-full ${this.progress >=
+              progressMap[DirectState.STARTING]
+                ? "bg-green-600"
+                : "bg-slate-600"}"
+            ></div>
+            <label>Starting</label>
+          </div>
+
+          <!--Live Milestone-->
+          <div
+            class="absolute left-2/3 -translate-x-1/2 flex flex-col size-fit items-center"
+          >
+            <div
+              class="h-5 w-5 rounded-full ${this.progress >=
+              progressMap[DirectState.LIVE]
+                ? "bg-green-600"
+                : "bg-slate-600"}"
+            ></div>
+            <label>Live</label>
+          </div>
+
+          <!--Live Unhealthy Milestone-->
+          <div class="absolute right-0 flex flex-col size-fit items-end">
+            <div
+              class="h-5 w-5 rounded-full ${this.progress >=
+              progressMap[DirectState.UNHEALTHY]
+                ? "bg-red-600"
+                : "bg-slate-600"}"
+            ></div>
+            <label>Unhealthy</label>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "broadcast-states": BroadcastStates;
+  }
+}

--- a/cmd/oceanbench/ts/types/broadcast.ts
+++ b/cmd/oceanbench/ts/types/broadcast.ts
@@ -1,0 +1,52 @@
+// Broadcast Config
+export type Broadcast = {
+  UUID: string; // The immutable unique key of the broadcast.
+  SKey: number; // The key of the site this broadcast belongs to.
+  Name: string; // The name of the broadcast.
+  BID: string; // Broadcast identification.
+  SID: string; // Stream ID for any currently associated stream.
+  CID: string; // ID of associated chat.
+  StreamName: string; // The name of the stream we'll bind to the broadcast.
+  Description: string; // The broadcast description shown below viewing window.
+  LivePrivacy: string; // Privacy of the broadcast whilst live i.e. public, private or unlisted.
+  PostLivePrivacy: string; // Privacy of the broadcast after it has ended i.e. public, private or unlisted.
+  Resolution: string; // Resolution of the stream e.g. 1080p.
+  StartTimestamp: string; // Start time of the broadcast in unix format.
+  Start: Date; // Start time in native go format for easy operations.
+  EndTimestamp: string; // End time of the broadcast in unix format.
+  End: Date; // End time in native go format for easy operations.
+  VidforwardHost: string; // Host address of vidforward service.
+  CameraMac: number; // Camera hardware's MAC address.
+  ControllerMAC: number; // Controller hardware's MAC adress (controller used to power camera).
+  OnActions: string; // A series of actions to be used for power up of camera hardware.
+  ShutdownActions: string; // A series of actions to be used for shutdown of camera hardware.
+  OffActions: string; // A series of actions to be used for power down of camera hardware.
+  RTMPVar: string; // The variable name that holds the RTMP URL and key.
+  Active: boolean; // This is true if the broadcast is currently active i.e. waiting for data or currently streaming.
+  Slate: boolean; // This is true if the broadcast is currently in slate mode i.e. no camera.
+  Issues: number; // The number of successive stream issues currently experienced. Reset when good health seen.
+  SendMsg: boolean; // True if sensor data will be sent to the YouTube live chat.
+  SensorList: object; // List of sensors which can be reported to the YouTube live chat.
+  RTMPKey: string; // The RTMP key corresponding to the newly created broadcast.
+  UsingVidforward: boolean; // Indicates if we're using vidforward i.e. doing long term broadcast.
+  CheckingHealth: boolean; // Are we performing health checks for the broadcast? Having this false is useful for dodgy testing streams.
+  AttemptingToStart: boolean; // Indicates if we're currently attempting to start the broadcast.
+  Enabled: boolean; // Is the broadcast enabled? If not, it will not be started.
+  Events: string[]; // Holds names of events that are yet to be handled.
+  Unhealthy: boolean; // True if the broadcast is unhealthy.
+  BroadcastState: string; // Holds the current state of the broadcast.
+  HardwareState: string; // Holds the current state of the hardware.
+  StartFailures: number; // The number of times the broadcast has failed to start.
+  Transitioning: boolean; // If the broadcast is transition from live to slate, or vice versa.
+  StateData: string; // States will be marshalled and their data stored here.
+  HardwareStateData: string; // Hardware states will be marshalled and their data stored here.
+  Account: string; // The YouTube account email that this broadcast is associated with.
+  InFailure: boolean; // True if the broadcast is in a failure state.
+  BatteryVoltagePin: string; // The pin that the battery voltage is read from.
+  RecoveringVoltage: boolean; // True if the broadcast is currently recovering voltage.
+  RequiredStreamingVoltage: number; // The required battery voltage for the camera to stream.
+  VoltageRecoveryTimeout: number; // Max allowable hours for voltage recovery before failure.
+  RegisterOpenFish: boolean; // True if the video should be registered with openfish for annotation.
+  OpenFishCaptureSource: string; // The capture source to register the stream to.
+  NotifySuppressRules: string; // Suppression rules for notifications.
+};


### PR DESCRIPTION
This change adds a stepped progress bar to the top of the broadcast page which polls for updates to the current broadcast.

requires #778 

<img width="1059" height="306" alt="image" src="https://github.com/user-attachments/assets/b1d9ce18-712a-4b06-82bd-ce32c5e22b5f" />
