### PR TITLE
Bench: Move index handler to skey prefixed endpoint

### DIFF
--- a/cmd/oceanbench/auth.go
+++ b/cmd/oceanbench/auth.go
@@ -26,13 +26,17 @@ LICENSE
 package main
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
 
 	"github.com/ausocean/cloud/backend"
+	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/gauth"
+	"github.com/ausocean/cloud/model"
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -121,6 +125,46 @@ func profileData(profile *gauth.Profile) (int64, string) {
 		return key, ""
 	}
 	return key, p[1]
+}
+
+// getDefaultSkey returns the default site key associated with a user's email. This
+// is stored in a variable scoped to the users email with '@' and '.' replaced with '_'.
+//
+// If no default site key yet exists, one will be automatically assigned based on the
+// user's current sites.
+//
+// A site key of `-1` will be returned on an error.
+// TODO: Make this configurable.
+func getDefaultSkey(ctx context.Context, profile *gauth.Profile) (int64, error) {
+	if profile == nil {
+		return -1, errors.New("no profile supplied")
+	}
+	scope := strings.ReplaceAll(profile.Email, "@", "_")
+	scope = strings.ReplaceAll(scope, ".", "_")
+	name := scope + ".defaultSkey"
+	v, err := model.GetVariable(ctx, settingsStore, -1, name)
+	if errors.Is(err, datastore.ErrNoSuchEntity) {
+		// Choose a default site from the user's current sites.
+		users, err := model.GetUsers(ctx, settingsStore, profile.Email)
+		if err != nil {
+			return -1, fmt.Errorf("failed to get users for email (%s): %v", profile.Email, err)
+		}
+		err = model.PutVariable(ctx, settingsStore, -1, name, fmt.Sprintf("%d", users[0].Skey))
+		if err != nil {
+			// This isn't considered an error, as the caller is still returned the default site,
+			// but we log it anyway as this likely indicates a systemic issue.
+			log.Printf("failed to put default site: %v", err)
+		}
+		return users[0].Skey, nil
+	} else if err != nil {
+		return -1, fmt.Errorf("unable to get default skey var: %v", err)
+	}
+
+	skey, err := strconv.ParseInt(v.Value, 10, 64)
+	if err != nil {
+		return -1, fmt.Errorf("unable to parse skey from default skey var (%s): %v", v.Value, err)
+	}
+	return skey, nil
 }
 
 // requestSiteData gets the site key from the request URL if present,

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -83,6 +83,10 @@ const (
 )
 
 const (
+	skeyParamKey = "skey" // Parameter key used for site key in url path.
+)
+
+const (
 	projectID          = "oceanbench"
 	oauthClientID      = "802166617157-v67emnahdpvfuc13ijiqb7qm3a7sf45b.apps.googleusercontent.com"
 	oauthMaxAge        = 60 * 60 * 24 * 7 // 7 days
@@ -298,6 +302,11 @@ func main() {
 	app.All("/data/*", dataHandler)
 	app.All("/throughputs", throughputsHandler)
 	app.All("/logs", logPageHandler)
+
+	// Handle paths with prefixed site keys.
+	app.Group("/:"+skeyParamKey).
+		All("/*", indexHandler)
+
 	app.All("/*", indexHandler)
 
 	if standalone {
@@ -449,13 +458,12 @@ func setupLocal(ctx context.Context, store datastore.Store) error {
 
 // indexHandler handles requests for the home page and unimplemented pages.
 // Signed-in users are presented with a list of their sites.
+//
+// Requests without signed in user are redirected to "/" and rendered.
+// Requests to / are redirected with prefixed default skey
+// Invalid requests are redirected to index with prefixed default skey
 func indexHandler(c *fiber.Ctx) error {
 	logRequest(c)
-
-	if c.Path() != "/" {
-		// Redirect all invalid URLs to the root homepage.
-		return c.Redirect("/", fiber.StatusFound)
-	}
 
 	profile, err := getProfile(c)
 	data := commonData{
@@ -466,8 +474,28 @@ func indexHandler(c *fiber.Ctx) error {
 		if err != gauth.TokenNotFound {
 			log.Printf("authentication error: %v", err)
 		}
+		if c.Path() != "/" {
+			// Clear the URL if not the root URL.
+			return c.Redirect("/", fiber.StatusSeeOther)
+		}
 		writeTemplate(c, "index.html", &data, "")
 		return nil
+	}
+
+	skey, err := c.ParamsInt(skeyParamKey)
+	if err != nil {
+		// Get the default skey and redirect.
+		skey, err := getDefaultSkey(c.UserContext(), profile)
+		if err != nil {
+			// This should never happen, and if it does we likely can't recover.
+			log.Panicf("unable to get default skey: %v", err)
+		}
+		return c.Redirect(fmt.Sprintf("/%d", skey), fiber.StatusSeeOther)
+	}
+
+	if c.Params("*") != "" {
+		// Redirect to /:skey
+		return c.Redirect(fmt.Sprintf("/%d", skey), fiber.StatusSeeOther)
 	}
 
 	writeTemplate(c, "index.html", &data, "")


### PR DESCRIPTION
This moves the index handler to using the prefixed skey.

This change also includes a new get default key method which stores a default key in the datastore. 