### PR TITLE
Bench: prefix superadmin tools with skey

### DIFF
--- a/cmd/oceanbench/admin.go
+++ b/cmd/oceanbench/admin.go
@@ -113,7 +113,7 @@ func adminHandler(c *fiber.Ctx) error {
 	// Require POST method, except for admin landing pages.
 	if c.Method() != "POST" {
 		switch c.Path() {
-		case "/admin/missioncontrol", "/admin/mediamanager", "/admin/utils":
+		case "/admin/utils":
 			// Okay.
 		default:
 			return c.Redirect("/", fiber.StatusMethodNotAllowed)
@@ -142,18 +142,6 @@ func adminHandler(c *fiber.Ctx) error {
 
 	case "/:skey/admin/user/delete":
 		return deleteUser(c, p)
-
-	case "/admin/missioncontrol":
-		if !isSuperAdmin(p.Email) {
-			return c.Redirect("/", fiber.StatusUnauthorized)
-		}
-		return missionControlHandler(c, p)
-
-	case "/admin/mediamanager":
-		if !isSuperAdmin(p.Email) {
-			return c.Redirect("/", fiber.StatusUnauthorized)
-		}
-		return mediaManagerHandler(c, p)
 
 	case "/admin/utils":
 		return utilsHandler(c, p)

--- a/cmd/oceanbench/main.go
+++ b/cmd/oceanbench/main.go
@@ -273,9 +273,6 @@ func main() {
 	app.All("/oauth2callback", oauthCallbackHandler)
 	app.All("/live/:broadcastName", liveHandler)
 	app.All("/admin/site/add", adminHandler)
-	app.All("/admin/tv-overview", tvOverviewHandler)
-	app.All("/admin/missioncontrol", adminHandler)
-	app.All("/admin/mediamanager", adminHandler)
 	app.All("/admin/sandbox/configure", configDevicesHandler)
 	app.All("/admin/sandbox", sandboxHandler)
 	app.All("/admin/utils", adminHandler)
@@ -313,6 +310,13 @@ func main() {
 
 		// Admin/Broadcast.
 		All("/admin/broadcast", broadcastHandler).
+
+		// Superadmin tools.
+		Get("/admin/tv-overview", tvOverviewHandler).
+		Get("/admin/missioncontrol", missionControlHandler).
+		All("/admin/mediamanager", mediaManagerHandler).
+
+		// Index.
 		All("/*", indexHandler)
 
 	app.All("/*", indexHandler)
@@ -781,13 +785,13 @@ func pages(c *fiber.Ctx, selected string) []page {
 		},
 		{
 			Name:  "mission control",
-			URL:   "/admin/missioncontrol",
+			URL:   prefix + "/admin/missioncontrol",
 			Level: 1,
 			Perm:  model.AdminPermission,
 		},
 		{
 			Name:  "media manager",
-			URL:   "/admin/mediamanager",
+			URL:   prefix + "/admin/mediamanager",
 			Level: 1,
 			Perm:  model.AdminPermission,
 		},

--- a/cmd/oceanbench/media_manager.go
+++ b/cmd/oceanbench/media_manager.go
@@ -24,13 +24,30 @@ LICENSE
 package main
 
 import (
+	"errors"
+	"log"
+
 	"github.com/ausocean/cloud/gauth"
 	"github.com/gofiber/fiber/v2"
 )
 
 // mediaManagerHandler handles media manager page requests.
-func mediaManagerHandler(c *fiber.Ctx, profile *gauth.Profile) error {
-	data := monitorData{commonData: commonData{Pages: pages(c, "media manager"), Profile: profile}}
+func mediaManagerHandler(c *fiber.Ctx) error {
+	logRequest(c)
+
+	p, err := getProfile(c)
+	switch {
+	case err != nil && !errors.Is(err, gauth.TokenNotFound):
+		log.Printf("authentication error: %v", err)
+		fallthrough
+	case err != nil:
+		return c.Redirect("/", fiber.StatusUnauthorized)
+	}
+
+	if !isSuperAdmin(p.Email) {
+		return c.Redirect("/", fiber.StatusUnauthorized)
+	}
+	data := monitorData{commonData: commonData{Pages: pages(c, "media manager"), Profile: p}}
 	writeTemplate(c, "media-manager.html", &data, "")
 	return nil
 }

--- a/cmd/oceanbench/mission_control.go
+++ b/cmd/oceanbench/mission_control.go
@@ -27,13 +27,31 @@ LICENSE
 package main
 
 import (
+	"errors"
+	"log"
+
 	"github.com/ausocean/cloud/gauth"
 	"github.com/gofiber/fiber/v2"
 )
 
 // missionControlHandler handles mission control page requests.
-func missionControlHandler(c *fiber.Ctx, profile *gauth.Profile) error {
-	data := monitorData{commonData: commonData{Pages: pages(c, "mission control"), Profile: profile}}
+func missionControlHandler(c *fiber.Ctx) error {
+	logRequest(c)
+
+	p, err := getProfile(c)
+	switch {
+	case err != nil && !errors.Is(err, gauth.TokenNotFound):
+		log.Printf("authentication error: %v", err)
+		fallthrough
+	case err != nil:
+		return c.Redirect("/", fiber.StatusUnauthorized)
+	}
+
+	if !isSuperAdmin(p.Email) {
+		return c.Redirect("/", fiber.StatusUnauthorized)
+	}
+
+	data := monitorData{commonData: commonData{Pages: pages(c, "mission control"), Profile: p}}
 	writeTemplate(c, "mission-control.html", &data, "")
 	return nil
 }

--- a/cmd/oceanbench/ts/site-footer.ts
+++ b/cmd/oceanbench/ts/site-footer.ts
@@ -48,7 +48,7 @@ export class SiteFooter extends TailwindElement() {
             ? html`
                 <div class="mt-4">
                   <a
-                    href="/admin/tv-overview"
+                    href="/default/admin/tv-overview"
                     class="inline-flex items-center px-3 py-1 bg-neutral-200 hover:bg-neutral-300 rounded text-xs font-medium transition-colors text-neutral-700 hover:text-neutral-900 no-underline"
                   >
                     TV Overview

--- a/cmd/oceanbench/tv_overview.go
+++ b/cmd/oceanbench/tv_overview.go
@@ -1,6 +1,12 @@
 package main
 
-import "github.com/gofiber/fiber/v2"
+import (
+	"errors"
+	"log"
+
+	"github.com/ausocean/cloud/gauth"
+	"github.com/gofiber/fiber/v2"
+)
 
 // tvOverviewHandler handles request to the tv overview page. This page lets the user
 // see an overview of different broadcasts which can be selected and setups saved. The
@@ -8,6 +14,21 @@ import "github.com/gofiber/fiber/v2"
 // is saved in a variable scoped to their username (email before the host, stripped of
 // any fullstops, user.name@ausocean.org -> username).
 func tvOverviewHandler(c *fiber.Ctx) error {
+	logRequest(c)
+
+	p, err := getProfile(c)
+	switch {
+	case err != nil && !errors.Is(err, gauth.TokenNotFound):
+		log.Printf("authentication error: %v", err)
+		fallthrough
+	case err != nil:
+		return c.Redirect("/", fiber.StatusUnauthorized)
+	}
+
+	if !isSuperAdmin(p.Email) {
+		return c.Redirect("/", fiber.StatusUnauthorized)
+	}
+
 	data := &commonData{
 		// This page is not accessible from the nav-menu.
 		Pages: pages(c, ""),


### PR DESCRIPTION
This change prefixes superadmin tools with skey, and manages authentication directly in the handlers, rather than through the catch all admin handler, simplifying the flow