### PR TITLE
oceantv: refactor yt

### DIFF
--- a/cmd/oceanbench/broadcast.go
+++ b/cmd/oceanbench/broadcast.go
@@ -40,15 +40,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/gauth"
 	"github.com/ausocean/cloud/model"
 	"github.com/ausocean/cloud/utils"
+	"github.com/ausocean/cloud/youtube"
 	"github.com/gofiber/adaptor/v2"
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
-	"google.golang.org/api/youtube/v3"
+	yt "google.golang.org/api/youtube/v3"
 )
 
 type Action int
@@ -363,7 +363,7 @@ func broadcastHandler(c *fiber.Ctx) error {
 
 		var err error
 		adaptErr := adaptor.HTTPHandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			err = yt.AuthChannel(r.Context(), w, r, youtube.YoutubeScope, tokenURI)
+			err = youtube.AuthChannel(r.Context(), w, r, yt.YoutubeScope, tokenURI)
 		})(c)
 		if adaptErr != nil {
 			reportError(c, req, "internal adapter error: %v", adaptErr)

--- a/cmd/oceantv/broadcast.go
+++ b/cmd/oceantv/broadcast.go
@@ -36,8 +36,8 @@ import (
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast_host"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/gauth"
 	"github.com/ausocean/cloud/model"
@@ -51,7 +51,7 @@ type (
 	Store = datastore.Store
 	Key   = datastore.Key
 	Ety   = datastore.Entity
-	Svc   = yt.BroadcastService
+	Svc   = broadcast_host.BroadcastHost
 )
 
 const (

--- a/cmd/oceantv/broadcast_host/broadcast_host.go
+++ b/cmd/oceantv/broadcast_host/broadcast_host.go
@@ -1,0 +1,69 @@
+/*
+AUTHORS
+  Saxon Nelson-Milton <saxon@ausocean.org>
+
+LICENSE
+  Copyright (C) 2026 the Australian Ocean Lab (AusOcean)
+
+  This file is part of Ocean TV. Ocean TV is free software: you can
+  redistribute it and/or modify it under the terms of the GNU
+  General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option)
+  any later version.
+
+  Ocean TV is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package broadcast_host
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ausocean/cloud/youtube"
+)
+
+// ServerResponse is an interface for a server response.
+type ServerResponse interface {
+	fmt.Stringer
+	StatusCode() int
+	HTTPHeader() http.Header
+}
+
+// BroadcastOption is an option to pass when creating a new broadcast host.
+type BroadcastOption func(interface{}) error
+
+// BroadcastHost is an interface for a broadcast host that the camera will stream to.
+// For example, YouTube and OceanMedia.
+type BroadcastHost interface {
+	CreateBroadcast(
+		ctx context.Context,
+		broadcastName, description, streamName, privacy, resolution string,
+		start, end time.Time,
+		opts ...BroadcastOption,
+	) (ServerResponse, youtube.IDs, string, error)
+
+	StartBroadcast(
+		name, bID, sID string,
+		saveLink func(key, link string) error,
+		extStart, extStop func() error,
+		notify func(msg string) error,
+		onLiveActions func() error,
+	) error
+
+	BroadcastStatus(ctx context.Context, id string) (string, error)
+	BroadcastScheduledStartTime(ctx context.Context, id string) (time.Time, error)
+	BroadcastHealth(ctx context.Context, sid string) (string, error)
+	RTMPKey(ctx context.Context, streamName string) (string, error)
+	CompleteBroadcast(ctx context.Context, id string) error
+	PostChatMessage(cID, msg string) error
+	SetBroadcastPrivacy(ctx context.Context, id, privacy string) error
+}

--- a/cmd/oceantv/broadcast_host/youtube-standalone.go
+++ b/cmd/oceantv/broadcast_host/youtube-standalone.go
@@ -27,9 +27,9 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-// package yt provides functionality for setting up a YouTube livestream
+// package youtube provides functionality for setting up a YouTube livestream
 // service and broadcast scheduling.
-package yt
+package broadcast_host
 
 import (
 	"log"

--- a/cmd/oceantv/broadcast_host/youtube.go
+++ b/cmd/oceantv/broadcast_host/youtube.go
@@ -20,7 +20,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package yt
+package broadcast_host
 
 import (
 	"context"
@@ -30,46 +30,10 @@ import (
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/ratelimit"
+	"github.com/ausocean/cloud/youtube"
 	"google.golang.org/api/googleapi"
-	"google.golang.org/api/youtube/v3"
+	yt "google.golang.org/api/youtube/v3"
 )
-
-// ServerResponse is an interface for a server response.
-type ServerResponse interface {
-	fmt.Stringer
-	StatusCode() int
-	HTTPHeader() http.Header
-}
-
-// BroadcastOption is an option to pass when creating a new broadcast service.
-type BroadcastOption func(interface{}) error
-
-// BroadcastService is an interface for a broadcast service where video
-// can be streamed to and then viewed by users.
-type BroadcastService interface {
-	CreateBroadcast(
-		ctx context.Context,
-		broadcastName, description, streamName, privacy, resolution string,
-		start, end time.Time,
-		opts ...BroadcastOption,
-	) (ServerResponse, IDs, string, error)
-
-	StartBroadcast(
-		name, bID, sID string,
-		saveLink func(key, link string) error,
-		extStart, extStop func() error,
-		notify func(msg string) error,
-		onLiveActions func() error,
-	) error
-
-	BroadcastStatus(ctx context.Context, id string) (string, error)
-	BroadcastScheduledStartTime(ctx context.Context, id string) (time.Time, error)
-	BroadcastHealth(ctx context.Context, sid string) (string, error)
-	RTMPKey(ctx context.Context, streamName string) (string, error)
-	CompleteBroadcast(ctx context.Context, id string) error
-	PostChatMessage(cID, msg string) error
-	SetBroadcastPrivacy(ctx context.Context, id, privacy string) error
-}
 
 // YouTubeResponse implements the ServerResponse interface for YouTube.
 // This is a wrapper for the googleapi.ServerResponse type.
@@ -79,26 +43,26 @@ func (y YouTubeResponse) String() string          { return fmt.Sprintf("%v", goo
 func (y YouTubeResponse) StatusCode() int         { return googleapi.ServerResponse(y).HTTPStatusCode }
 func (y YouTubeResponse) HTTPHeader() http.Header { return googleapi.ServerResponse(y).Header }
 
-// YouTubeBroadcastService is a BroadcastService implementation for YouTube.
-type YouTubeBroadcastService struct {
+// YouTubeBroadcastHost is a BroadcastHost implementation for YouTube.
+type YouTubeBroadcastHost struct {
 	limiter  ratelimit.RateLimiter
 	log      func(string, ...interface{})
 	tokenURI string
 }
 
-func NewYouTubeBroadcastService(tokenURI string, log func(string, ...interface{})) *YouTubeBroadcastService {
-	return &YouTubeBroadcastService{log: log, tokenURI: tokenURI}
+func NewYouTubeBroadcastHost(tokenURI string, log func(string, ...interface{})) *YouTubeBroadcastHost {
+	return &YouTubeBroadcastHost{log: log, tokenURI: tokenURI}
 }
 
 // WithRateLimiter is a BroadcastOption that sets the rate limiter for a
-// YouTubeBroadcastService.
+// YouTubeBroadcastHost.
 func WithRateLimiter(limiter ratelimit.RateLimiter) BroadcastOption {
 	return func(i interface{}) error {
-		if s, ok := i.(*YouTubeBroadcastService); ok {
+		if s, ok := i.(*YouTubeBroadcastHost); ok {
 			s.limiter = limiter
 			return nil
 		}
-		return errors.New("this option is not for YouTubeBroadcastService")
+		return errors.New("this option is not for YouTubeBroadcastHost")
 	}
 }
 
@@ -108,34 +72,34 @@ var ErrRequestLimitExceeded = errors.New("request limit exceeded")
 
 // CreateBroadcast creates a broadcast with the given parameters using the
 // YouTube API.
-func (s *YouTubeBroadcastService) CreateBroadcast(
+func (s *YouTubeBroadcastHost) CreateBroadcast(
 	ctx context.Context,
 	broadcastName, description, streamName, privacy, resolution string,
 	start, end time.Time,
 	opts ...BroadcastOption,
-) (ServerResponse, IDs, string, error) {
+) (ServerResponse, youtube.IDs, string, error) {
 	for _, opt := range opts {
 		if err := opt(s); err != nil {
-			return nil, IDs{}, "", fmt.Errorf("could not apply option: %w", err)
+			return nil, youtube.IDs{}, "", fmt.Errorf("could not apply option: %w", err)
 		}
 	}
 
 	if s.limiter != nil {
 		if !s.limiter.RequestOK() {
-			return nil, IDs{}, "", ErrRequestLimitExceeded
+			return nil, youtube.IDs{}, "", ErrRequestLimitExceeded
 		}
 	}
 
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
-		return YouTubeResponse{}, IDs{}, "", fmt.Errorf("could not get service: %w", err)
+		return YouTubeResponse{}, youtube.IDs{}, "", fmt.Errorf("could not get service: %w", err)
 	}
 
 	const (
 		typ       = "rtmp"
 		framerate = "30fps"
 	)
-	resp, ids, err := BroadcastStream(
+	resp, ids, err := youtube.BroadcastStream(
 		svc,
 		broadcastName,
 		description,
@@ -149,12 +113,12 @@ func (s *YouTubeBroadcastService) CreateBroadcast(
 		s.log,
 	)
 	if err != nil {
-		return YouTubeResponse{}, IDs{}, "", fmt.Errorf("could not broadcast stream: %w response: %v", err, resp)
+		return YouTubeResponse{}, youtube.IDs{}, "", fmt.Errorf("could not broadcast stream: %w response: %v", err, resp)
 	}
 
-	key, err := RTMPKey(svc, streamName)
+	key, err := youtube.RTMPKey(svc, streamName)
 	if err != nil {
-		return YouTubeResponse{}, IDs{}, "", fmt.Errorf("could not get stream RTMP key: %w", err)
+		return YouTubeResponse{}, youtube.IDs{}, "", fmt.Errorf("could not get stream RTMP key: %w", err)
 	}
 
 	return YouTubeResponse(resp), ids, key, nil
@@ -164,14 +128,14 @@ func (s *YouTubeBroadcastService) CreateBroadcast(
 // live status using the YouTube API. We can provide functions to be called
 // before and after the broadcast is started, as well as a function to be
 // called when the broadcast is live.
-func (s *YouTubeBroadcastService) StartBroadcast(
+func (s *YouTubeBroadcastHost) StartBroadcast(
 	name, bID, sID string,
 	saveLink func(key, link string) error,
 	extStart, extStop func() error,
 	notify func(msg string) error,
 	onLiveActions func() error,
 ) error {
-	return Start(
+	return youtube.Start(
 		name,
 		bID,
 		sID,
@@ -187,13 +151,13 @@ func (s *YouTubeBroadcastService) StartBroadcast(
 
 // BroadcastStatus gets the status of the broadcast identification id using the
 // YouTube API.
-func (s *YouTubeBroadcastService) BroadcastStatus(ctx context.Context, id string) (string, error) {
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+func (s *YouTubeBroadcastHost) BroadcastStatus(ctx context.Context, id string) (string, error) {
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("get service error: %w", err)
 	}
-	status, err := GetBroadcastStatus(svc, id)
-	if err != nil && !errors.Is(err, ErrNoBroadcastItems) {
+	status, err := youtube.GetBroadcastStatus(svc, id)
+	if err != nil && !errors.Is(err, youtube.ErrNoBroadcastItems) {
 		return "", fmt.Errorf("get broadcast status error: %w", err)
 	}
 	return status, nil
@@ -211,13 +175,13 @@ func (s *YouTubeBroadcastService) BroadcastStatus(ctx context.Context, id string
 //
 // Similarly, we don't consider configuration issues to be problematic,
 // unless they are of error severity. This may also need to be revisited.
-func (s *YouTubeBroadcastService) BroadcastHealth(ctx context.Context, sid string) (string, error) {
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+func (s *YouTubeBroadcastHost) BroadcastHealth(ctx context.Context, sid string) (string, error) {
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("could not get youtube service: %w", err)
 	}
 
-	health, err := GetHealthStatus(svc, sid)
+	health, err := youtube.GetHealthStatus(svc, sid)
 	if err != nil {
 		return "", fmt.Errorf("could not get health status: %w", err)
 	}
@@ -246,13 +210,13 @@ func (s *YouTubeBroadcastService) BroadcastHealth(ctx context.Context, sid strin
 }
 
 // BroadcastScheduledStartTime returns the scheduled start time of a broadcast.
-func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx context.Context, id string) (time.Time, error) {
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+func (s *YouTubeBroadcastHost) BroadcastScheduledStartTime(ctx context.Context, id string) (time.Time, error) {
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("get service error: %w", err)
 	}
-	start, err := GetBroadcastScheduledStart(svc, id)
-	if err != nil && !errors.Is(err, ErrNoBroadcastItems) {
+	start, err := youtube.GetBroadcastScheduledStart(svc, id)
+	if err != nil && !errors.Is(err, youtube.ErrNoBroadcastItems) {
 		return time.Time{}, fmt.Errorf("get broadcast status error: %w", err)
 	}
 	startTime, err := time.Parse(time.RFC3339, start)
@@ -264,12 +228,12 @@ func (s *YouTubeBroadcastService) BroadcastScheduledStartTime(ctx context.Contex
 
 // CompleteBroadcast transitions a broadcast with identification id to complete
 // status using the YouTube API.
-func (s *YouTubeBroadcastService) CompleteBroadcast(ctx context.Context, id string) error {
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+func (s *YouTubeBroadcastHost) CompleteBroadcast(ctx context.Context, id string) error {
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return fmt.Errorf("get service error: %w", err)
 	}
-	err = CompleteBroadcast(svc, id, s.log)
+	err = youtube.CompleteBroadcast(svc, id, s.log)
 	if err != nil {
 		return fmt.Errorf("complete broadcast error: %w", err)
 	}
@@ -278,12 +242,12 @@ func (s *YouTubeBroadcastService) CompleteBroadcast(ctx context.Context, id stri
 
 // RTMPKey gets the broadcast RTMP key for the provided stream name using the
 // YouTube API.
-func (s *YouTubeBroadcastService) RTMPKey(ctx context.Context, streamName string) (string, error) {
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+func (s *YouTubeBroadcastHost) RTMPKey(ctx context.Context, streamName string) (string, error) {
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("get service error: %w", err)
 	}
-	key, err := RTMPKey(svc, streamName)
+	key, err := youtube.RTMPKey(svc, streamName)
 	if err != nil {
 		return "", fmt.Errorf("get RTMP key error: %w", err)
 	}
@@ -292,8 +256,8 @@ func (s *YouTubeBroadcastService) RTMPKey(ctx context.Context, streamName string
 
 // PostChatMessage posts a chat message with the provided message and token URI
 // to the chat identification cID using the YouTube API.
-func (s *YouTubeBroadcastService) PostChatMessage(cID, msg string) error {
-	return PostChatMessage(cID, s.tokenURI, msg)
+func (s *YouTubeBroadcastHost) PostChatMessage(cID, msg string) error {
+	return youtube.PostChatMessage(cID, msg, s.tokenURI)
 }
 
 // SetBroadcastPrivacy sets the broadcast privacy of the broadcast with
@@ -301,16 +265,16 @@ func (s *YouTubeBroadcastService) PostChatMessage(cID, msg string) error {
 // The privacy can be one of "public", "unlisted", or "private".
 // This can be called before, during or after the
 // The broadcast and resulting video share ID and privacy settings.
-func (s *YouTubeBroadcastService) SetBroadcastPrivacy(ctx context.Context, id, privacy string) error {
-	video := &youtube.Video{
+func (s *YouTubeBroadcastHost) SetBroadcastPrivacy(ctx context.Context, id, privacy string) error {
+	video := &yt.Video{
 		Id: id,
-		Status: &youtube.VideoStatus{
+		Status: &yt.VideoStatus{
 			PrivacyStatus: privacy,
 			Embeddable:    true, // This must be set, otherwise it defaults to not embeddable.
 		},
 	}
 
-	svc, err := GetService(ctx, youtube.YoutubeScope, s.tokenURI)
+	svc, err := youtube.GetService(ctx, yt.YoutubeScope, s.tokenURI)
 	if err != nil {
 		return fmt.Errorf("could not get youtube service: %w", err)
 	}

--- a/cmd/oceantv/broadcast_states.go
+++ b/cmd/oceantv/broadcast_states.go
@@ -11,12 +11,12 @@ import (
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast_host"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
 	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/notify"
 )
 
@@ -476,7 +476,7 @@ func createBroadcastAndRequestHardware(ctx *broadcastContext, cfg *Cfg, onCreati
 		ctx.store,
 		ctx.svc,
 	)
-	if errors.Is(err, yt.ErrRequestLimitExceeded) {
+	if errors.Is(err, broadcast_host.ErrRequestLimitExceeded) {
 		onFailureClosure(ctx, cfg, true)(fmt.Errorf("could not create broadcast: %w", err))
 		return
 	}

--- a/cmd/oceantv/broadcast_test.go
+++ b/cmd/oceantv/broadcast_test.go
@@ -34,15 +34,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast_host"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
 	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/ratelimit"
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/model"
 	"github.com/ausocean/cloud/notify"
+	"github.com/ausocean/cloud/youtube"
 )
 
 // dummyManager is a dummy implementation of the broadcastManager interface.
@@ -94,7 +95,7 @@ func (d *dummyManager) CreateBroadcast(
 	svc Svc,
 ) error {
 	if d.Limiter != nil && !d.Limiter.RequestOK() {
-		return yt.ErrRequestLimitExceeded
+		return broadcast_host.ErrRequestLimitExceeded
 	}
 	return nil
 }
@@ -248,9 +249,9 @@ func (d *dummyService) CreateBroadcast(
 	ctx Ctx,
 	broadcastName, description, streamName, privacy, resolution string,
 	start, end time.Time,
-	opts ...yt.BroadcastOption,
-) (yt.ServerResponse, yt.IDs, string, error) {
-	return nil, yt.IDs{}, "", nil
+	opts ...broadcast_host.BroadcastOption,
+) (broadcast_host.ServerResponse, youtube.IDs, string, error) {
+	return nil, youtube.IDs{}, "", nil
 }
 
 func (d *dummyService) StartBroadcast(

--- a/cmd/oceantv/manager/manager.go
+++ b/cmd/oceantv/manager/manager.go
@@ -26,26 +26,26 @@ import (
 	"context"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast_host"
 	"github.com/ausocean/cloud/datastore"
 )
 
-type BroadcastCallback func(context.Context, *broadcast.Config, datastore.Store, yt.BroadcastService) error
+type BroadcastCallback func(context.Context, *broadcast.Config, datastore.Store, broadcast_host.BroadcastHost) error
 
 // Broadcast is an interface for managing broadcasts.
 type Broadcast interface {
-	CreateBroadcast(cfg *broadcast.Config, store datastore.Store, svc yt.BroadcastService) error
+	CreateBroadcast(cfg *broadcast.Config, store datastore.Store, svc broadcast_host.BroadcastHost) error
 
-	StartBroadcast(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc yt.BroadcastService, extStart func() error,
+	StartBroadcast(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc broadcast_host.BroadcastHost, extStart func() error,
 		onSuccess func(),
 		onFailure func(error))
-	StopBroadcast(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc yt.BroadcastService) error
+	StopBroadcast(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc broadcast_host.BroadcastHost) error
 	Save(ctx context.Context, update func(*broadcast.Config)) error
 
 	// HandleStatus checks the status of a broadcast and would perform any
 	// necessary actions based on this status. For example, if the broadcast
 	// status is complete or revoked, it might stop the broadcast.
-	HandleStatus(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc yt.BroadcastService, noBroadcastCallBack BroadcastCallback) error
+	HandleStatus(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc broadcast_host.BroadcastHost, noBroadcastCallBack BroadcastCallback) error
 
 	// HandleChatMessage prepares and sends chat messages to the broadcast
 	// service's chat session. This might contain information such as

--- a/cmd/oceantv/manager/ocean_broadcast.go
+++ b/cmd/oceantv/manager/ocean_broadcast.go
@@ -32,11 +32,12 @@ import (
 
 	rv_config "github.com/ausocean/av/revid/config"
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast_host"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
 	"github.com/ausocean/cloud/cmd/oceantv/ratelimit"
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/datastore"
 	"github.com/ausocean/cloud/model"
+	"github.com/ausocean/cloud/youtube"
 	"github.com/ausocean/utils/nmea"
 	"github.com/google/uuid"
 )
@@ -46,7 +47,7 @@ const locationID = "Australia/Adelaide" // TODO: Use site location (remove dupli
 // OceanBroadcast is an implementation of BroadcastManager with
 // a particular focus around ocean broadcasts and AusOcean's infrastructure.
 type OceanBroadcast struct {
-	svc   yt.BroadcastService
+	svc   broadcast_host.BroadcastHost
 	log   func(string, ...interface{})
 	cfg   *broadcast.Config
 	store datastore.Store
@@ -59,7 +60,7 @@ type OceanBroadcast struct {
 // NewOceanBroadcast creates a new OceanBroadcastManager.
 // svc may be nil, but any methods that require it will panic.
 func NewOceanBroadcast(
-	svc yt.BroadcastService,
+	svc broadcast_host.BroadcastHost,
 	cfg *broadcast.Config,
 	store datastore.Store,
 	log func(string, ...interface{}),
@@ -78,7 +79,7 @@ func NewOceanBroadcast(
 func (m *OceanBroadcast) CreateBroadcast(
 	cfg *broadcast.Config,
 	store datastore.Store,
-	svc yt.BroadcastService,
+	svc broadcast_host.BroadcastHost,
 ) error {
 	// Only create a new broadcast if a valid one doesn't already exist.
 	if m.BroadcastCanBeReused() {
@@ -126,7 +127,7 @@ func (m *OceanBroadcast) CreateBroadcast(
 		cfg.Resolution,
 		timeCreated,
 		cfg.End,
-		yt.WithRateLimiter(limiter),
+		broadcast_host.WithRateLimiter(limiter),
 	)
 	if err != nil {
 		return fmt.Errorf("could not create broadcast: %w, resp: %v", err, resp)
@@ -150,7 +151,7 @@ func (m *OceanBroadcast) StartBroadcast(
 	ctx context.Context,
 	cfg *broadcast.Config,
 	store datastore.Store,
-	svc yt.BroadcastService,
+	svc broadcast_host.BroadcastHost,
 	extStart func() error,
 	onSuccess func(),
 	onFailure func(error),
@@ -183,7 +184,7 @@ func (m *OceanBroadcast) StartBroadcast(
 
 // StopBroadcast stops a broadcast using the youtube live streaming API.
 // It uses AusOcean methods for saving and stopping external hardware.
-func (m *OceanBroadcast) StopBroadcast(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc yt.BroadcastService) error {
+func (m *OceanBroadcast) StopBroadcast(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc broadcast_host.BroadcastHost) error {
 	m.log("stopping broadcast")
 
 	status, err := svc.BroadcastStatus(ctx, cfg.BID)
@@ -191,7 +192,7 @@ func (m *OceanBroadcast) StopBroadcast(ctx context.Context, cfg *broadcast.Confi
 		return fmt.Errorf("could not get broadcast status: %w", err)
 	}
 
-	if status != yt.StatusComplete && status != "" {
+	if status != youtube.StatusComplete && status != "" {
 		err := svc.CompleteBroadcast(ctx, cfg.BID)
 		if err != nil {
 			return fmt.Errorf("could not complete broadcast: %w", err)
@@ -275,11 +276,11 @@ func (m *OceanBroadcast) Save(ctx context.Context, update func(_cfg *broadcast.C
 
 // HandleStatus checks the status of a broadcast and stops it if it has
 // complete or revoked status.
-func (m *OceanBroadcast) HandleStatus(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc yt.BroadcastService, noBroadcastCallBack BroadcastCallback) error {
+func (m *OceanBroadcast) HandleStatus(ctx context.Context, cfg *broadcast.Config, store datastore.Store, svc broadcast_host.BroadcastHost, noBroadcastCallBack BroadcastCallback) error {
 	m.log("handling status check")
 	status, err := svc.BroadcastStatus(ctx, cfg.BID)
 	if err != nil {
-		if !errors.Is(err, yt.ErrNoBroadcastItems) {
+		if !errors.Is(err, youtube.ErrNoBroadcastItems) {
 			return fmt.Errorf("could not get broadcast status: %w", err)
 		}
 
@@ -290,7 +291,7 @@ func (m *OceanBroadcast) HandleStatus(ctx context.Context, cfg *broadcast.Config
 		}
 	}
 
-	if status != yt.StatusComplete && status != yt.StatusRevoked {
+	if status != youtube.StatusComplete && status != youtube.StatusRevoked {
 		return nil
 	}
 
@@ -486,7 +487,7 @@ func (m *OceanBroadcast) BroadcastCanBeReused() bool {
 		return false
 	}
 	m.log("today's broadcast has status: %s", status)
-	return m.cfg.BID != "" && m.cfg.SID != "" && status != "" && status != yt.StatusRevoked && status != yt.StatusComplete
+	return m.cfg.BID != "" && m.cfg.SID != "" && status != "" && status != youtube.StatusRevoked && status != youtube.StatusComplete
 }
 
 // saveLinkFunc provides a closure for saving a broadcast link with a given key.

--- a/cmd/oceantv/system.go
+++ b/cmd/oceantv/system.go
@@ -8,14 +8,15 @@ import (
 	"time"
 
 	"github.com/ausocean/cloud/cmd/oceantv/broadcast"
+	"github.com/ausocean/cloud/cmd/oceantv/broadcast_host"
 	"github.com/ausocean/cloud/cmd/oceantv/event"
 	"github.com/ausocean/cloud/cmd/oceantv/forwarding"
 	"github.com/ausocean/cloud/cmd/oceantv/hardware"
 	"github.com/ausocean/cloud/cmd/oceantv/manager"
 	"github.com/ausocean/cloud/cmd/oceantv/notifier"
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/notify"
 	"github.com/ausocean/cloud/utils"
+	"github.com/ausocean/cloud/youtube"
 )
 
 // broadcastSystem represents a video broadcasting control system.
@@ -118,7 +119,7 @@ func newBroadcastSystem(ctx Ctx, store Store, cfg *Cfg, logOutput func(v ...any)
 
 	// Create the youtube broadcast service. This will deal with the YouTube API bindings.
 	tokenURI := utils.TokenURIFromAccount(cfg.Account)
-	svc := yt.NewYouTubeBroadcastService(tokenURI, log)
+	svc := broadcast_host.NewYouTubeBroadcastHost(tokenURI, log)
 
 	// Create the broadcast manager. This will manage things between the broadcast, the
 	// hardware and the YouTube broadcast service.
@@ -206,7 +207,7 @@ func (bs *broadcastSystem) tick() error {
 			if err != nil {
 				bs.log("could not get broadcast status: %v", err)
 			} else {
-				if status == yt.StatusLive {
+				if status == youtube.StatusLive {
 					err = bs.ctx.svc.CompleteBroadcast(context.Background(), bs.ctx.cfg.BID)
 					if err != nil {
 						bs.ctx.logAndNotify(notifier.KindService, "could not complete broadcast, please check this manually: %v", err)

--- a/youtube/auth.go
+++ b/youtube/auth.go
@@ -27,7 +27,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package yt
+package youtube
 
 import (
 	"context"

--- a/youtube/storage.go
+++ b/youtube/storage.go
@@ -25,7 +25,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package yt
+package youtube
 
 import (
 	"context"

--- a/youtube/storage_test.go
+++ b/youtube/storage_test.go
@@ -23,7 +23,7 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-package yt
+package youtube
 
 import "testing"
 

--- a/youtube/upload.go
+++ b/youtube/upload.go
@@ -32,7 +32,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/ausocean/cloud/cmd/oceantv/yt"
 	"github.com/ausocean/cloud/utils"
 	"google.golang.org/api/youtube/v3"
 )
@@ -195,7 +194,7 @@ func UploadVideo(ctx context.Context, media io.Reader, account string, opts ...V
 
 	// Force using the default account (AusOcean's account).
 	tokenURI := utils.TokenURIFromAccount(account)
-	svc, err := yt.GetService(ctx, youtube.YoutubeScope, tokenURI)
+	svc, err := GetService(ctx, youtube.YoutubeScope, tokenURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get YouTube service: %w", err)
 	}
@@ -220,7 +219,7 @@ func UploadVideo(ctx context.Context, media io.Reader, account string, opts ...V
 // is passed, the AusOcean channel will be used.
 func CheckUploadStatus(ctx context.Context, videoID string, account string) (string, error) {
 	tokenURI := utils.TokenURIFromAccount(account)
-	svc, err := yt.GetService(ctx, youtube.YoutubeScope, tokenURI)
+	svc, err := GetService(ctx, youtube.YoutubeScope, tokenURI)
 	if err != nil {
 		return "", fmt.Errorf("failed to get YouTube service: %w", err)
 	}

--- a/youtube/youtube.go
+++ b/youtube/youtube.go
@@ -29,9 +29,9 @@ LICENSE
   in gpl.txt. If not, see <http://www.gnu.org/licenses/>.
 */
 
-// package yt provides functionality for setting up a YouTube livestream
+// package youtube provides functionality for setting up a YouTube livestream
 // service and broadcast scheduling.
-package yt
+package youtube
 
 import (
 	"context"


### PR DESCRIPTION

This change refactors the yt package by splitting it into two separate packages - youtube and broadcast_host. Youtube is split out as another service as another service is using it. yt is renamed to broadcast_host as it is a more generic name. BroadcastService is renamed to BroadcastHost as there are a lot of things named service and it isn't referring to an OceanTV service but an external host of the live stream.
