### PR TITLE
OTV: Create hardware package

### DIFF
--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -29,7 +29,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -262,61 +261,6 @@ type ErrInvalidEndTime struct {
 
 func (e ErrInvalidEndTime) Error() string {
 	return fmt.Sprintf("end time (%v) is invalid relative to start time (%v)", e.end, e.start)
-}
-
-// extStart uses the OnActions in the provided broadcast config to perform
-// external streaming hardware startup. In addition, the RTMP key is obtained
-// from the broadcast's associated stream object and used to set the devices
-// RTMPKey variable.
-func extStart(ctx Ctx, cfg *Cfg, log func(string, ...interface{})) error {
-	if cfg.OnActions == "" {
-		return nil
-	}
-
-	onActions := cfg.OnActions + "," + cfg.RTMPVar + "=" + broadcast.RTMPDestinationAddress + cfg.RTMPKey
-	err := setActionVars(ctx, cfg.SKey, onActions, store, log)
-	if err != nil {
-		return fmt.Errorf("could not set device variables required to start stream: %w", err)
-	}
-
-	return nil
-}
-
-// errNoShutdownActions represents no shutdown actions being registered for the broadcast.
-var errNoShutdownActions = errors.New("no shutdown actions provided")
-
-// SkipAction is the placeholder used to represent that the action step should be skipped.
-const SkipAction = "skip"
-
-func extShutdown(ctx Ctx, cfg *Cfg, log func(string, ...interface{})) error {
-	if cfg.ShutdownActions == SkipAction {
-		return broadcast.WarnSkipShutdown
-	}
-	if cfg.ShutdownActions == "" {
-		return errNoShutdownActions
-	}
-
-	err := setActionVars(ctx, cfg.SKey, cfg.ShutdownActions, store, log)
-	if err != nil {
-		return fmt.Errorf("could not set device variables to end stream: %w", err)
-	}
-
-	return nil
-}
-
-// extStop uses the OffActions in the provided broadcast config to perform
-// external streaming hardware shutdown.
-func extStop(ctx Ctx, cfg *Cfg, log func(string, ...interface{})) error {
-	if cfg.OffActions == "" {
-		return nil
-	}
-
-	err := setActionVars(ctx, cfg.SKey, cfg.OffActions, store, log)
-	if err != nil {
-		return fmt.Errorf("could not set device variables to end stream: %w", err)
-	}
-
-	return nil
 }
 
 // liveHandler handles requests to /live/<broadcast name>. This redirects to the

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -107,7 +107,7 @@ func (sm *hardwareStateMachine) handleEvent(e event.Event) error {
 func (sm *hardwareStateMachine) handleTimeEvent(t event.Time) {
 	sm.log("handling time event")
 	eventIfStatus := func(e event.Event, status bool) {
-		sm.ctx.hardware.PublishEventIfStatus(sm.ctx, e, status, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
+		sm.ctx.hardware.PublishEventIfStatus(sm.ctx.newHWContext(), e, status, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
 	}
 	switch sm.currentState.(type) {
 	case *hardwareStarting:
@@ -130,7 +130,7 @@ func (sm *hardwareStateMachine) handleTimeEvent(t event.Time) {
 			return
 		}
 
-		voltage, err := sm.ctx.hardware.Voltage(sm.ctx)
+		voltage, err := sm.ctx.hardware.Voltage(sm.ctx.newHWContext())
 		if err != nil {
 			errWrapped := fmt.Errorf("could not get hardware voltage: %v", err)
 			sm.log(errWrapped.Error())
@@ -227,7 +227,7 @@ func (sm *hardwareStateMachine) handleHardwareStartRequestEvent(e event.Hardware
 	case *hardwareOff, *hardwareRestarting:
 		sm.transition(newHardwareStarting(sm.ctx))
 	case *hardwareStarting:
-		sm.ctx.hardware.PublishEventIfStatus(sm.ctx, event.HardwareStarted{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
+		sm.ctx.hardware.PublishEventIfStatus(sm.ctx.newHWContext(), event.HardwareStarted{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
 	case *hardwareStopping:
 		// Ignore and log.
 		sm.log("ignoring hardware start request event since hardware is still stopping")

--- a/cmd/oceantv/broadcast_hardware_machine.go
+++ b/cmd/oceantv/broadcast_hardware_machine.go
@@ -1,17 +1,13 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
 	"github.com/ausocean/cloud/cmd/oceantv/registry"
-	"github.com/ausocean/cloud/datastore"
-	"github.com/ausocean/cloud/model"
 )
 
 func register(state registry.Named) struct{} {
@@ -111,7 +107,7 @@ func (sm *hardwareStateMachine) handleEvent(e event.Event) error {
 func (sm *hardwareStateMachine) handleTimeEvent(t event.Time) {
 	sm.log("handling time event")
 	eventIfStatus := func(e event.Event, status bool) {
-		sm.ctx.hardware.publishEventIfStatus(sm.ctx, e, status, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
+		sm.ctx.hardware.PublishEventIfStatus(sm.ctx, e, status, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
 	}
 	switch sm.currentState.(type) {
 	case *hardwareStarting:
@@ -134,7 +130,7 @@ func (sm *hardwareStateMachine) handleTimeEvent(t event.Time) {
 			return
 		}
 
-		voltage, err := sm.ctx.hardware.voltage(sm.ctx)
+		voltage, err := sm.ctx.hardware.Voltage(sm.ctx)
 		if err != nil {
 			errWrapped := fmt.Errorf("could not get hardware voltage: %v", err)
 			sm.log(errWrapped.Error())
@@ -231,7 +227,7 @@ func (sm *hardwareStateMachine) handleHardwareStartRequestEvent(e event.Hardware
 	case *hardwareOff, *hardwareRestarting:
 		sm.transition(newHardwareStarting(sm.ctx))
 	case *hardwareStarting:
-		sm.ctx.hardware.publishEventIfStatus(sm.ctx, event.HardwareStarted{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
+		sm.ctx.hardware.PublishEventIfStatus(sm.ctx, event.HardwareStarted{}, true, sm.ctx.cfg.CameraMac, sm.ctx.store, sm.log, sm.ctx.bus.Publish)
 	case *hardwareStopping:
 		// Ignore and log.
 		sm.log("ignoring hardware start request event since hardware is still stopping")
@@ -314,161 +310,6 @@ func (sm *hardwareStateMachine) unexpectedEvent(e event.Event, state state) {
 
 func (sm *hardwareStateMachine) log(format string, args ...interface{}) {
 	sm.ctx.log("(hardware sm) "+format, args...)
-}
-
-type hardwareManager interface {
-	voltage(ctx *broadcastContext) (float64, error)
-	alarmVoltage(ctx *broadcastContext) (float64, error)
-	isUp(ctx *broadcastContext, mac string) (bool, error)
-	start(ctx *broadcastContext)
-	shutdown(ctx *broadcastContext)
-	stop(ctx *broadcastContext)
-	publishEventIfStatus(ctx *broadcastContext, e event.Event, status bool, mac int64, store Store, log func(format string, args ...interface{}), publish func(e event.Event))
-	error(ctx *broadcastContext) (error, error)
-}
-
-type revidCameraClient struct{}
-
-type ControllerError string
-
-const (
-	None            ControllerError = ""
-	LowVoltageAlarm ControllerError = "LowVoltage"
-)
-
-func (e ControllerError) Error() string {
-	return string(e)
-}
-
-func (e ControllerError) Is(target error) bool {
-	if target == nil {
-		return false
-	}
-	if t, ok := target.(ControllerError); ok {
-		return e == t
-	}
-	return false
-}
-
-func (c *revidCameraClient) voltage(ctx *broadcastContext) (float64, error) {
-	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
-	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.cfg.ControllerMAC, ctx.cfg.BatteryVoltagePin)
-	if err != nil {
-		return 0, fmt.Errorf("could not get battery voltage sensor (%s.%s): %w", model.MacDecode(ctx.cfg.ControllerMAC), ctx.cfg.BatteryVoltagePin, err)
-	}
-
-	// Get current battery voltage.
-	voltage, err := model.GetSensorValue(context.Background(), ctx.store, sensor)
-	switch {
-	case errors.Is(err, datastore.ErrNoSuchEntity):
-		// We'll get this if the controller is off from low voltage, so just
-		// assume we have alarm voltage.
-		alarmVoltage, err := c.alarmVoltage(ctx)
-		if err != nil {
-			return 0, fmt.Errorf("could not get alarm voltage: %w", err)
-		}
-		return alarmVoltage, nil
-	case err != nil:
-		return 0, fmt.Errorf("could not get current battery voltage: %w", err)
-	}
-
-	return voltage, nil
-}
-
-func (c *revidCameraClient) alarmVoltage(ctx *broadcastContext) (float64, error) {
-	// Get AlarmVoltage variable; if the voltage is above this we expect the controller to be on.
-	// If the voltage is below this, we expect the controller to be off.
-	controllerMACHex := (&model.Device{Mac: ctx.cfg.ControllerMAC}).Hex()
-	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, controllerMACHex+".AlarmVoltage")
-	if err != nil {
-		return 0, fmt.Errorf("could not get alarm voltage variable: %w", err)
-	}
-	ctx.log("got AlarmVoltage for %s: %s", controllerMACHex, alarmVoltageVar.Value)
-
-	uncalibratedAlarmVoltage, err := strconv.Atoi(alarmVoltageVar.Value)
-	if err != nil {
-		return 0, fmt.Errorf("could not convert uncalibrated alarm voltage from string: %w", err)
-	}
-
-	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
-	batteryVoltagePin := ctx.cfg.BatteryVoltagePin
-	if batteryVoltagePin == "" {
-		const defaultBatteryVoltagePin = "A4"
-		batteryVoltagePin = defaultBatteryVoltagePin
-	}
-	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.cfg.ControllerMAC, batteryVoltagePin)
-	if err != nil {
-		return 0, fmt.Errorf("could not get battery voltage sensor: %w", err)
-	}
-
-	// Transform the alarm voltage to the actual voltage.
-	alarmVoltage, err := sensor.Transform(float64(uncalibratedAlarmVoltage))
-	if err != nil {
-		return 0, fmt.Errorf("could not transform alarm voltage: %w", err)
-	}
-
-	return alarmVoltage, nil
-}
-
-func (c *revidCameraClient) isUp(ctx *broadcastContext, mac string) (bool, error) {
-	deviceIsUp, err := model.DeviceIsUp(context.Background(), ctx.store, mac)
-	if err != nil {
-		return false, fmt.Errorf("could not get controller status: %w", err)
-	}
-	return deviceIsUp, nil
-}
-
-func (c *revidCameraClient) start(ctx *broadcastContext) {
-	err := extStart(context.Background(), ctx.cfg, ctx.log)
-	if err != nil {
-		ctx.log("could not start external hardware: %v", err)
-		ctx.bus.Publish(event.HardwareStartFailed{Err: fmt.Errorf("external hardware start actions failed: %w", err)})
-		return
-	}
-}
-
-func (c *revidCameraClient) shutdown(ctx *broadcastContext) {
-	err := extShutdown(context.Background(), ctx.cfg, ctx.log)
-	if err != nil {
-		ctx.bus.Publish(event.HardwareShutdownFailed{Err: fmt.Errorf("could not perform shutdown actions: %w", err)})
-		return
-	}
-}
-
-func (c *revidCameraClient) stop(ctx *broadcastContext) {
-	err := extStop(context.Background(), ctx.cfg, ctx.log)
-	if err != nil {
-		ctx.log("could not stop external hardware: %v", err)
-		ctx.bus.Publish(event.HardwareStopFailed{Err: fmt.Errorf("could not perform stop actions: %w", err)})
-		return
-	}
-}
-
-func (c *revidCameraClient) publishEventIfStatus(ctx *broadcastContext, e event.Event, status bool, mac int64, store Store, log func(string, ...interface{}), publish func(e event.Event)) {
-	if mac == 0 {
-		publish(event.InvalidConfiguration{errors.New("camera mac is empty")})
-		return
-	}
-	log("checking status of device with mac: %d", mac)
-	alive, err := model.DeviceIsUp(context.Background(), store, model.MacDecode(mac))
-	if err != nil {
-		log("could not get device status: %v", err)
-		return
-	}
-	log("status from DeviceIsUp check: %v", alive)
-	if alive == status {
-		publish(e)
-		return
-	}
-}
-
-func (c *revidCameraClient) error(ctx *broadcastContext) (error, error) {
-	controllerMACHex := (&model.Device{Mac: ctx.cfg.ControllerMAC}).Hex()
-	devErr, err := model.GetVariable(context.Background(), ctx.store, ctx.cfg.SKey, controllerMACHex+".error")
-	if err != nil {
-		return nil, fmt.Errorf("could not get controller error variable: %w", err)
-	}
-	return ControllerError(devErr.Value), nil
 }
 
 func (sm *hardwareStateMachine) saveHardwareStateToConfig() error {

--- a/cmd/oceantv/broadcast_hardware_machine_test.go
+++ b/cmd/oceantv/broadcast_hardware_machine_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/notify"
 	"github.com/stretchr/testify/assert"
@@ -363,7 +364,7 @@ func (h hardwareSystem) withForwardingService(fs forwarding.Service) hardwareSys
 	}
 }
 
-func (h hardwareSystem) withHardwareManager(hm hardwareManager) hardwareSystemOption {
+func (h hardwareSystem) withHardwareManager(hm hardware.Manager) hardwareSystemOption {
 	return func(bs *hardwareSystem) error {
 		bs.ctx.hardware = hm
 		return nil
@@ -455,7 +456,7 @@ func TestHardwareStopAndRestart(t *testing.T) {
 		cfg                func(*Cfg)
 		finalHardwareState state
 		initialEvent       event.Event
-		hardwareMan        hardwareManager
+		hardwareMan        hardware.Manager
 		newBroadcastMan    func(*testing.T, *Cfg) manager.Broadcast
 
 		// Leave unset to use default max ticks.

--- a/cmd/oceantv/broadcast_machine_test.go
+++ b/cmd/oceantv/broadcast_machine_test.go
@@ -9,6 +9,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
 	"github.com/ausocean/cloud/notify"
@@ -1215,7 +1216,7 @@ func TestBroadcastStart(t *testing.T) {
 		cfg                      *Cfg
 		initialState             state
 		finalState               state
-		hardwareMan              hardwareManager
+		hardwareMan              hardware.Manager
 		expectHardwareStartCall  bool
 		expectBroadcastStartCall bool
 		inputEvent               event.Event
@@ -1537,7 +1538,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 		initialBroadcastState state
 		finalBroadcastState   state
 		finalHardwareState    state
-		hardwareMan           hardwareManager
+		hardwareMan           hardware.Manager
 		newBroadcastMan       func(*testing.T, *Cfg) manager.Broadcast
 
 		// Leave unset to use default max ticks.
@@ -1794,7 +1795,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			initialBroadcastState: &directIdle{},
 			finalBroadcastState:   &directStarting{},
 			finalHardwareState:    &hardwareRecoveringVoltage{},
-			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withHardwareError(LowVoltageAlarm)),
+			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withHardwareError(hardware.LowVoltageAlarm)),
 			newBroadcastMan: func(t *testing.T, c *Cfg) manager.Broadcast {
 				return newDummyManager(t, c)
 			},
@@ -1816,7 +1817,7 @@ func TestHardwareVoltageAndFaultHandling(t *testing.T) {
 			initialBroadcastState: &directIdle{},
 			finalBroadcastState:   &directStarting{},
 			finalHardwareState:    &hardwareStarting{},
-			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withHardwareError(LowVoltageAlarm)),
+			hardwareMan:           newDummyHardwareManager(withLowVoltage(), withHardwareError(hardware.LowVoltageAlarm)),
 			newBroadcastMan: func(t *testing.T, c *Cfg) manager.Broadcast {
 				return newDummyManager(t, c)
 			},

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
 	"github.com/ausocean/cloud/cmd/oceantv/yt"
@@ -26,7 +27,7 @@ type broadcastContext struct {
 	svc      Svc
 	fwd      forwarding.Service
 	bus      event.EventBus
-	hardware hardwareManager
+	hardware hardware.Manager
 
 	// When nil, defaults to log.Println. Useful to plug in test implementation.
 	logOutput func(v ...any)

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -97,6 +97,10 @@ func (ctx *broadcastContext) logAndNotify(kind notify.Kind, msg string, args ...
 	}
 }
 
+func (ctx *broadcastContext) newHWContext() *hardware.Context {
+	return hardware.NewContext(ctx.store, ctx.cfg, ctx.bus, ctx.logOutput)
+}
+
 type state interface {
 	enter()
 	exit()

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/ratelimit"
 	"github.com/ausocean/cloud/cmd/oceantv/yt"
@@ -366,17 +367,17 @@ func newDummyHardwareManager(options ...func(*dummyHardwareManager)) *dummyHardw
 	}
 	return m
 }
-func (h *dummyHardwareManager) voltage(ctx *broadcastContext) (float64, error) {
+func (h *dummyHardwareManager) Voltage(ctx *hardware.Context) (float64, error) {
 	// This is assuming we call this function every tick.
 	h.volts += h.chargeRate
 	return h.volts, nil
 }
-func (h *dummyHardwareManager) alarmVoltage(ctx *broadcastContext) (float64, error) {
+func (h *dummyHardwareManager) AlarmVoltage(ctx *hardware.Context) (float64, error) {
 	return h.alarmVolts, nil
 }
-func (h *dummyHardwareManager) isUp(ctx *broadcastContext, mac string) (bool, error) {
+func (h *dummyHardwareManager) IsUp(ctx *hardware.Context, mac string) (bool, error) {
 	if mac == h.controllerMAC {
-		ctx.log("checking controller status, volts: %v, alarmVolts: %v, hardwareHealthy: %v", h.volts, h.alarmVolts, h.hardwareHealthy)
+		ctx.Log("checking controller status, volts: %v, alarmVolts: %v, hardwareHealthy: %v", h.volts, h.alarmVolts, h.hardwareHealthy)
 		if h.volts < h.alarmVolts {
 			return false, nil
 		}
@@ -390,7 +391,7 @@ func (h *dummyHardwareManager) isUp(ctx *broadcastContext, mac string) (bool, er
 		if !h.hardwareHealthy {
 			return false, nil
 		}
-		ctx.log("checking camera status: %v", h.latestRequest)
+		ctx.Log("checking camera status: %v", h.latestRequest)
 		if h.latestRequest.kind != "" && time.Now().Sub(h.latestRequest.Time) > 1*time.Minute {
 			switch h.latestRequest.kind {
 			case "start":
@@ -408,34 +409,34 @@ func (h *dummyHardwareManager) isUp(ctx *broadcastContext, mac string) (bool, er
 	return false, fmt.Errorf("could not get device: %w", datastore.ErrNoSuchEntity)
 }
 
-func (h *dummyHardwareManager) start(ctx *broadcastContext) {
-	ctx.log("starting hardware")
+func (h *dummyHardwareManager) Start(ctx *hardware.Context) {
+	ctx.Log("starting hardware")
 	h.startCalled = true
 	// Can't start if we're already shutting down.
 	if h.latestRequest.kind != "shutdown" {
 		h.latestRequest = request{"start", time.Now()}
 	}
 }
-func (h *dummyHardwareManager) shutdown(ctx *broadcastContext) {
-	ctx.log("shutting down hardware")
+func (h *dummyHardwareManager) Shutdown(ctx *hardware.Context) {
+	ctx.Log("shutting down hardware")
 	h.shutdownCalled = true
-	if ctx.cfg.ShutdownActions == "" {
-		ctx.bus.Publish(event.HardwareShutdownFailed{})
+	if ctx.Cfg.ShutdownActions == "" {
+		ctx.Bus.Publish(event.HardwareShutdownFailed{})
 		return
 	}
 	h.latestRequest = request{"shutdown", time.Now()}
 }
-func (h *dummyHardwareManager) stop(ctx *broadcastContext) {
-	ctx.log("stopping hardware")
+func (h *dummyHardwareManager) Stop(ctx *hardware.Context) {
+	ctx.Log("stopping hardware")
 	h.stopCalled = true
 	h.latestRequest = request{"stop", time.Now()}
 }
-func (h *dummyHardwareManager) publishEventIfStatus(ctx *broadcastContext, e event.Event, status bool, mac int64, store Store, log func(format string, args ...interface{}), publish func(e event.Event)) {
+func (h *dummyHardwareManager) PublishEventIfStatus(ctx *hardware.Context, e event.Event, status bool, mac int64, store Store, log func(format string, args ...interface{}), publish func(e event.Event)) {
 	if h.checkMAC && mac == 0 {
 		publish(event.InvalidConfiguration{errors.New("camera mac is empty")})
 		return
 	}
-	up, err := h.isUp(ctx, model.MacDecode(mac))
+	up, err := h.IsUp(ctx, model.MacDecode(mac))
 	if err != nil {
 		publish(event.InvalidConfiguration{fmt.Errorf("could not get device: %w", err)})
 		return
@@ -447,9 +448,9 @@ func (h *dummyHardwareManager) publishEventIfStatus(ctx *broadcastContext, e eve
 		publish(e)
 	}
 }
-func (h *dummyHardwareManager) error(ctx *broadcastContext) (error, error) {
+func (h *dummyHardwareManager) Error(ctx *hardware.Context) (error, error) {
 	if h.volts > h.alarmVolts {
-		return None, nil
+		return hardware.None, nil
 	}
 	return h.hwErr, nil
 }

--- a/cmd/oceantv/hardware/manager.go
+++ b/cmd/oceantv/hardware/manager.go
@@ -1,0 +1,59 @@
+/*
+AUTHORS
+  Saxon Nelson-Milton <saxon@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This file is part of Ocean TV. Ocean TV is free software: you can
+  redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option)
+  any later version.
+
+  Ocean TV is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package hardware
+
+import (
+	"log"
+
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/event"
+	"github.com/ausocean/cloud/datastore"
+)
+
+type Context struct {
+	store datastore.Store
+	Cfg   *broadcast.Config
+	Bus   event.EventBus
+
+	// When nil, defaults to log.Println. Useful to plug in test implementation.
+	logOutput func(v ...any)
+}
+
+func (ctx *Context) Log(msg string, args ...interface{}) {
+	// If context has nil log output, use standard logger log.Println.
+	if ctx.logOutput == nil {
+		ctx.logOutput = log.Println
+	}
+	broadcast.LogForBroadcast(ctx.Cfg, ctx.logOutput, msg, args...)
+}
+
+type Manager interface {
+	Voltage(ctx *Context) (float64, error)
+	AlarmVoltage(ctx *Context) (float64, error)
+	IsUp(ctx *Context, mac string) (bool, error)
+	Start(ctx *Context)
+	Shutdown(ctx *Context)
+	Stop(ctx *Context)
+	PublishEventIfStatus(ctx *Context, e event.Event, status bool, mac int64, store datastore.Store, log func(format string, args ...interface{}), publish func(e event.Event))
+	Error(ctx *Context) (error, error)
+}

--- a/cmd/oceantv/hardware/manager.go
+++ b/cmd/oceantv/hardware/manager.go
@@ -39,6 +39,10 @@ type Context struct {
 	logOutput func(v ...any)
 }
 
+func NewContext(store datastore.Store, cfg *broadcast.Config, bus event.EventBus, log func(v ...any)) *Context {
+	return &Context{store, cfg, bus, log}
+}
+
 func (ctx *Context) Log(msg string, args ...interface{}) {
 	// If context has nil log output, use standard logger log.Println.
 	if ctx.logOutput == nil {

--- a/cmd/oceantv/hardware/revid.go
+++ b/cmd/oceantv/hardware/revid.go
@@ -1,0 +1,254 @@
+/*
+AUTHORS
+  Saxon Nelson-Milton <saxon@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This file is part of Ocean TV. Ocean TV is free software: you can
+  redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option)
+  any later version.
+
+  Ocean TV is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package hardware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/event"
+	"github.com/ausocean/cloud/datastore"
+	"github.com/ausocean/cloud/model"
+)
+
+type RevidCameraClient struct {
+	SetActionVars func(ctx context.Context, sKey int64, acts string, store datastore.Store, log func(string, ...interface{})) error
+}
+
+type ControllerError string
+
+const (
+	None            ControllerError = ""
+	LowVoltageAlarm ControllerError = "LowVoltage"
+)
+
+func (e ControllerError) Error() string {
+	return string(e)
+}
+
+func (e ControllerError) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+	if t, ok := target.(ControllerError); ok {
+		return e == t
+	}
+	return false
+}
+
+func (c *RevidCameraClient) Voltage(ctx *Context) (float64, error) {
+	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
+	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.Cfg.ControllerMAC, ctx.Cfg.BatteryVoltagePin)
+	if err != nil {
+		return 0, fmt.Errorf("could not get battery voltage sensor (%s.%s): %w", model.MacDecode(ctx.Cfg.ControllerMAC), ctx.Cfg.BatteryVoltagePin, err)
+	}
+
+	// Get current battery voltage.
+	voltage, err := model.GetSensorValue(context.Background(), ctx.store, sensor)
+	switch {
+	case errors.Is(err, datastore.ErrNoSuchEntity):
+		// We'll get this if the controller is off from low voltage, so just
+		// assume we have alarm voltage.
+		alarmVoltage, err := c.AlarmVoltage(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("could not get alarm voltage: %w", err)
+		}
+		return alarmVoltage, nil
+	case err != nil:
+		return 0, fmt.Errorf("could not get current battery voltage: %w", err)
+	}
+
+	return voltage, nil
+}
+
+func (c *RevidCameraClient) AlarmVoltage(ctx *Context) (float64, error) {
+	// Get AlarmVoltage variable; if the voltage is above this we expect the controller to be on.
+	// If the voltage is below this, we expect the controller to be off.
+	controllerMACHex := (&model.Device{Mac: ctx.Cfg.ControllerMAC}).Hex()
+	alarmVoltageVar, err := model.GetVariable(context.Background(), ctx.store, ctx.Cfg.SKey, controllerMACHex+".AlarmVoltage")
+	if err != nil {
+		return 0, fmt.Errorf("could not get alarm voltage variable: %w", err)
+	}
+	ctx.Log("got AlarmVoltage for %s: %s", controllerMACHex, alarmVoltageVar.Value)
+
+	uncalibratedAlarmVoltage, err := strconv.Atoi(alarmVoltageVar.Value)
+	if err != nil {
+		return 0, fmt.Errorf("could not convert uncalibrated alarm voltage from string: %w", err)
+	}
+
+	// Get battery voltage sensor, which we'll use to get scale factor and current voltage value.
+	batteryVoltagePin := ctx.Cfg.BatteryVoltagePin
+	if batteryVoltagePin == "" {
+		const defaultBatteryVoltagePin = "A4"
+		batteryVoltagePin = defaultBatteryVoltagePin
+	}
+	sensor, err := model.GetSensorV2(context.Background(), ctx.store, ctx.Cfg.ControllerMAC, batteryVoltagePin)
+	if err != nil {
+		return 0, fmt.Errorf("could not get battery voltage sensor: %w", err)
+	}
+
+	// Transform the alarm voltage to the actual voltage.
+	alarmVoltage, err := sensor.Transform(float64(uncalibratedAlarmVoltage))
+	if err != nil {
+		return 0, fmt.Errorf("could not transform alarm voltage: %w", err)
+	}
+
+	return alarmVoltage, nil
+}
+
+func (c *RevidCameraClient) IsUp(ctx *Context, mac string) (bool, error) {
+	deviceIsUp, err := model.DeviceIsUp(context.Background(), ctx.store, mac)
+	if err != nil {
+		return false, fmt.Errorf("could not get controller status: %w", err)
+	}
+	return deviceIsUp, nil
+}
+
+func (c *RevidCameraClient) Start(ctx *Context) {
+	err := extStart(context.Background(), ctx.store, ctx.Cfg, ctx.Log, c.SetActionVars)
+	if err != nil {
+		ctx.Log("could not start external hardware: %v", err)
+		ctx.Bus.Publish(event.HardwareStartFailed{Err: fmt.Errorf("external hardware start actions failed: %w", err)})
+		return
+	}
+}
+
+func (c *RevidCameraClient) Shutdown(ctx *Context) {
+	err := extShutdown(context.Background(), ctx.store, ctx.Cfg, ctx.Log, c.SetActionVars)
+	if err != nil {
+		ctx.Bus.Publish(event.HardwareShutdownFailed{Err: fmt.Errorf("could not perform shutdown actions: %w", err)})
+		return
+	}
+}
+
+func (c *RevidCameraClient) Stop(ctx *Context) {
+	err := extStop(context.Background(), ctx.store, ctx.Cfg, ctx.Log, c.SetActionVars)
+	if err != nil {
+		ctx.Log("could not stop external hardware: %v", err)
+		ctx.Bus.Publish(event.HardwareStopFailed{Err: fmt.Errorf("could not perform stop actions: %w", err)})
+		return
+	}
+}
+
+func (c *RevidCameraClient) PublishEventIfStatus(ctx *Context, e event.Event, status bool, mac int64, store datastore.Store, log func(string, ...interface{}), publish func(e event.Event)) {
+	if mac == 0 {
+		publish(event.InvalidConfiguration{errors.New("camera mac is empty")})
+		return
+	}
+	log("checking status of device with mac: %d", mac)
+	alive, err := model.DeviceIsUp(context.Background(), store, model.MacDecode(mac))
+	if err != nil {
+		log("could not get device status: %v", err)
+		return
+	}
+	log("status from DeviceIsUp check: %v", alive)
+	if alive == status {
+		publish(e)
+		return
+	}
+}
+
+func (c *RevidCameraClient) Error(ctx *Context) (error, error) {
+	controllerMACHex := (&model.Device{Mac: ctx.Cfg.ControllerMAC}).Hex()
+	devErr, err := model.GetVariable(context.Background(), ctx.store, ctx.Cfg.SKey, controllerMACHex+".error")
+	if err != nil {
+		return nil, fmt.Errorf("could not get controller error variable: %w", err)
+	}
+	return ControllerError(devErr.Value), nil
+}
+
+// extStart uses the OnActions in the provided broadcast config to perform
+// external streaming hardware startup. In addition, the RTMP key is obtained
+// from the broadcast's associated stream object and used to set the devices
+// RTMPKey variable.
+func extStart(
+	ctx context.Context,
+	store datastore.Store,
+	cfg *broadcast.Config,
+	log func(string, ...interface{}),
+	setActionVars func(ctx context.Context, sKey int64, acts string, store datastore.Store, log func(string, ...interface{})) error,
+) error {
+	if cfg.OnActions == "" {
+		return nil
+	}
+
+	onActions := cfg.OnActions + "," + cfg.RTMPVar + "=" + broadcast.RTMPDestinationAddress + cfg.RTMPKey
+	err := setActionVars(ctx, cfg.SKey, onActions, store, log)
+	if err != nil {
+		return fmt.Errorf("could not set device variables required to start stream: %w", err)
+	}
+
+	return nil
+}
+
+// errNoShutdownActions represents no shutdown actions being registered for the broadcast.
+var errNoShutdownActions = errors.New("no shutdown actions provided")
+
+// SkipAction is the placeholder used to represent that the action step should be skipped.
+const SkipAction = "skip"
+
+func extShutdown(
+	ctx context.Context,
+	store datastore.Store,
+	cfg *broadcast.Config,
+	log func(string, ...interface{}),
+	setActionVars func(ctx context.Context, sKey int64, acts string, store datastore.Store, log func(string, ...interface{})) error,
+) error {
+	if cfg.ShutdownActions == SkipAction {
+		return broadcast.WarnSkipShutdown
+	}
+	if cfg.ShutdownActions == "" {
+		return errNoShutdownActions
+	}
+
+	err := setActionVars(ctx, cfg.SKey, cfg.ShutdownActions, store, log)
+	if err != nil {
+		return fmt.Errorf("could not set device variables to end stream: %w", err)
+	}
+
+	return nil
+}
+
+// extStop uses the OffActions in the provided broadcast config to perform
+// external streaming hardware shutdown.
+func extStop(
+	ctx context.Context,
+	store datastore.Store,
+	cfg *broadcast.Config,
+	log func(string, ...interface{}),
+	setActionVars func(ctx context.Context, sKey int64, acts string, store datastore.Store, log func(string, ...interface{})) error,
+) error {
+	if cfg.OffActions == "" {
+		return nil
+	}
+
+	err := setActionVars(ctx, cfg.SKey, cfg.OffActions, store, log)
+	if err != nil {
+		return fmt.Errorf("could not set device variables to end stream: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/oceantv/hardware/revid.go
+++ b/cmd/oceantv/hardware/revid.go
@@ -204,8 +204,8 @@ func extStart(
 	return nil
 }
 
-// errNoShutdownActions represents no shutdown actions being registered for the broadcast.
-var errNoShutdownActions = errors.New("no shutdown actions provided")
+// ErrNoShutdownActions represents no shutdown actions being registered for the broadcast.
+var ErrNoShutdownActions = errors.New("no shutdown actions provided")
 
 // SkipAction is the placeholder used to represent that the action step should be skipped.
 const SkipAction = "skip"
@@ -221,7 +221,7 @@ func extShutdown(
 		return broadcast.WarnSkipShutdown
 	}
 	if cfg.ShutdownActions == "" {
-		return errNoShutdownActions
+		return ErrNoShutdownActions
 	}
 
 	err := setActionVars(ctx, cfg.SKey, cfg.ShutdownActions, store, log)

--- a/cmd/oceantv/state_hw_powering_off.go
+++ b/cmd/oceantv/state_hw_powering_off.go
@@ -22,7 +22,7 @@ func newHardwarePoweringOff(ctx *broadcastContext) *hardwarePoweringOff {
 
 func (s *hardwarePoweringOff) enter() {
 	s.LastEntered = time.Now()
-	s.hardware.Stop(s.broadcastContext)
+	s.hardware.Stop(s.broadcastContext.newHWContext())
 }
 
 func (s *hardwarePoweringOff) exit() {}

--- a/cmd/oceantv/state_hw_powering_off.go
+++ b/cmd/oceantv/state_hw_powering_off.go
@@ -22,7 +22,7 @@ func newHardwarePoweringOff(ctx *broadcastContext) *hardwarePoweringOff {
 
 func (s *hardwarePoweringOff) enter() {
 	s.LastEntered = time.Now()
-	s.hardware.stop(s.broadcastContext)
+	s.hardware.Stop(s.broadcastContext)
 }
 
 func (s *hardwarePoweringOff) exit() {}

--- a/cmd/oceantv/state_hw_restarting.go
+++ b/cmd/oceantv/state_hw_restarting.go
@@ -176,7 +176,7 @@ func (s *hardwareRestarting) handleHardwareShutdownFailedEvent(e event.HardwareS
 }
 
 func (s *hardwareRestarting) cameraIsReporting() bool {
-	up, err := s.hardware.isUp(s.broadcastContext, model.MacDecode(s.cfg.CameraMac))
+	up, err := s.hardware.IsUp(s.broadcastContext.newHWContext(), model.MacDecode(s.cfg.CameraMac))
 	if err != nil {
 		s.bus.Publish(event.InvalidConfiguration{fmt.Errorf("could not get camera reporting status: %w", err)})
 		return false

--- a/cmd/oceantv/state_hw_shutting_down.go
+++ b/cmd/oceantv/state_hw_shutting_down.go
@@ -22,7 +22,7 @@ func newHardwareShuttingDown(ctx *broadcastContext) *hardwareShuttingDown {
 
 func (s *hardwareShuttingDown) enter() {
 	s.LastEntered = time.Now()
-	s.hardware.shutdown(s.broadcastContext)
+	s.hardware.Shutdown(s.broadcastContext.newHWContext())
 }
 
 func (s *hardwareShuttingDown) exit() {}

--- a/cmd/oceantv/state_hw_starting.go
+++ b/cmd/oceantv/state_hw_starting.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/event"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/model"
 )
 
@@ -32,12 +33,12 @@ func (s *hardwareStarting) enter() {
 	s.LastEntered = time.Now()
 	// A MAC of 0 indicates it is invalid or unset, proceed with starting the camera.
 	if s.cfg.ControllerMAC == 0 {
-		s.hardware.start(s.broadcastContext)
+		s.hardware.Start(s.broadcastContext.newHWContext())
 		return
 	}
 
 	// The first check for any known hardware error states.
-	hwErr, err := s.hardware.error(s.broadcastContext)
+	hwErr, err := s.hardware.Error(s.broadcastContext.newHWContext())
 	if err != nil {
 		errWrapped := fmt.Errorf("could not get hardware error state: %w", err)
 		s.log(errWrapped.Error())
@@ -49,11 +50,11 @@ func (s *hardwareStarting) enter() {
 	}
 
 	switch {
-	case errors.Is(hwErr, LowVoltageAlarm):
+	case errors.Is(hwErr, hardware.LowVoltageAlarm):
 		s.log("controller voltage is low, waiting for recovery before starting")
 		s.bus.Publish(event.LowVoltage{})
 		return
-	case errors.Is(hwErr, None):
+	case errors.Is(hwErr, hardware.None):
 		// Continue other checks, this is good.
 	case hwErr != nil:
 		errWrapped := fmt.Errorf("unhandled controller hardware error: %w", hwErr)
@@ -65,7 +66,7 @@ func (s *hardwareStarting) enter() {
 		// we have a controller that doesn't have the latest firmware.
 	}
 
-	voltage, err := s.hardware.voltage(s.broadcastContext)
+	voltage, err := s.hardware.Voltage(s.broadcastContext.newHWContext())
 	if err != nil {
 		errWrapped := fmt.Errorf("could not get hardware voltage: %w", err)
 		s.log(errWrapped.Error())
@@ -73,7 +74,7 @@ func (s *hardwareStarting) enter() {
 		return
 	}
 
-	alarmVoltage, err := s.hardware.alarmVoltage(s.broadcastContext)
+	alarmVoltage, err := s.hardware.AlarmVoltage(s.broadcastContext.newHWContext())
 	if err != nil {
 		errWrapped := fmt.Errorf("could not get alarm voltage: %w", err)
 		s.log(errWrapped.Error())
@@ -81,7 +82,7 @@ func (s *hardwareStarting) enter() {
 		return
 	}
 
-	controllerIsOn, err := s.hardware.isUp(s.broadcastContext, model.MacDecode(s.cfg.ControllerMAC))
+	controllerIsOn, err := s.hardware.IsUp(s.broadcastContext.newHWContext(), model.MacDecode(s.cfg.ControllerMAC))
 	if err != nil {
 		errWrapped := fmt.Errorf("could not get controller status: %w", err)
 		s.log(errWrapped.Error())
@@ -117,7 +118,7 @@ func (s *hardwareStarting) enter() {
 
 	// Controller is reporting and we're above streaming voltage, let's power
 	// on the hardware.
-	s.hardware.start(s.broadcastContext)
+	s.hardware.Start(s.broadcastContext.newHWContext())
 }
 
 func (s *hardwareStarting) exit() {}

--- a/cmd/oceantv/state_hw_stopping.go
+++ b/cmd/oceantv/state_hw_stopping.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
 	"github.com/ausocean/cloud/cmd/oceantv/registry"
 	"github.com/ausocean/cloud/model"
@@ -173,7 +174,7 @@ func (s *hardwareStopping) handleHardwareShutdownFailedEvent(e event.HardwareShu
 		// when shutdown is skipped.
 		if errors.Is(e, broadcast.WarnSkipShutdown) {
 			s.log("skipping shutdown: %v:", e.Error)
-		} else if errors.Is(e, errNoShutdownActions) {
+		} else if errors.Is(e, hardware.ErrNoShutdownActions) {
 			s.logAndNotify(notifier.KindHardware, "shutdown skipped: %v", e.Error())
 		}
 		s.transition()
@@ -192,7 +193,7 @@ func (s *hardwareStopping) handleHardwarePowerOffFailedEvent(e event.HardwarePow
 }
 
 func (s *hardwareStopping) cameraIsReporting() bool {
-	up, err := s.hardware.isUp(s.broadcastContext, model.MacDecode(s.cfg.CameraMac))
+	up, err := s.hardware.IsUp(s.broadcastContext.newHWContext(), model.MacDecode(s.cfg.CameraMac))
 	if err != nil {
 		s.bus.Publish(event.InvalidConfiguration{fmt.Errorf("could not get camera reporting status: %w", err)})
 		return false

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
+	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
 	"github.com/ausocean/cloud/cmd/oceantv/yt"
@@ -49,7 +50,7 @@ func withForwardingService(fs forwarding.Service) broadcastSystemOption {
 	}
 }
 
-func withHardwareManager(hm hardwareManager) broadcastSystemOption {
+func withHardwareManager(hm hardware.Manager) broadcastSystemOption {
 	return func(bs *broadcastSystem) error {
 		bs.ctx.hardware = hm
 		return nil
@@ -142,7 +143,7 @@ func newBroadcastSystem(ctx Ctx, store Store, cfg *Cfg, logOutput func(v ...any)
 	bus := event.NewBasicEventBus(ctx, storeEventsAfterCtx, log)
 
 	// This context will be used by the state machines for access to our bits and bobs.
-	broadcastContext := &broadcastContext{cfg, man, store, svc, forwarding.NewVidforwardService(log, broadcastByName), bus, &revidCameraClient{}, logOutput, nil}
+	broadcastContext := &broadcastContext{cfg, man, store, svc, forwarding.NewVidforwardService(log, broadcastByName), bus, &hardware.RevidCameraClient{}, logOutput, nil}
 
 	// Subscribe event handler that notifies on events that implement errorEvent.
 	bus.Subscribe(func(e event.Event) error {


### PR DESCRIPTION
This change creates a hardware package where the hardware manager interface and the revid camera client now live. This also creates a new type of context specifically for the hardware package, and a conversion from the broadcast context to the hardware context.

requires #785-#790