### PR TITLE
dsadmin: add annotation end time migration

### DIFF
--- a/cmd/dsadmin/entities.go
+++ b/cmd/dsadmin/entities.go
@@ -480,3 +480,43 @@ type Species struct {
 func (vs *Species) Copy(dst datastore.Entity) (datastore.Entity, error) {
 	return datastore.CopyEntity(vs, dst)
 }
+
+// Kind of entity to store / fetch from the datastore.
+const TypeAnnotation = "Annotation"
+
+// BoundingBox is a rectangle enclosing something interesting in a video.
+// It is represented using two x y coordinates, top left corner and bottom right corner of the rectangle.
+type BoundingBox struct {
+	X1 float32 `json:"x1" example:"10.00`
+	X2 float32 `json:"x2" example:"50.00"`
+	Y1 float32 `json:"y1" example:"25.00"`
+	Y2 float32 `json:"y2" example:"75.00"`
+}
+
+// KeyPoint is a bounding box and time within the video.
+type KeyPoint struct {
+	BoundingBox BoundingBox `json:"box"`
+	Time        int64       `json:"time"`                 // Time of the keypoint in ms.
+	Confidence  float32     `json:"confidence,omitempty"` // Confidence of the keypoint (optional).
+}
+
+// An Annotation holds information about observations at a particular moment and region within a video stream.
+type Annotation struct {
+	SubFeedID int64
+	StartTime int64      // for indexing purposes.
+	EndTime   int64      // for indexing purposes.
+	Keypoints []KeyPoint `datastore:",noindex"`
+	CreatedBy int64
+
+	// User ID and Species ID are stored separately, so we can query for annotations made
+	// by a particular user or with a particular species. NOTE: a species ID may appear
+	// multiple times if it is identified by many users.
+	IdentificationUserID    []int64
+	IdentificationSpeciesID []int64
+	datastore.NoCache
+}
+
+// Implements Copy from the Entity interface.
+func (an *Annotation) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	return datastore.CopyEntity(an, dst)
+}

--- a/cmd/dsadmin/main.go
+++ b/cmd/dsadmin/main.go
@@ -131,6 +131,7 @@ func main() {
 	datastore.RegisterEntity(typeSignal, func() datastore.Entity { return new(Signal) })
 	datastore.RegisterEntity(TypeSpecies, func() datastore.Entity { return new(Species) })
 	datastore.RegisterEntity(typeSpeciesV2, func() datastore.Entity { return new(Species) })
+	datastore.RegisterEntity(TypeAnnotation, func() datastore.Entity { return new(Annotation) })
 
 	var store, store2 datastore.Store
 	var err error
@@ -292,6 +293,11 @@ func main() {
 			err = migrateSpecies(store)
 			if err != nil {
 				log.Fatalf("migrateSpecies failed with error: %v", err)
+			}
+		case TypeAnnotation:
+			err = migrateAnnotations(store)
+			if err != nil {
+				log.Fatalf("migrateAnnotations failed with error: %v", err)
 			}
 		default:
 			log.Fatalf("invalid kind %s", kind)
@@ -1202,5 +1208,43 @@ func migrateSpeciesRarity(store datastore.Store) error {
 		}
 	}
 	fmt.Printf("Migration complete. Total migrated: %d species\n", n)
+	return nil
+}
+
+// migrateAnnotations migrates Annotation entities to add/update EndTime.
+func migrateAnnotations(store datastore.Store) error {
+	ctx := context.Background()
+
+	q := store.NewQuery(TypeAnnotation, true)
+	keys, err := store.GetAll(ctx, q, nil)
+	if err != nil {
+		return err
+	}
+	total := len(keys)
+	fmt.Printf("Found %d Annotation entities to migrate. Starting migration...\n", total)
+
+	n := 0
+	for _, k := range keys {
+		a := new(Annotation)
+		err := store.Get(ctx, k, a)
+		if err != nil {
+			return err
+		}
+
+		if len(a.Keypoints) > 0 {
+			a.EndTime = a.Keypoints[len(a.Keypoints)-1].Time
+		}
+
+		_, err = store.Put(ctx, k, a)
+		if err != nil {
+			return err
+		}
+		n += 1
+
+		if n%50 == 0 {
+			fmt.Printf("Progress: Migrated %d / %d annotations...\n", n, total)
+		}
+	}
+	fmt.Printf("Migration complete. Total migrated: %d annotations\n", n)
 	return nil
 }


### PR DESCRIPTION

This change adds a migration that adds the end time field to all annotation entites. This is necessary for https://github.com/ausocean/ausoceantv/pull/359 to work properly.
