### PR TITLE
Bench: Prefix pages in nav menu

### DIFF
--- a/cmd/oceanbench/admin.go
+++ b/cmd/oceanbench/admin.go
@@ -93,7 +93,7 @@ func adminHandler(c *fiber.Ctx) error {
 		}
 		data := adminData{
 			commonData: commonData{
-				Pages:   pages("admin"),
+				Pages:   pages(c, "admin"),
 				Profile: p,
 			},
 		}
@@ -412,7 +412,7 @@ func writeAdmin(c *fiber.Ctx, p *gauth.Profile, err error) {
 
 	data := adminData{
 		commonData: commonData{
-			Pages:   pages("site"),
+			Pages:   pages(c, "site"),
 			Profile: p,
 		},
 		Skey: skey,
@@ -476,7 +476,7 @@ func utilsHandler(c *fiber.Ctx, p *gauth.Profile) error {
 
 	data := utilsData{
 		commonData: commonData{
-			Pages:   pages("utils"),
+			Pages:   pages(c, "utils"),
 			Profile: p,
 		},
 		Devices: devices,

--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -206,7 +206,7 @@ func broadcastHandler(c *fiber.Ctx) error {
 
 	req := broadcastRequest{
 		commonData: commonData{
-			Pages: pages("broadcast"),
+			Pages: pages(c, "broadcast"),
 		},
 		CurrentBroadcast: BroadcastConfig{
 			UUID:                  c.FormValue("broadcast-uuid"),

--- a/cmd/oceanbench/device-log.go
+++ b/cmd/oceanbench/device-log.go
@@ -114,7 +114,7 @@ func logPageHandler(c *fiber.Ctx) error {
 	skey, _ := requestSiteData(c, profile)
 	data := adminData{
 		commonData: commonData{
-			Pages:   pages("logs"),
+			Pages:   pages(c, "logs"),
 			Profile: profile,
 		},
 		Skey: skey,

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -467,7 +467,7 @@ func indexHandler(c *fiber.Ctx) error {
 
 	profile, err := getProfile(c)
 	data := commonData{
-		Pages:   pages("home"),
+		Pages:   pages(c, "home"),
 		Profile: profile,
 	}
 	if err != nil {
@@ -635,6 +635,24 @@ func hasPermission(ctx context.Context, p *gauth.Profile, mid, perm int64) (bool
 	return perm&user.Perm != 0, nil
 }
 
+// getCurrentSkey returns the current site key. This goes in order of:
+// 1. From the URL.
+// 2. The user's default site key.
+func getCurrentSkey(c *fiber.Ctx, profile *gauth.Profile) (int64, error) {
+	// First try to get from the URL param.
+	var skey int64
+	skFromParam := c.Params(skeyParamKey)
+	skey, err := strconv.ParseInt(skFromParam, 10, 64)
+	if err != nil {
+		log.Printf("unable to get skey from URL param: %v", err)
+		skey, err = getDefaultSkey(c.UserContext(), profile)
+		if err != nil {
+			return -1, fmt.Errorf("unable to get default skey: %v", err)
+		}
+	}
+	return skey, nil
+}
+
 // writeTemplate writes the given template with the supplied data,
 // populating some common properties.
 func writeTemplate(c *fiber.Ctx, name string, data interface{}, msg string) error {
@@ -691,11 +709,12 @@ func writeTemplate(c *fiber.Ctx, name string, data interface{}, msg string) erro
 }
 
 // pages returns a copy of the app's pages, selecting the one that matches selected.
-func pages(selected string) []page {
+func pages(c *fiber.Ctx, selected string) []page {
+	prefix := "/" + c.Params(skeyParamKey)
 	pages := []page{
 		{
 			Name: "home",
-			URL:  "/",
+			URL:  prefix + "/",
 			Perm: model.ReadPermission,
 		},
 		{

--- a/cmd/oceanbench/media_manager.go
+++ b/cmd/oceanbench/media_manager.go
@@ -30,7 +30,7 @@ import (
 
 // mediaManagerHandler handles media manager page requests.
 func mediaManagerHandler(c *fiber.Ctx, profile *gauth.Profile) error {
-	data := monitorData{commonData: commonData{Pages: pages("media manager"), Profile: profile}}
+	data := monitorData{commonData: commonData{Pages: pages(c, "media manager"), Profile: profile}}
 	writeTemplate(c, "media-manager.html", &data, "")
 	return nil
 }

--- a/cmd/oceanbench/mission_control.go
+++ b/cmd/oceanbench/mission_control.go
@@ -33,7 +33,7 @@ import (
 
 // missionControlHandler handles mission control page requests.
 func missionControlHandler(c *fiber.Ctx, profile *gauth.Profile) error {
-	data := monitorData{commonData: commonData{Pages: pages("mission control"), Profile: profile}}
+	data := monitorData{commonData: commonData{Pages: pages(c, "mission control"), Profile: profile}}
 	writeTemplate(c, "mission-control.html", &data, "")
 	return nil
 }

--- a/cmd/oceanbench/monitor.go
+++ b/cmd/oceanbench/monitor.go
@@ -102,7 +102,7 @@ func monitorHandler(c *fiber.Ctx) error {
 		return c.Redirect("/", fiber.StatusUnauthorized)
 	}
 
-	data := monitorData{commonData: commonData{Pages: pages("monitor"), Profile: profile}}
+	data := monitorData{commonData: commonData{Pages: pages(c, "monitor"), Profile: profile}}
 
 	ctx := c.UserContext()
 

--- a/cmd/oceanbench/sandbox.go
+++ b/cmd/oceanbench/sandbox.go
@@ -55,7 +55,7 @@ func sandboxHandler(c *fiber.Ctx) error {
 
 	data := sandboxData{
 		commonData: commonData{
-			Pages:   pages("home"),
+			Pages:   pages(c, "home"),
 			Profile: profile,
 		},
 	}
@@ -233,7 +233,7 @@ type configureData struct {
 func writeConfigure(c *fiber.Ctx, profile *gauth.Profile) error {
 	data := configureData{
 		commonData: commonData{
-			Pages: pages("devices"),
+			Pages: pages(c, "devices"),
 		}}
 	ctx := c.UserContext()
 	var err error

--- a/cmd/oceanbench/search.go
+++ b/cmd/oceanbench/search.go
@@ -137,7 +137,7 @@ func searchHandler(c *fiber.Ctx) error {
 	// searchData struct is used by the template.
 	sd := searchData{
 		commonData: commonData{
-			Pages:      pages("search"),
+			Pages:      pages(c, "search"),
 			Standalone: standalone,
 		},
 		SKey:       skey,

--- a/cmd/oceanbench/set.go
+++ b/cmd/oceanbench/set.go
@@ -112,7 +112,7 @@ func writeDevices(c *fiber.Ctx, msg string, args ...interface{}) error {
 
 	data := devicesData{
 		commonData: commonData{
-			Pages: pages("devices"),
+			Pages: pages(c, "devices"),
 		},
 		Mac:        c.FormValue("ma"),
 		Device:     &model.Device{Enabled: true},
@@ -765,7 +765,7 @@ func writeCrons(c *fiber.Ctx, msg string) error {
 
 	data := dataFields{
 		commonData: commonData{
-			Pages: pages("crons"),
+			Pages: pages(c, "crons"),
 			Msg:   msg,
 		},
 		Timezone: site.Timezone,

--- a/cmd/oceanbench/tv_overview.go
+++ b/cmd/oceanbench/tv_overview.go
@@ -10,7 +10,7 @@ import "github.com/gofiber/fiber/v2"
 func tvOverviewHandler(c *fiber.Ctx) error {
 	data := &commonData{
 		// This page is not accessible from the nav-menu.
-		Pages: pages(""),
+		Pages: pages(c, ""),
 	}
 
 	// Write the template with the minimum data, and load the

--- a/cmd/oceanbench/video.go
+++ b/cmd/oceanbench/video.go
@@ -190,7 +190,7 @@ func uploadHandler(c *fiber.Ctx) error {
 	profile, err := getProfile(c)
 	data := uploadData{
 		commonData: commonData{
-			Pages:   pages("upload"),
+			Pages:   pages(c, "upload"),
 			Profile: profile,
 		},
 		MID: 0,
@@ -338,7 +338,7 @@ func playHandler(c *fiber.Ctx) error {
 
 	data := playData{
 		commonData: commonData{
-			Pages: pages("play"),
+			Pages: pages(c, "play"),
 		},
 		MID: mid,
 	}


### PR DESCRIPTION
This change adds a skey prefix to the nav menu. Currently this only happens for sites that are ready to handle this.